### PR TITLE
CROWD-1236 remove project export urls

### DIFF
--- a/pybossa/exporter/csv_reports_export.py
+++ b/pybossa/exporter/csv_reports_export.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PyBossa.  If not, see <http://www.gnu.org/licenses/>.
 # Cache global variables for timeouts
+import os
 import tempfile
 from pybossa.exporter.csv_export import CsvExporter
 from pybossa.core import project_repo, uploader
@@ -80,25 +81,17 @@ class ProjectReportCsvExporter(CsvExporter):
         name = self._project_name_latin_encoded(project)
         csv_task_generator = self._respond_csv(ty, project.id)
         if csv_task_generator is not None:
-            datafile = tempfile.NamedTemporaryFile()
-            try:
+            with tempfile.NamedTemporaryFile() as datafile, \
+                 tempfile.NamedTemporaryFile(delete=False) as zipped_datafile:
                 for line in csv_task_generator:
                     datafile.write(str(line))
                 datafile.flush()
                 csv_task_generator.close()  # delete temp csv file
-                zipped_datafile = tempfile.NamedTemporaryFile()
-                try:
-                    _zip = self._zip_factory(zipped_datafile.name)
-                    _zip.write(
-                        datafile.name,
-                        secure_filename('%s_%s.csv' % (name, ty)))
-                    _zip.close()
-                    container = "user_%d" % project.owner_id
-                    _file = FileStorage(
+                _zip = self._zip_factory(zipped_datafile.name)
+                _zip.write(
+                    datafile.name,
+                    secure_filename('%s_%s.csv' % (name, ty)))
+                _zip.close()
+            return dict(filepath=zipped_datafile.name,
                         filename=self.download_name(project, ty),
-                        stream=zipped_datafile)
-                    uploader.upload_file(_file, container=container)
-                finally:
-                    zipped_datafile.close()
-            finally:
-                datafile.close()
+                        delete=True)

--- a/pybossa/exporter/csv_reports_export.py
+++ b/pybossa/exporter/csv_reports_export.py
@@ -83,15 +83,20 @@ class ProjectReportCsvExporter(CsvExporter):
         if csv_task_generator is not None:
             with tempfile.NamedTemporaryFile() as datafile, \
                  tempfile.NamedTemporaryFile(delete=False) as zipped_datafile:
-                for line in csv_task_generator:
-                    datafile.write(str(line))
-                datafile.flush()
-                csv_task_generator.close()  # delete temp csv file
-                _zip = self._zip_factory(zipped_datafile.name)
-                _zip.write(
-                    datafile.name,
-                    secure_filename('%s_%s.csv' % (name, ty)))
-                _zip.close()
-            return dict(filepath=zipped_datafile.name,
-                        filename=self.download_name(project, ty),
-                        delete=True)
+                try:
+                    for line in csv_task_generator:
+                        datafile.write(str(line))
+                    datafile.flush()
+                    csv_task_generator.close()  # delete temp csv file
+                    _zip = self._zip_factory(zipped_datafile.name)
+                    _zip.write(
+                        datafile.name,
+                        secure_filename('%s_%s.csv' % (name, ty)))
+                    _zip.close()
+                    return dict(filepath=zipped_datafile.name,
+                                filename=self.download_name(project, ty),
+                                delete=True)
+                except Exception:
+                    if os.path.exists(zipped_datafile.name):
+                        os.remove(zipped_datafile.name)
+                    raise

--- a/pybossa/exporter/project_csv_export.py
+++ b/pybossa/exporter/project_csv_export.py
@@ -22,7 +22,7 @@ CSV Exporter module for exporting tasks and tasks results out of PyBossa
 
 import tempfile
 from pybossa.exporter.csv_export import CsvExporter
-from pybossa.core import uploader, project_repo, user_repo
+from pybossa.core import project_repo, user_repo
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
 from pybossa.cache.helpers import n_available_tasks

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -1071,7 +1071,6 @@ def push_notification(project_id, **kwargs):
 
 def mail_project_report(info, current_user_email_addr):
     from pybossa.core import project_csv_exporter
-    from pybossa.core import uploader
 
     try:
         zipfile = None


### PR DESCRIPTION
There is no need to for the project report to be uploaded before it is sent to the client.  Instead, we can simply send the file in the response.