### PR TITLE
Reset password alternate route

### DIFF
--- a/pybossa/forms/account_view_forms.py
+++ b/pybossa/forms/account_view_forms.py
@@ -22,6 +22,7 @@ from forms import (
     RegisterForm,
     UpdateProfileForm,
     ChangePasswordForm,
+    PasswordResetKeyForm,
     ResetPasswordForm,
     ForgotPasswordForm,
     AvatarUploadForm,

--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -101,7 +101,7 @@ class ProjectUpdateForm(ProjectForm):
                                 message=lazy_gettext(
                                     "You must provide a description.")),
                              validators.Length(max=255)])
-    short_name = TextField(label=None, widget=HiddenInput())    
+    short_name = TextField(label=None, widget=HiddenInput())
     long_description = TextAreaField(lazy_gettext('Long Description'))
     allow_anonymous_contributors = BooleanField(lazy_gettext('Allow Anonymous Contributors'))
     zip_download = BooleanField(lazy_gettext('Allow ZIP data download'))
@@ -587,6 +587,12 @@ class ForgotPasswordForm(Form):
                             validators.Email()])
 
 
+class PasswordResetKeyForm(Form):
+    password_reset_key = TextAreaField(lazy_gettext('Password Reset Key'),
+                                       [validators.Required(message=lazy_gettext(
+                                        'You must provide the Password Reset Key.'))])
+
+
 class OTPForm(Form):
     otp = TextField(lazy_gettext('One Time Password'),
                     [validators.Required(message=lazy_gettext(
@@ -704,7 +710,7 @@ class UserPrefMetadataForm(Form):
         if not can_update:
             return {field: 'Form is not updatable.' for field in self}
         return {getattr(self, name): reason for name, reason in six.iteritems(disabled_fields or {})}
-    
+
     def is_disabled(self, field):
         return self._disabled.get(field, False)
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3959,6 +3959,22 @@ class TestWeb(web.Helper):
         data = json.loads(res.data)
         assert data.get('code') == 403, data
 
+    @with_context
+    @patch('pybossa.view.account.signer.loads')
+    def test_password_reset_key_page(self, mock_signer_loads):
+        """Test WEB password reset key page"""
+        self.register()
+        res = self.app.get('/account/forgot-password', follow_redirects=True)
+        assert res.status_code == 200, res
+        user = User.query.get(1)
+        res = self.app.post('/account/forgot-password', data={'email': user.email_addr}, follow_redirects=True)
+        assert res.status_code == 200, res
+        mock_signer_loads.return_value = {}
+        res = self.app.post('/account/password-reset-key', data={'password_reset_key': 'asdf'}, follow_redirects=True)
+        assert res.status_code == 403, res
+        mock_signer_loads.return_value = {'user': user.name, 'password': user.passwd_hash}
+        res = self.app.post('/account/password-reset-key', data={'password_reset_key': 'asdf'}, follow_redirects=True)
+        assert res.status_code == 200, res
 
     @with_context
     @patch('pybossa.view.account.signer.loads')
@@ -8752,7 +8768,7 @@ class TestWebUserMetadataUpdate(web.Helper):
 
     original = {
         'user_type': 'Curator',
-        'languages': ["Afrikaans", "Albanian", "Welsh"], 
+        'languages': ["Afrikaans", "Albanian", "Welsh"],
         'work_hours_from': '08:00',
         'work_hours_to': '15:00',
         'review': 'Original Review',
@@ -8762,7 +8778,7 @@ class TestWebUserMetadataUpdate(web.Helper):
 
     update = {
         'user_type': 'Researcher',
-        'languages': ["Afrikaans", "Albanian"], 
+        'languages': ["Afrikaans", "Albanian"],
         'work_hours_from': '09:00',
         'work_hours_to': '16:00',
         'review': 'Updated Review',


### PR DESCRIPTION
Provide a page where users can input the password reset key rather than require them to follow a URL.