### PR TITLE
Replace hard-coded test using "mymaster" with settings_test.py config

### DIFF
--- a/test/test_jobs/test_schedule_jobs.py
+++ b/test/test_jobs/test_schedule_jobs.py
@@ -48,7 +48,7 @@ class TestSetupScheduledJobs(object):
                 port=settings_test.REDIS_PORT, db=db, password=pwd)
         else:
             sentinel = Sentinel(settings_test.REDIS_SENTINEL)
-            self.connection = sentinel.master_for('mymaster', db=db, password=pwd)
+            self.connection = sentinel.master_for(settings_test.REDIS_MASTER_NAME, db=db, password=pwd)
         self.connection.flushall()
         self.scheduler = Scheduler('test_queue', connection=self.connection)
 

--- a/test/test_jobs/test_schedule_jobs.py
+++ b/test/test_jobs/test_schedule_jobs.py
@@ -43,12 +43,13 @@ class TestSetupScheduledJobs(object):
     def setUp(self):
         db = getattr(settings_test, 'REDIS_DB', 0)
         pwd = getattr(settings_test, 'REDIS_PWD', None)
+        master = getattr(settings_test, 'REDIS_MASTER_NAME', 'mymaster')
         if all(hasattr(settings_test, attr) for attr in ['REDIS_MASTER_DNS', 'REDIS_PORT']):
             self.connection = StrictRedis(host=settings_test.REDIS_MASTER_DNS,
                 port=settings_test.REDIS_PORT, db=db, password=pwd)
         else:
             sentinel = Sentinel(settings_test.REDIS_SENTINEL)
-            self.connection = sentinel.master_for(settings_test.REDIS_MASTER_NAME, db=db, password=pwd)
+            self.connection = sentinel.master_for(master, db=db, password=pwd)
         self.connection.flushall()
         self.scheduler = Scheduler('test_queue', connection=self.connection)
 


### PR DESCRIPTION
- Replace hard-coded `mymaster` with `settings_test.REDIS_MASTER_NAME` from settings_test.py

When running the tests locally, this change allows the tests in `test_schedule_jobs.py` to pass, as my REDIS is not named `mymaster`.

Does it make sense to include this change?