### PR TITLE
Configure quiz short_circuit at project level. Allow 0 for passing gr…

### DIFF
--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -156,8 +156,8 @@ class ProjectQuizForm(Form):
     passing = IntegerField(
         lazy_gettext('Number of correct answers to pass quiz'),
         [
-            validators.Required(lazy_gettext('This field must be a positive integer.')),
-            validators.NumberRange(min=1)
+            validators.Required(lazy_gettext('This field must be a non-negative integer.')),
+            validators.NumberRange(min=0) # Making this 0 to allow quizzes with free-form answers.
         ]
     )
 

--- a/pybossa/model/project.py
+++ b/pybossa/model/project.py
@@ -209,8 +209,10 @@ class Project(db.Model, DomainObject):
                 'questions': 0
             }
         )
+        # If short_circuit is not configured for the project then use the current app setting.
+        quiz.setdefault('short_circuit', current_app.config.get('SHORT_CIRCUIT_QUIZ', True))
 
-        quiz['short_circuit'] = current_app.config.get('SHORT_CIRCUIT_QUIZ', True)
+        # We changed the name of 'pass' to 'passing'. Upgrade any existing data with the old name.
         if 'passing' not in quiz:
             quiz['passing'] = quiz['pass']
             del quiz['pass']


### PR DESCRIPTION
…ade.

These changes are to enable a type of free-form self-graded quiz. The idea is the project owner has a set of questions and answers that they want the workers to see and attempt to answer before working on the project. But the answers will not be graded and everyone will pass. It is like a tutorial.

To enable this, set passing to 0 and short_circuit to False.