### PR TITLE
RDISCROWD-1500 Bypass two-factor authentication via config list

### DIFF
--- a/pybossa/otp.py
+++ b/pybossa/otp.py
@@ -73,3 +73,10 @@ def retrieve_email_for_token(token):
 def expire_token(token):
     key = _create_url_token_key(token)
     conn.delete(key)
+
+def is_enabled(user_email, config):
+    # Allow bypassing two-factor-auth if the feature is disabled or if the user's email is included in the bypass list.
+    bypass_list = getattr(config, 'BYPASS_TWO_FACTOR_AUTH', [])
+    enable_two_factor_auth = getattr(config, 'ENABLE_TWO_FACTOR_AUTH', False)
+
+    return enable_two_factor_auth and not user_email in bypass_list

--- a/pybossa/otp.py
+++ b/pybossa/otp.py
@@ -76,7 +76,7 @@ def expire_token(token):
 
 def is_enabled(user_email, config):
     # Allow bypassing two-factor-auth if the feature is disabled or if the user's email is included in the bypass list.
-    bypass_list = getattr(config, 'BYPASS_TWO_FACTOR_AUTH', [])
-    enable_two_factor_auth = getattr(config, 'ENABLE_TWO_FACTOR_AUTH', False)
+    bypass_list = config.get('BYPASS_TWO_FACTOR_AUTH', [])
+    enable_two_factor_auth = config.get('ENABLE_TWO_FACTOR_AUTH', False)
 
     return enable_two_factor_auth and not user_email in bypass_list

--- a/pybossa/otp.py
+++ b/pybossa/otp.py
@@ -79,4 +79,4 @@ def is_enabled(user_email, config):
     bypass_list = config.get('BYPASS_TWO_FACTOR_AUTH', [])
     enable_two_factor_auth = config.get('ENABLE_TWO_FACTOR_AUTH', False)
 
-    return enable_two_factor_auth and not user_email in bypass_list
+    return enable_two_factor_auth and (bypass_list is None or not user_email in bypass_list)

--- a/pybossa/otp.py
+++ b/pybossa/otp.py
@@ -76,7 +76,7 @@ def expire_token(token):
 
 def is_enabled(user_email, config):
     # Allow bypassing two-factor-auth if the feature is disabled or if the user's email is included in the bypass list.
-    bypass_list = config.get('BYPASS_TWO_FACTOR_AUTH', [])
-    enable_two_factor_auth = config.get('ENABLE_TWO_FACTOR_AUTH', False)
+    bypass_list = config.get('BYPASS_TWO_FACTOR_AUTH') or []
+    enable_two_factor_auth = config.get('ENABLE_TWO_FACTOR_AUTH') or False
 
-    return enable_two_factor_auth and (bypass_list is None or not user_email in bypass_list)
+    return enable_two_factor_auth and user_email not in bypass_list

--- a/test/test_otp.py
+++ b/test/test_otp.py
@@ -1,6 +1,10 @@
+import json
 from default import with_context
 from pybossa import otp
 
+class JSONObject:
+    def __init__( self, dict ):
+        vars(self).update(dict)
 
 @with_context
 def test_create_otp():
@@ -33,3 +37,46 @@ def test_expire_token():
     token = otp.generate_url_token(user_email)
     otp.expire_token(token)
     assert otp.retrieve_email_for_token(token) is None
+
+
+@with_context
+def test_otp_enabled():
+    user_email = 'test@test.com'
+    config = json.loads('{ "ENABLE_TWO_FACTOR_AUTH": true }', object_hook=JSONObject)
+
+    assert otp.is_enabled(user_email, config) is True
+
+@with_context
+def test_otp_disabled():
+    user_email = 'test@test.com'
+    config = json.loads('{ "ENABLE_TWO_FACTOR_AUTH": false }', object_hook=JSONObject)
+
+    assert otp.is_enabled(user_email, config) is False
+
+@with_context
+def test_otp_enabled_user_bypass():
+    user_email = 'test@test.com'
+    config = json.loads('{ "ENABLE_TWO_FACTOR_AUTH": true, "BYPASS_TWO_FACTOR_AUTH": ["test@test.com"] }', object_hook=JSONObject)
+
+    assert otp.is_enabled(user_email, config) is False
+
+@with_context
+def test_otp_disabled_user_bypass():
+    user_email = 'test@test.com'
+    config = json.loads('{ "ENABLE_TWO_FACTOR_AUTH": false, "BYPASS_TWO_FACTOR_AUTH": ["test@test.com"] }', object_hook=JSONObject)
+
+    assert otp.is_enabled(user_email, config) is False
+
+@with_context
+def test_otp_enabled_user_no_bypass():
+    user_email = 'test@test.com'
+    config = json.loads('{ "ENABLE_TWO_FACTOR_AUTH": true, "BYPASS_TWO_FACTOR_AUTH": ["test2@test.com"] }', object_hook=JSONObject)
+
+    assert otp.is_enabled(user_email, config) is True
+
+@with_context
+def test_otp_disabled_user_no_bypass():
+    user_email = 'test@test.com'
+    config = json.loads('{ "ENABLE_TWO_FACTOR_AUTH": false, "BYPASS_TWO_FACTOR_AUTH": ["test2@test.com"] }', object_hook=JSONObject)
+
+    assert otp.is_enabled(user_email, config) is False

--- a/test/test_otp.py
+++ b/test/test_otp.py
@@ -1,10 +1,6 @@
-import json
-from default import with_context
+from default import with_context, with_context_settings
 from pybossa import otp
-
-class JSONObject:
-    def __init__( self, dict ):
-        vars(self).update(dict)
+from flask import current_app
 
 @with_context
 def test_create_otp():
@@ -39,44 +35,32 @@ def test_expire_token():
     assert otp.retrieve_email_for_token(token) is None
 
 
-@with_context
+@with_context_settings(ENABLE_TWO_FACTOR_AUTH=True, BYPASS_TWO_FACTOR_AUTH=[])
 def test_otp_enabled():
     user_email = 'test@test.com'
-    config = json.loads('{ "ENABLE_TWO_FACTOR_AUTH": true }', object_hook=JSONObject)
+    assert otp.is_enabled(user_email, current_app.config) is True
 
-    assert otp.is_enabled(user_email, config) is True
-
-@with_context
+@with_context_settings(ENABLE_TWO_FACTOR_AUTH=False, BYPASS_TWO_FACTOR_AUTH=[])
 def test_otp_disabled():
     user_email = 'test@test.com'
-    config = json.loads('{ "ENABLE_TWO_FACTOR_AUTH": false }', object_hook=JSONObject)
+    assert otp.is_enabled(user_email, current_app.config) is False
 
-    assert otp.is_enabled(user_email, config) is False
-
-@with_context
+@with_context_settings(ENABLE_TWO_FACTOR_AUTH=True, BYPASS_TWO_FACTOR_AUTH=["test@test.com"])
 def test_otp_enabled_user_bypass():
     user_email = 'test@test.com'
-    config = json.loads('{ "ENABLE_TWO_FACTOR_AUTH": true, "BYPASS_TWO_FACTOR_AUTH": ["test@test.com"] }', object_hook=JSONObject)
+    assert otp.is_enabled(user_email, current_app.config) is False
 
-    assert otp.is_enabled(user_email, config) is False
-
-@with_context
+@with_context_settings(ENABLE_TWO_FACTOR_AUTH=False, BYPASS_TWO_FACTOR_AUTH=["test@test.com"])
 def test_otp_disabled_user_bypass():
     user_email = 'test@test.com'
-    config = json.loads('{ "ENABLE_TWO_FACTOR_AUTH": false, "BYPASS_TWO_FACTOR_AUTH": ["test@test.com"] }', object_hook=JSONObject)
+    assert otp.is_enabled(user_email, current_app.config) is False
 
-    assert otp.is_enabled(user_email, config) is False
-
-@with_context
+@with_context_settings(ENABLE_TWO_FACTOR_AUTH=True, BYPASS_TWO_FACTOR_AUTH=["test2@test.com"])
 def test_otp_enabled_user_no_bypass():
     user_email = 'test@test.com'
-    config = json.loads('{ "ENABLE_TWO_FACTOR_AUTH": true, "BYPASS_TWO_FACTOR_AUTH": ["test2@test.com"] }', object_hook=JSONObject)
+    assert otp.is_enabled(user_email, current_app.config) is True
 
-    assert otp.is_enabled(user_email, config) is True
-
-@with_context
+@with_context_settings(ENABLE_TWO_FACTOR_AUTH=False, BYPASS_TWO_FACTOR_AUTH=["test2@test.com"])
 def test_otp_disabled_user_no_bypass():
     user_email = 'test@test.com'
-    config = json.loads('{ "ENABLE_TWO_FACTOR_AUTH": false, "BYPASS_TWO_FACTOR_AUTH": ["test2@test.com"] }', object_hook=JSONObject)
-
-    assert otp.is_enabled(user_email, config) is False
+    assert otp.is_enabled(user_email, current_app.config) is False

--- a/test/test_otp.py
+++ b/test/test_otp.py
@@ -35,12 +35,12 @@ def test_expire_token():
     assert otp.retrieve_email_for_token(token) is None
 
 
-@with_context_settings(ENABLE_TWO_FACTOR_AUTH=True, BYPASS_TWO_FACTOR_AUTH=[])
+@with_context_settings(ENABLE_TWO_FACTOR_AUTH=True)
 def test_otp_enabled():
     user_email = 'test@test.com'
     assert otp.is_enabled(user_email, current_app.config) is True
 
-@with_context_settings(ENABLE_TWO_FACTOR_AUTH=False, BYPASS_TWO_FACTOR_AUTH=[])
+@with_context_settings(ENABLE_TWO_FACTOR_AUTH=False)
 def test_otp_disabled():
     user_email = 'test@test.com'
     assert otp.is_enabled(user_email, current_app.config) is False


### PR DESCRIPTION
- Added config option to bypass two-factor authentication based upon login email address.
- Support for automated testing specific login email address.

```python
# Enable two factor authentication
ENABLE_TWO_FACTOR_AUTH = True
BYPASS_TWO_FACTOR_AUTH = ['user1@user.com', 'user2@user.com']
```