### PR TITLE
Don't initialize blank task properties in csv import.

### DIFF
--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -89,7 +89,7 @@ class BulkTaskCSVImport(BulkTaskImport):
                         task_data[header] = json.loads(cell.lower())
                     else:
                         task_data[header] = {}
-                else:
+                elif cell:
                     task_data[header] = cell
                 continue
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-1878*

**Describe your changes**
In CSV task import, if a column for a reserved task property (other than user_pref) is blank then don't initialize that property on the task. Current code initializes the property to empty string.

Reserved properties are:
state
quorum
calibration
priority_0
n_answers
expiration

**Testing performed**
Manual and unit test.
