### PR TITLE
RDISCROWD-1635: Disable updating a Gold task for non-owners of a project

### DIFF
--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -442,8 +442,8 @@ def task_gold(project_id=None):
     project = project_repo.get(project_id)
 
     # Allow project owner, sub-admin co-owners, and admins to update Gold tasks.
-    isGoldAccess = (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin
-    if project is None or not isGoldAccess:
+    is_gold_access = (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin
+    if project is None or not is_gold_access:
         raise Forbidden
 
     task_data = request.json

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -440,8 +440,10 @@ def task_gold(project_id=None):
         return abort(401)
 
     project = project_repo.get(project_id)
-    if project is None or not(current_user.admin
-        or current_user.id in project.owners_ids):
+
+    # Allow project owner, sub-admin co-owners, and admins to update Gold tasks.
+    isGoldAccess = (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin
+    if project is None or not isGoldAccess:
         raise Forbidden
 
     task_data = request.json


### PR DESCRIPTION
- Only project owners, sub-admin co-owners, and administrators may update a Gold task for a project.

*Note: To create a project, a user must be either an admin or sub-admin. The project owner and co-owners will be included in `project.owners_ids`. If a co-owner is not a sub-admin, they will only have read access to gold tasks.*

Referencing https://github.com/bloomberg/pybossa-default-theme/pull/122