### PR TITLE
Support enrichment for CSV imported tasks.

### DIFF
--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -50,7 +50,7 @@ class TaskAPI(APIBase):
     """Class for domain object Task."""
 
     __class__ = Task
-    reserved_keys = set(['id', 'created', 'state', 'fav_user_ids',
+    reserved_keys = set(['id', 'created', 'fav_user_ids',
         'calibration'])
 
     immutable_keys = set(['project_id'])

--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -50,7 +50,7 @@ class TaskAPI(APIBase):
     """Class for domain object Task."""
 
     __class__ = Task
-    reserved_keys = set(['id', 'created', 'fav_user_ids',
+    reserved_keys = set(['id', 'created', 'state', 'fav_user_ids',
         'calibration'])
 
     immutable_keys = set(['project_id'])

--- a/pybossa/cache/helpers.py
+++ b/pybossa/cache/helpers.py
@@ -39,6 +39,7 @@ def n_available_tasks(project_id, user_id=None, user_ip=None):
     if user_id and not user_ip:
         query = text('''SELECT COUNT(*) AS n_tasks FROM task
                         WHERE project_id=:project_id AND state !='completed'
+                        AND state !='enrich'
                         AND id NOT IN
                         (SELECT task_id FROM task_run WHERE
                         project_id=:project_id AND user_id=:user_id);''')
@@ -49,6 +50,7 @@ def n_available_tasks(project_id, user_id=None, user_ip=None):
             user_ip = '127.0.0.1'
         query = text('''SELECT COUNT(*) AS n_tasks FROM task
                         WHERE project_id=:project_id AND state !='completed'
+                        AND state !='enrich'
                         AND id NOT IN
                         (SELECT task_id FROM task_run WHERE
                         project_id=:project_id AND user_ip=:user_ip);''')
@@ -67,6 +69,7 @@ def oldest_available_task(project_id, user_id, user_ip=None):
     if user_id and not user_ip:
         query = text('''SELECT created FROM task
                         WHERE project_id=:project_id AND state !='completed'
+                        AND state !='enrich'
                         AND id NOT IN
                         (SELECT task_id FROM task_run WHERE
                         project_id=:project_id AND user_id=:user_id)
@@ -79,6 +82,7 @@ def oldest_available_task(project_id, user_id, user_ip=None):
             user_ip = '127.0.0.1'
         query = text('''SELECT created FROM task
                         WHERE project_id=:project_id AND state !='completed'
+                        AND state !='enrich'
                         AND id NOT IN
                         (SELECT task_id FROM task_run WHERE
                         project_id=:project_id AND user_ip=:user_ip)
@@ -182,6 +186,7 @@ def n_available_tasks_for_user(project, user_id=None, user_ip=None):
         sql = '''
                SELECT COUNT(*) AS n_tasks FROM task
                WHERE project_id=:project_id AND state !='completed'
+               AND state !='enrich'
                AND id NOT IN
                (SELECT task_id FROM task_run WHERE
                project_id=:project_id AND user_id=:user_id) {}
@@ -191,6 +196,7 @@ def n_available_tasks_for_user(project, user_id=None, user_ip=None):
         sql = '''
                SELECT COUNT(*) AS n_tasks FROM task
                WHERE project_id=:project_id AND state !='completed'
+               AND state !='enrich'
                AND id NOT IN
                (SELECT task_id FROM task_run WHERE
                project_id=:project_id AND user_id=:user_id)

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -123,12 +123,13 @@ class Importer(object):
         self._importers['youtube'] = BulkTaskYoutubeImport
         self._importer_constructor_params['youtube'] = youtube_params
 
-    def upload_private_data(self, task, project_id, use_file_url=False):
+    def upload_private_data(self, task, project_id):
         private_fields = task.pop('private_fields', None)
         if not private_fields:
             return
         file_name = 'task_private_data.json'
         urls = upload_files_priv(task, project_id, private_fields, file_name)
+        use_file_url = (task.get('state') == 'enrich')        
         task['info']['private_json__upload_url'] = urls if use_file_url else urls['externalUrl']
 
     def create_tasks(self, task_repo, project, **form_data):
@@ -169,8 +170,8 @@ class Importer(object):
         n_answers = project.get_default_n_answers()
         try:
             for task_data in tasks:
-                use_file_url = (task_data.get('state') == 'enrich')
-                self.upload_private_data(task_data, project.id, use_file_url=use_file_url)
+                
+                self.upload_private_data(task_data, project.id)
                 
                 task = Task(project_id=project.id, n_answers=n_answers)
                 [setattr(task, k, v) for k, v in task_data.iteritems()]

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -168,7 +168,7 @@ class Importer(object):
         validator = TaskImportValidator()
         n_answers = project.get_default_n_answers()
         try:
-            task_state, use_file_url = ('enrich', True) if project.info.get('enrichments') else ('ongoing', False)
+            task_state, use_file_url = (u'enrich', True) if project.info.get('enrichments') else (u'ongoing', False)
             for task_data in tasks:
                 self.upload_private_data(task_data, project.id, use_file_url=use_file_url)
                 

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -168,11 +168,11 @@ class Importer(object):
         validator = TaskImportValidator()
         n_answers = project.get_default_n_answers()
         try:
-            task_state, use_file_url = (u'enrich', True) if project.info.get('enrichments') else (u'ongoing', False)
             for task_data in tasks:
+                use_file_url = (task_data.get('state') == 'enrich')
                 self.upload_private_data(task_data, project.id, use_file_url=use_file_url)
                 
-                task = Task(project_id=project.id, n_answers=n_answers, state=task_state)
+                task = Task(project_id=project.id, n_answers=n_answers)
                 [setattr(task, k, v) for k, v in task_data.iteritems()]
 
                 gold_answers = task_data.pop('gold_answers', None)

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -129,7 +129,7 @@ class Importer(object):
             return
         file_name = 'task_private_data.json'
         urls = upload_files_priv(task, project_id, private_fields, file_name)
-        task['info']['private_json__upload_url'] = urls if use_file_url else use_file_url['externalUrl']
+        task['info']['private_json__upload_url'] = urls if use_file_url else urls['externalUrl']
 
     def create_tasks(self, task_repo, project, **form_data):
         """Create tasks."""

--- a/pybossa/task_creator_helper.py
+++ b/pybossa/task_creator_helper.py
@@ -44,7 +44,8 @@ def set_gold_answers(task, gold_answers):
     task.gold_answers = gold_answers
     task.calibration = 1
     task.exported = True
-    task.state = 'ongoing'
+    if task.state == u'completed':
+        task.state = u'ongoing'
 
 def upload_files_priv(task, project_id, data, file_name):
     bucket = bucket_name()

--- a/pybossa/task_creator_helper.py
+++ b/pybossa/task_creator_helper.py
@@ -38,7 +38,7 @@ def set_gold_answers(task, gold_answers):
     if not gold_answers:
         return
     if encrypted():
-        url = upload_files_priv(task, task.project_id, gold_answers, TASK_PRIVATE_GOLD_ANSWER_FILE_NAME)
+        url = upload_files_priv(task, task.project_id, gold_answers, TASK_PRIVATE_GOLD_ANSWER_FILE_NAME)['externalUrl']
         gold_answers = dict([(TASK_GOLD_ANSWER_URL_KEY, url)])
 
     task.gold_answers = gold_answers
@@ -57,7 +57,7 @@ def upload_files_priv(task, project_id, data, file_name):
         path='{}/{}'.format(task_hash, file_name)
     )
     file_url = url_for('fileproxy.encrypted_file', **values)
-    upload_json_data(
+    internal_url = upload_json_data(
         bucket=bucket,
         json_data=data,
         upload_path=path,
@@ -65,7 +65,7 @@ def upload_files_priv(task, project_id, data, file_name):
         encryption=True,
         conn_name='S3_TASK_REQUEST'
     )
-    return file_url
+    return { 'externalUrl': file_url, 'internalUrl': internal_url }
 
 def get_gold_answers(task):
     gold_answers = task.gold_answers

--- a/test/test_importers/__init__.py
+++ b/test/test_importers/__init__.py
@@ -235,11 +235,11 @@ class TestImporterPublicMethods(Test):
     ):
         mock_importer = Mock()
         mock_importer.tasks.return_value = [{'info': {u'Foo': u'a'}, 'private_fields': {u'Bar2': u'd', u'Bar': u'c'},
-            'gold_answers': {u'ans2': u'e', u'ans': u'b'}, 'calibration': 1, 'exported': True}]
+            'gold_answers': {u'ans2': u'e', u'ans': u'b'}, 'calibration': 1, 'exported': True, 'state': u'enrich'}]
 
         importer_factory.return_value = mock_importer
         # enrichments needs to be a truthy value to trigger enrichment.
-        project = ProjectFactory.create(info={'enrichments':True})
+        project = ProjectFactory.create()
         form_data = dict(type='localCSV', csv_filename='fakefile.csv')
 
         with patch.dict(

--- a/test/test_importers/__init__.py
+++ b/test/test_importers/__init__.py
@@ -223,3 +223,62 @@ class TestImporterPublicMethods(Test):
             assert filename == 'task_private_gold_answer.json', filename
             assert task.calibration and task.exported
             assert task.state == 'ongoing', task.state
+
+    @with_context
+    @patch('pybossa.cloud_store_api.s3.s3_upload_from_string', return_value='https:/s3/task.json')
+    @patch('pybossa.importers.importer.delete_import_csv_file', return_value=None)
+    def test_create_tasks_creates_private_regular_and_gold_fields_with_enrichment(
+        self,
+        mock_del,
+        upload_from_string,
+        importer_factory
+    ):
+        mock_importer = Mock()
+        mock_importer.tasks.return_value = [{'info': {u'Foo': u'a'}, 'private_fields': {u'Bar2': u'd', u'Bar': u'c'},
+            'gold_answers': {u'ans2': u'e', u'ans': u'b'}, 'calibration': 1, 'exported': True}]
+
+        importer_factory.return_value = mock_importer
+        # enrichments needs to be a truthy value to trigger enrichment.
+        project = ProjectFactory.create(info={'enrichments':True})
+        form_data = dict(type='localCSV', csv_filename='fakefile.csv')
+
+        with patch.dict(
+            self.flask_app.config,
+            {
+                'S3_REQUEST_BUCKET': 'mybucket',
+                'S3_CONN_TYPE': 'dev',
+                'ENABLE_ENCRYPTION': True
+            }
+        ):
+            result = self.importer.create_tasks(task_repo, project, **form_data)
+            importer_factory.assert_called_with(**form_data)
+            upload_from_string.assert_called()
+            assert result.message == '1 new task was imported successfully ', result
+
+            # validate task created has private fields url, gold_answers url
+            # calibration and exported flag set
+            tasks = task_repo.filter_tasks_by(project_id=project.id)
+            assert len(tasks) == 1, len(tasks)
+            task = tasks[0]
+            private_json_file_url = task.info['private_json__upload_url']
+            private_json_url = private_json_file_url['externalUrl']
+            localhost, fileproxy, encrypted, env, bucket, project_id, hash_key, filename = private_json_url.split('/', 2)[2].split('/')
+            assert localhost == 'localhost', localhost
+            assert fileproxy == 'fileproxy', fileproxy
+            assert encrypted == 'encrypted', encrypted
+            assert env == 'dev', env
+            assert bucket == 'mybucket', bucket
+            assert project_id == '1', project_id
+            assert filename == 'task_private_data.json', filename
+
+            gold_ans__upload_url = task.gold_answers['gold_ans__upload_url']
+            localhost, fileproxy, encrypted, env, bucket, project_id, hash_key, filename = gold_ans__upload_url.split('/', 2)[2].split('/')
+            assert localhost == 'localhost', localhost
+            assert fileproxy == 'fileproxy', fileproxy
+            assert encrypted == 'encrypted', encrypted
+            assert env == 'dev', env
+            assert bucket == 'mybucket', bucket
+            assert project_id == '1', project_id
+            assert filename == 'task_private_gold_answer.json', filename
+            assert task.calibration and task.exported
+            assert task.state == 'enrich', task.state


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-1878*

**Describe your changes**
Adding a new task state, "enrich", for tasks that are imported by CSV when there are enrichment settings configured on a project. These tasks will not be scheduled to workers while in the "enrich" state. The task poller will pull these tasks into BBDS and then they will be enriched by the BBDS listener and then pushed back to gigwork with enriched request fields and a state of "ongoing".

**Testing performed**
Manual and unit tests.
