### PR TITLE
Add quiz completion mode setting.

### DIFF
--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -150,6 +150,13 @@ class ProjectQuizForm(Form):
             validators.NumberRange(min=0) # Making this 0 to allow quizzes with free-form answers.
         ]
     )
+    completion_mode = SelectField(
+        lazy_gettext('Completion mode'),
+        choices=[
+            ('all_questions', 'Present all the quiz questions'),
+            ('short_circuit', 'End as soon as pass/fail status is known')
+        ]
+    )
 
     def validate_passing(form, field):
         correct = field.data

--- a/pybossa/model/user.py
+++ b/pybossa/model/user.py
@@ -172,12 +172,13 @@ class User(db.Model, DomainObject, UserMixin):
     def update_quiz_status(self, project):
         quiz = self.get_quiz_for_project(project)
         right_count = quiz['result']['right']
+        wrong_count = quiz['result']['wrong']
         correct_to_pass = quiz['config']['passing']
         questions = quiz['config']['questions']
         status = None
         if right_count >= correct_to_pass:
             status = 'passed'
-        elif quiz['result']['wrong'] > questions - correct_to_pass:
+        elif wrong_count > questions - correct_to_pass:
             status = 'failed'
 
         if not status:

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -2965,6 +2965,7 @@ def assign_users(short_name):
 
 def process_quiz_mode_request(project):
     current_quiz_config = project.get_quiz()
+    current_quiz_config['completion_mode'] = 'short_circuit' if current_quiz_config['short_circuit'] else 'all_questions'
 
     if request.method == 'GET':
         return ProjectQuizForm(**current_quiz_config)
@@ -2985,6 +2986,7 @@ def process_quiz_mode_request(project):
         )
         return form
 
+    new_quiz_config['short_circuit'] = (new_quiz_config['completion_mode'] == 'short_circuit')
     project.set_quiz(new_quiz_config)
     project_repo.update(project)
     auditlogger.log_event(

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -9158,7 +9158,8 @@ class TestWebQuizModeUpdate(web.Helper):
     disabled_update = {
         'questions': 20,
         'passing': 15,
-        'garbage': 'junk'
+        'garbage': 'junk',
+        'completion_mode': 'short_circuit'
     }
 
     enabled_update = dict.copy(disabled_update)
@@ -9168,7 +9169,8 @@ class TestWebQuizModeUpdate(web.Helper):
         'enabled': False,
         'questions': disabled_update['questions'],
         'passing': disabled_update['passing'],
-        'short_circuit': True
+        'short_circuit': True,
+        'completion_mode': 'short_circuit'
     }
 
     enabled_result = dict.copy(disabled_result)
@@ -9202,7 +9204,7 @@ class TestWebQuizModeUpdate(web.Helper):
     def test_reset(self):
         admin = UserFactory.create()
         self.signin_user(admin)
-        quiz = {'enabled':True,'questions':10,'passing':5}
+        quiz = {'enabled':True,'questions':10,'passing':5,'completion_mode':'short_circuit'}
         project = ProjectFactory.create(owner=admin, info={'quiz':quiz})
         TaskFactory.create_batch(20, project=project, n_answers=1, calibration=1)
         assert admin.get_quiz_not_started(project)
@@ -9215,12 +9217,12 @@ class TestWebQuizModeUpdate(web.Helper):
     def test_not_enough_gold(self):
         admin = UserFactory.create()
         self.signin_user(admin)
-        quiz = {'enabled':True,'questions':10,'passing':5}
+        quiz = {'enabled':True,'questions':10,'passing':5,'completion_mode':'short_circuit'}
         project = ProjectFactory.create(owner=admin, info={'quiz':quiz})
         TaskFactory.create_batch(20, project=project, n_answers=1, calibration=1)
         quiz['questions'] = 100
         response = self.update_project(project, quiz)
-        assert "There must be at least as many gold tasks as the number of questions in the quiz." in response.data
+        assert "There must be at least as many gold tasks as the number of questions in the quiz." in response.data, response.data
 
     @with_context
     def test_enable(self):


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-1815*

**Describe your changes**
Added a new setting, completion mode, to quiz mode configuration. It lets the project owner configure whether the quiz will present all the questions regardless of how the worker answers, or if it will end the quiz as soon as the pass/fail status is known.

**Testing performed**
Manual testing
