### PR TITLE
Fix for database unit test setup

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -1,7 +1,2 @@
 #!/bin/bash
-set -x
-this_dir="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
-
-PYBOSSA_SETTINGS="${this_dir}/settings_test.py" \
-    PYBOSSA_REDIS_CACHE_DISABLED=1 \
-    nosetests ${@:-test/}
+PYBOSSA_SETTINGS="./settings_test.py" PYBOSSA_REDIS_CACHE_DISABLED=1 nosetests ${@:-test/}

--- a/test/default.py
+++ b/test/default.py
@@ -61,7 +61,7 @@ def with_context_settings(**kwargs):
 
 
 def delete_indexes():
-    sql = text('''select * from pg_indexes WHERE tablename = 'users_rank' ''')
+    sql = text('''select * from pg_indexes WHERE schemaname = current_schema() and tablename = 'users_rank' ''')
     results = db.session.execute(sql)
     for row in results:
         sql = 'drop index %s;' % row.indexname


### PR DESCRIPTION
- Updated delete indexes in the test setup to check against the current schema. This resolves an issue with trying to delete indexes found in other schemas that do not exist in the current one.
- Updated the `./run_tests` shortcut for cross-compatibility.