### PR TITLE
Handle _priv_gold fields in CSV task import.

### DIFF
--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -55,32 +55,35 @@ class BulkTaskCSVImport(BulkTaskImport):
         task_data = {"info": {}}
         private_fields = dict()
         for idx, cell in enumerate(row):
+            header = self._headers[idx]
             if idx in self.field_header_index:
-                if self._headers[idx] == 'user_pref':
+                if header == 'user_pref':
                     if cell:
-                        task_data[self._headers[idx]] = json.loads(cell.lower())
+                        task_data[header] = json.loads(cell.lower())
                     else:
-                        task_data[self._headers[idx]] = {}
+                        task_data[header] = {}
                 else:
-                    task_data[self._headers[idx]] = cell
-            elif self._headers[idx].endswith('_gold'):
+                    task_data[header] = cell
+            elif header.endswith('_priv_gold'):
                 if cell:
-                    field_name = re.sub('_gold$', '', self._headers[idx])
-                    if 'gold_answers' not in task_data:
-                        task_data['gold_answers'] = {}
-                    task_data['gold_answers'][field_name] = cell
-            elif self._headers[idx].endswith('_priv'):
+                    field_name = re.sub('_priv_gold$', '', header)
+                    task_data.setdefault('gold_answers', {})[field_name] = cell
+            elif header.endswith('_gold'):
                 if cell:
-                    field_name = re.sub('_priv$', '', self._headers[idx])
+                    field_name = re.sub('_gold$', '', header)
+                    task_data.setdefault('gold_answers', {})[field_name] = cell
+            elif header.endswith('_priv'):
+                if cell:
+                    field_name = re.sub('_priv$', '', header)
                     if data_access_levels:
                         private_fields[field_name] = cell
                     else:
                         task_data["info"][field_name] = cell
-            elif self._headers[idx] == 'data_access' and data_access_levels:
+            elif header == 'data_access' and data_access_levels:
                 if cell:
-                    task_data["info"][self._headers[idx]] = json.loads(cell.upper())
+                    task_data["info"][header] = json.loads(cell.upper())
             else:
-                task_data["info"][self._headers[idx]] = cell
+                task_data["info"][header] = cell
         if private_fields:
             task_data['private_fields'] = private_fields
         return task_data

--- a/test/test_importers/test_localCSV_importer.py
+++ b/test/test_importers/test_localCSV_importer.py
@@ -78,12 +78,12 @@ class TestBulkTaskLocalCSVImport(Test):
     def test_priv_fields_import(self, mock_data_access, s3_get):
         mock_data_access = True
         expected_t1_priv_field = {u'Bar2': u'4', u'Bar': u'3'}
-        expected_t1_gold_ans = {u'ans2': u'5', u'ans': u'2'}
+        expected_t1_gold_ans = {u'ans2': u'5', u'ans': u'2', u'ans3': u'6'}
         expected_t2_priv_field = {u'Bar2': u'd', u'Bar': u'c'}
-        expected_t2_gold_ans = {u'ans2': u'e', u'ans': u'b'}
+        expected_t2_gold_ans = {u'ans2': u'e', u'ans': u'b', u'ans3': u'f'}
 
         with patch('pybossa.importers.csv.io.open', mock_open(
-            read_data=u'Foo,ans_gold,Bar_priv,Bar2_priv,ans2_gold\n1,2,3,4,5\na,b,c,d,e\n'), create=True):
+            read_data=u'Foo,ans_gold,Bar_priv,Bar2_priv,ans2_gold,ans3_priv_gold\n1,2,3,4,5,6\na,b,c,d,e,f\n'), create=True):
             [t1, t2] = self.importer.tasks()
             assert_equal(t1['private_fields'], expected_t1_priv_field), t1
             assert_equal(t1['gold_answers'], expected_t1_gold_ans), t1


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD_2043*

**Describe your changes**
In CSV task import, we used to require a field to end with _priv_gold to store it as a private gold answer. We would remove that suffix to get the actual field name. We changed the behavior to store all gold answers on private GIGwork as private, so we stopped looking for _priv_gold and just
looked for _gold. That meant that a field imported with _priv_gold suffix will just have _gold removed and _priv will still be at the end of the name, which will leave us storing the wrong name.

This PR removes the _priv_gold suffix in addition to the _gold suffix.

**Testing performed**
New unit tests
