### PR TITLE
Validate CSV headers.

### DIFF
--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -320,6 +320,11 @@ class BulkTaskGDImportForm(Form):
 
 class BulkTaskLocalCSVImportForm(Form):
     form_name = TextField(label=None, widget=HiddenInput(), default='localCSV')
+    do_not_validate_tp = BooleanField(
+        label=lazy_gettext("Do not require all fields used in task presenter code to be present in the csv file"),
+        default=False
+    )
+
     _allowed_extensions = set(['csv'])
     def _allowed_file(self, filename):
         return '.' in filename and \
@@ -350,7 +355,11 @@ class BulkTaskLocalCSVImportForm(Form):
             if csv_file and self._allowed_file(csv_file.filename):
                 file_path = get_file_path_for_import_csv(csv_file)
                 return {'type': 'localCSV', 'csv_filename': file_path}
-        return {'type': 'localCSV', 'csv_filename': None}
+        return {
+            'type': 'localCSV',
+            'csv_filename': None,
+            'validate_tp': not self.do_not_validate_tp.data
+        }
 
 
 class BulkTaskEpiCollectPlusImportForm(Form):

--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -346,18 +346,20 @@ class BulkTaskLocalCSVImportForm(Form):
         raise IOError('Local Upload folder is missing: {0}'.format(filepath))
 
     def get_import_data(self):
-        if request.method == 'POST':
+        def get_csv_filename():
+            if request.method != 'POST':
+                return
             if 'file' not in request.files:
-                return {'type': 'localCSV', 'csv_filename': None}
+                return
             csv_file = request.files['file']
             if csv_file.filename == '':
-                return {'type': 'localCSV', 'csv_filename': None}
+                return
             if csv_file and self._allowed_file(csv_file.filename):
-                file_path = get_file_path_for_import_csv(csv_file)
-                return {'type': 'localCSV', 'csv_filename': file_path}
+                return get_file_path_for_import_csv(csv_file)
+
         return {
             'type': 'localCSV',
-            'csv_filename': None,
+            'csv_filename': get_csv_filename(),
             'validate_tp': not self.do_not_validate_tp.data
         }
 

--- a/pybossa/importers/base.py
+++ b/pybossa/importers/base.py
@@ -29,8 +29,10 @@ class BulkTaskImport(object):
 
     """Class to import tasks in bulk."""
 
+    def __init__(self):
+        self._headers = None
+
     importer_id = None
-    _headers = None
 
     def tasks(self):
         """Return a generator with all the tasks imported."""

--- a/pybossa/importers/base.py
+++ b/pybossa/importers/base.py
@@ -43,6 +43,9 @@ class BulkTaskImport(object):
     def headers(self):
         return self._headers
 
+    def fields(self):
+        return set(self.headers() or [])
+
     def import_metadata(self):
         return None
 

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -176,10 +176,18 @@ class BulkTaskCSVImportBase(BulkTaskImport):
         BulkTaskImport.__init__(self)
         self._field_processors = None
         self._input_fields = None
-
+        self._task_list = None
+    
+    def count_tasks(self):
+        """Return amount of tasks to be imported."""
+        return len(self.tasks())
+    
     def tasks(self):
         """Get tasks from a given URL."""
-        return self._get_csv_data()
+        if self._task_list is None:
+            self._task_list = list(self._get_csv_data())
+        
+        return self._task_list
 
     def headers(self, csvreader=None):
         if self._headers is not None:
@@ -352,6 +360,3 @@ class BulkTaskLocalCSVImport(BulkTaskCSVImportBase):
         csv_file.stream.seek(0)
         csvcontent = io.StringIO(csv_file.stream.read())
         return unicode_csv_reader(csvcontent)
-    
-    def tasks(self):
-        return list(BulkTaskCSVImportBase.tasks(self))

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -193,8 +193,10 @@ class BulkTaskCSVImport(BulkTaskImport):
                 if not enrichments:
                     raise BulkImportException('No enrichment settings configured. Task state of "enrich" not allowed.')
                 enrichment_fields_in_import = [
-                    enrichment.get('out_field_name') for enrichment in enrichments
-                    if enrichment.get('out_field_name') in self._headers
+                    out_field_name
+                    for enrichment in enrichments
+                    for out_field_name in [enrichment.get('out_field_name')]
+                    if out_field_name in task_data['info']
                 ]
                 if enrichment_fields_in_import:
                     raise BulkImportException('Enrichment output field is in import: {}'.format(', '.join(enrichment_fields_in_import)))

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -58,6 +58,105 @@ def get_value(header, value_string, data_type):
 
     return value
 
+class ReservedFieldProcessor(object):
+    def __init__(self, header):
+        self.header = header
+    
+    is_input = False
+
+    @staticmethod
+    def can_process(header, index, reserved_field_header_indexes):
+        if index in reserved_field_header_indexes:
+            return ReservedFieldProcessor(header)
+
+    def process(self, task_data, cell, *args):
+        if self.header == 'user_pref':
+            if cell:
+                task_data[self.header] = json.loads(cell.lower())
+            else:
+                task_data[self.header] = {}
+        elif cell:
+            task_data[self.header] = cell
+
+class GoldFieldProcessor(object):
+    def __init__(self, data_type, field_name, header):
+        self.data_type = data_type
+        self.field_name = field_name
+        self.header = header
+
+    is_input = False
+
+    @staticmethod
+    def can_process(header):
+        gold_match = re.match('(?P<field>.*?)(_priv)?_gold(_(?P<type>json|number|bool|null))?$', header)
+        if gold_match:
+            return GoldFieldProcessor(gold_match.group('type'), gold_match.group('field'), header)
+
+    def process(self, task_data, cell, *args):
+        if not cell:
+            return
+        task_data.setdefault('gold_answers', {})[self.field_name] = get_value(self.header, cell, self.data_type)
+
+class PrivateFieldProcessor(object):
+    def __init__(self, data_type, field_name, header):
+        self.data_type = data_type
+        self.field_name = field_name
+        self.header = header
+
+    is_input = True
+
+    @staticmethod
+    def can_process(header):
+        priv_match = re.match('(?P<field>.*?)_priv(_(?P<type>json|number|bool|null))?$', header)
+        if priv_match:
+            return PrivateFieldProcessor(priv_match.group('type'), priv_match.group('field'), header)
+
+    def process(self, task_data, cell, private_fields, *args):
+        if not cell:
+            return
+
+        if data_access_levels: # This is how we check for private GIGwork.
+            private_fields[self.field_name] = get_value(self.header, cell, self.data_type)
+        else:
+            task_data["info"][self.field_name] = get_value(self.header, cell, self.data_type)
+
+class DataAccessFieldProcessor(object):
+    def __init__(self):
+        self.field_name = 'data_access'
+
+    is_input = True
+
+    @staticmethod
+    def can_process(header):
+        if header == self.field_name and data_access_levels:
+            return DataAccessFieldProcessor()
+
+    def process(self, task_data, cell, *args):
+        if not cell:
+            return
+
+        task_data["info"][self.field_name] = json.loads(cell.upper())
+
+class PublicFieldProcessor(object):
+    def __init__(self, data_type, field_name, header):
+        self.data_type = data_type
+        self.field_name = field_name
+        self.header = header
+
+    is_input = True
+
+    @staticmethod
+    def can_process(header):
+        pub_match = re.match('(?P<field>.*?)(_(?P<type>json|number|bool|null))?$', header)
+        if pub_match: # This must match since there are no other options left.
+            return PublicFieldProcessor(pub_match.group('type'), pub_match.group('field'), header)
+
+    def process(self, task_data, cell, *args):
+        if not cell:
+            return
+
+        task_data["info"][self.field_name] = get_value(self.header, cell, self.data_type)
+
 class BulkTaskCSVImport(BulkTaskImport):
 
     """Class to import CSV tasks in bulk."""
@@ -76,7 +175,8 @@ class BulkTaskCSVImport(BulkTaskImport):
     def __init__(self, csv_url, last_import_meta=None):
         self.url = csv_url
         self.last_import_meta = last_import_meta
-        self._fields = None
+        self._field_processors = None
+        self._input_fields = None
 
     def tasks(self):
         """Get tasks from a given URL."""
@@ -107,83 +207,32 @@ class BulkTaskCSVImport(BulkTaskImport):
         return self._headers
 
     def fields(self):
-        def get_fields():
+        def get_field_processors():
             for idx, header in enumerate(self.headers()):
-                if idx in self.reserved_field_header_index:
-                    yield header
-                gold_match = re.match('(?P<field>.*?)(_priv)?_gold(_(?P<type>json|number|bool|null))?$', header)
-                if gold_match:
-                    continue
-                priv_match = re.match('(?P<field>.*?)_priv(_(?P<type>json|number|bool|null))?$', header)
-                if priv_match:
-                    yield priv_match.group('field')
-                if header == 'data_access' and data_access_levels:
-                    yield header
-                pub_match = re.match('(?P<field>.*?)(_(?P<type>json|number|bool|null))?$', header)
-                if pub_match: # This must match since there are no other options left.
-                    yield pub_match.group('field')
+                yield (
+                    ReservedFieldProcessor.can_process(header, idx, self.reserved_field_header_index)
+                    or GoldFieldProcessor.can_process(header)
+                    or PrivateFieldProcessor.can_process(header)
+                    or DataAccessFieldProcessor.can_process(header)
+                    or PublicFieldProcessor.can_process(header)
+                )
 
-        if self._fields is None:      
-            self._fields = set(get_fields())
+        if self._field_processors is None:
+            self._field_processors = list(get_field_processors())
+            self._input_fields = {field.field_name for field in self._field_processors if field.is_input}
 
-        return self._fields
+        return self._input_fields
 
     def _get_data_url(self):
         """Get data from URL."""
         return self.url
-
-    def _process_cell(self, idx, cell, task_data, private_fields):
-        header = self._headers[idx]
-        if idx in self.reserved_field_header_index:
-            if header == 'user_pref':
-                if cell:
-                    task_data[header] = json.loads(cell.lower())
-                else:
-                    task_data[header] = {}
-            elif cell:
-                task_data[header] = cell
-            return
-
-        gold_match = re.match('(?P<field>.*?)(_priv)?_gold(_(?P<type>json|number|bool|null))?$', header)
-        if gold_match:
-            if cell:
-                data_type = gold_match.group('type')
-                field_name = gold_match.group('field')
-                task_data.setdefault('gold_answers', {})[field_name] = get_value(header, cell, data_type)
-            return
-
-        priv_match = re.match('(?P<field>.*?)_priv(_(?P<type>json|number|bool|null))?$', header)
-        if priv_match:
-            if cell:
-                data_type = priv_match.group('type')
-                field_name = priv_match.group('field')
-                if data_access_levels: # This is how we check for private GIGwork.
-                    private_fields[field_name] = get_value(header, cell, data_type)
-                else:
-                    task_data["info"][field_name] = get_value(header, cell, data_type)
-            return
-
-        if header == 'data_access' and data_access_levels:
-            if cell:
-                task_data["info"][header] = json.loads(cell.upper())
-            return
-
-        pub_match = re.match('(?P<field>.*?)(_(?P<type>json|number|bool|null))?$', header)
-        if pub_match: # This must match since there are no other options left.
-            if cell:
-                data_type = pub_match.group('type')
-                field_name = pub_match.group('field')
-                task_data["info"][field_name] = get_value(header, cell, data_type)
-            return
-
-        raise BulkImportException('{} is not recognized as a valid import header'.format(header))
 
     def _convert_row_to_task_data(self, row, row_number):
         task_data = {"info": {}}
         private_fields = dict()
 
         for idx, cell in enumerate(row):
-            self._process_cell(idx, cell, task_data, private_fields)
+            self._field_processors[idx].process(task_data, cell, private_fields)
         if private_fields:
             task_data['private_fields'] = private_fields
         return task_data
@@ -206,23 +255,6 @@ class BulkTaskCSVImport(BulkTaskImport):
                                 .format(','.join(invalid_fields)))
                 raise BulkImportException(msg)
             task_data = self._convert_row_to_task_data(row, row_number)
-            # task_state = task_data.get('state')
-            # print 'task_state', task_state
-            # if task_state not in ['enrich', 'ongoing', None]:
-            #     raise BulkImportException('Invalid task state: {}'.format(task_state))
-
-            # if self.project and task_state == 'enrich':
-            #     enrichments = project.info.get('enrichments')
-            #     if not enrichments:
-            #         raise BulkImportException('No enrichment settings configured. Task state of "enrich" not allowed.')
-            #     enrichment_fields_in_import = [
-            #         out_field_name
-            #         for enrichment in enrichments
-            #         for out_field_name in [enrichment.get('out_field_name')]
-            #         if out_field_name in task_data['info']
-            #     ]
-            #     if enrichment_fields_in_import:
-            #         raise BulkImportException('Enrichment output field is in import: {}'.format(', '.join(enrichment_fields_in_import)))
             yield task_data
 
     def _check_no_duplicated_headers(self):

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -124,7 +124,7 @@ class BulkTaskCSVImport(BulkTaskImport):
                     yield pub_match.group('field')
 
         if self._fields is None:      
-            self._fields = list(get_fields())
+            self._fields = set(get_fields())
 
         return self._fields
 

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -275,7 +275,7 @@ class BulkTaskCSVImportBase(BulkTaskImport):
     def _get_csv_data(self):
         return self._import_csv_tasks(self._get_csv_reader())
 
-class BulkTaskUrlCSVImport(BulkTaskCSVImportBase):
+class BulkTaskCSVImport(BulkTaskCSVImportBase):
     importer_id = "csv"
 
     def __init__(self, csv_url, last_import_meta=None):
@@ -303,14 +303,14 @@ class BulkTaskUrlCSVImport(BulkTaskCSVImportBase):
         csvcontent = StringIO(r.text)
         return unicode_csv_reader(csvcontent)
 
-class BulkTaskGDImport(BulkTaskUrlCSVImport):
+class BulkTaskGDImport(BulkTaskCSVImport):
 
     """Class to import tasks from Google Drive in bulk."""
 
     importer_id = "gdocs"
 
     def __init__(self, googledocs_url):
-        BulkTaskUrlCSVImport.__init__(self, googledocs_url)
+        BulkTaskCSVImport.__init__(self, googledocs_url)
 
     def _get_data_url(self):
         """Get data from URL."""

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -336,9 +336,6 @@ class BulkTaskLocalCSVImport(BulkTaskCSVImportBase):
        BulkTaskCSVImportBase.__init__(self)
        self.form_data = form_data
 
-    def count_tasks(self):
-        return len([task for task in self.tasks()])
-
     def _get_csv_reader(self):
         csv_filename = self.form_data['csv_filename']
         if csv_filename is None:

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -173,6 +173,7 @@ class BulkTaskCSVImportBase(BulkTaskImport):
     """Class to import CSV tasks in bulk."""
 
     def __init__(self):
+        BulkTaskImport.__init__(self)
         self._field_processors = None
         self._input_fields = None
 

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -184,7 +184,7 @@ class BulkTaskCSVImport(BulkTaskImport):
         private_fields = dict()
 
         for idx, cell in enumerate(row):
-            self.process_cell(idx, cell, task_data, private_fields)
+            self._process_cell(idx, cell, task_data, private_fields)
         if private_fields:
             task_data['private_fields'] = private_fields
         return task_data

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -207,22 +207,23 @@ class BulkTaskCSVImport(BulkTaskImport):
                                 .format(','.join(invalid_fields)))
                 raise BulkImportException(msg)
             task_data = self._convert_row_to_task_data(row, row_number)
-            task_state = task_data.get('state')
-            if task_state not in ['enrich', 'ongoing', None]:
-                raise BulkImportException('Invalid task state: {}'.format(task_state))
+            # task_state = task_data.get('state')
+            # print 'task_state', task_state
+            # if task_state not in ['enrich', 'ongoing', None]:
+            #     raise BulkImportException('Invalid task state: {}'.format(task_state))
 
-            if self.project and task_state == 'enrich':
-                enrichments = project.info.get('enrichments')
-                if not enrichments:
-                    raise BulkImportException('No enrichment settings configured. Task state of "enrich" not allowed.')
-                enrichment_fields_in_import = [
-                    out_field_name
-                    for enrichment in enrichments
-                    for out_field_name in [enrichment.get('out_field_name')]
-                    if out_field_name in task_data['info']
-                ]
-                if enrichment_fields_in_import:
-                    raise BulkImportException('Enrichment output field is in import: {}'.format(', '.join(enrichment_fields_in_import)))
+            # if self.project and task_state == 'enrich':
+            #     enrichments = project.info.get('enrichments')
+            #     if not enrichments:
+            #         raise BulkImportException('No enrichment settings configured. Task state of "enrich" not allowed.')
+            #     enrichment_fields_in_import = [
+            #         out_field_name
+            #         for enrichment in enrichments
+            #         for out_field_name in [enrichment.get('out_field_name')]
+            #         if out_field_name in task_data['info']
+            #     ]
+            #     if enrichment_fields_in_import:
+            #         raise BulkImportException('Enrichment output field is in import: {}'.format(', '.join(enrichment_fields_in_import)))
             yield task_data
 
     def _check_no_duplicated_headers(self):

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -100,7 +100,7 @@ class BulkTaskCSVImport(BulkTaskImport):
         self._check_no_empty_headers()
         self._check_required_headers()
 
-        reserved_field_headers = set(self._headers) & reserved_fields
+        reserved_field_headers = set(self._headers) & self.reserved_fields
         self.reserved_field_header_index = [
             self._headers.index(field) for field in reserved_field_headers
         ]

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -131,13 +131,14 @@ class PrivateFieldProcessor(object):
 
 class DataAccessFieldProcessor(object):
     def __init__(self):
-        self.field_name = 'data_access'
+        pass
 
+    field_name = 'data_access'
     is_input = True
 
     @staticmethod
     def can_process(header):
-        if header == self.field_name and data_access_levels:
+        if header == DataAccessFieldProcessor.field_name and data_access_levels:
             return DataAccessFieldProcessor()
 
     def process(self, task_data, cell, *args):

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -73,10 +73,9 @@ class BulkTaskCSVImport(BulkTaskImport):
         'expiration'
     ])
 
-    def __init__(self, csv_url, last_import_meta=None, project=None):
+    def __init__(self, csv_url, last_import_meta=None):
         self.url = csv_url
         self.last_import_meta = last_import_meta
-        self.project = project
         self._fields = None
 
     def tasks(self):

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -176,18 +176,10 @@ class BulkTaskCSVImportBase(BulkTaskImport):
         BulkTaskImport.__init__(self)
         self._field_processors = None
         self._input_fields = None
-        self._task_list = None
-    
-    def count_tasks(self):
-        """Return amount of tasks to be imported."""
-        return len(self.tasks())
     
     def tasks(self):
         """Get tasks from a given URL."""
-        if self._task_list is None:
-            self._task_list = list(self._get_csv_data())
-        
-        return self._task_list
+        return self._get_csv_data()
 
     def headers(self, csvreader=None):
         if self._headers is not None:
@@ -360,3 +352,6 @@ class BulkTaskLocalCSVImport(BulkTaskCSVImportBase):
         csv_file.stream.seek(0)
         csvcontent = io.StringIO(csv_file.stream.read())
         return unicode_csv_reader(csvcontent)
+
+    def tasks(self):
+        return list(BulkTaskCSVImportBase.tasks(self))

--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -197,7 +197,7 @@ class BulkTaskCSVImportBase(BulkTaskImport):
 
     def fields(self, csvreader=None):
         def get_field_processors():
-            for idx, header in enumerate(self.headers(csvreader)):
+            for header in self.headers(csvreader):
                 yield (
                     ReservedFieldProcessor.can_process(header)
                     or GoldFieldProcessor.can_process(header)

--- a/pybossa/importers/dropbox.py
+++ b/pybossa/importers/dropbox.py
@@ -29,6 +29,7 @@ class BulkTaskDropboxImport(BulkTaskImport):
     importer_id = 'dropbox'
 
     def __init__(self, files, last_import_meta=None):
+        BulkTaskImport.__init__(self)
         self.files = files
         self.last_import_meta = last_import_meta
 

--- a/pybossa/importers/epicollect.py
+++ b/pybossa/importers/epicollect.py
@@ -31,6 +31,7 @@ class BulkTaskEpiCollectPlusImport(BulkTaskImport):
 
     def __init__(self, epicollect_project,
                  epicollect_form, last_import_meta=None):
+        BulkTaskImport.__init__(self)
         self.project = epicollect_project
         self.form = epicollect_form
         self.last_import_meta = last_import_meta

--- a/pybossa/importers/flickr.py
+++ b/pybossa/importers/flickr.py
@@ -30,6 +30,7 @@ class BulkTaskFlickrImport(BulkTaskImport):
 
     def __init__(self, api_key, album_id, last_import_meta=None):
         """Init method."""
+        BulkTaskImport.__init__(self)
         self.api_key = api_key
         self.album_id = album_id
         self.last_import_meta = last_import_meta

--- a/pybossa/importers/iiif.py
+++ b/pybossa/importers/iiif.py
@@ -30,6 +30,7 @@ class BulkTaskIIIFImporter(BulkTaskImport):
 
     def __init__(self, manifest_uri, version='2.1'):
         """Init method."""
+        BulkTaskImport.__init__(self)
         self.manifest_uri = manifest_uri
         self.version = version
 

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -93,13 +93,13 @@ class TaskImportValidator(object):
         'ernichment output in import': validate_no_enrichment_output_field
     }
 
-    def __init__(self, project):
+    def __init__(self, enrichment_output_fields):
         self.errors = defaultdict(int)
-        self._project = project
+        self._enrichment_output_fields = enrichment_output_fields
 
     def validate(self, task):
         for error, validator in self.validations.items():
-            if not validator(task, self._project):
+            if not validator(task, self._enrichment_output_fields):
                 self.errors[error] += 1
                 return False
         return True

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -193,7 +193,7 @@ class Importer(object):
         """Create tasks from a remote source using an importer object and
         avoiding the creation of repeated tasks"""
         n = 0
-        importer = self._create_importer_for(project=project, **form_data)
+        importer = self._create_importer_for(**form_data)
         tasks = importer.tasks()
         msg = ''
         validator = TaskImportValidator(project)

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -177,7 +177,7 @@ class Importer(object):
         """Create tasks from a remote source using an importer object and
         avoiding the creation of repeated tasks"""
         n = 0
-        importer = self._create_importer_for(**form_data, project=project)
+        importer = self._create_importer_for(project=project, **form_data)
         tasks = importer.tasks()
         msg = ''
         validator = TaskImportValidator()

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -243,12 +243,6 @@ class Importer(object):
 
         return ImportReport(message=msg, metadata=metadata, total=n)
 
-    def import_if_not_more_than(self, max_task_count, task_repo, project, **form_data):
-        importer = self._create_importer_for(**form_data)
-        if importer.count_tasks() > max_task_count:
-            return
-        return self.create_tasks(task_repo, project, importer, **form_data)
-
     def count_tasks_to_import(self, **form_data):
         """Count tasks to import."""
         return self._create_importer_for(**form_data).count_tasks()

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -135,32 +135,29 @@ class Importer(object):
     def validate_headers(self, project, **form_data):
         validate_against_task_presenter = form_data.pop('validate_tp', True)
         importer = self._create_importer_for(**form_data)
-        import_headers = importer.headers()
+        import_fields = importer.fields()
 
         def get_error_message():
-            if not import_headers:
+            if not validate_against_task_presenter:
                 return
-
+            if not import_fields:
+                return
             if not project:
                 return gettext('Could not load project info')
 
-            if validate_against_task_presenter:
-                task_presenter_fields = project.get_presenter_headers()
-                # Check that all task fields used in task presenter are also in import.
-                # We need to map the import header name to actual field names for this to work right.
-                # We have suffixes on headers that aren't part of field name, such as:
-                # _priv, _json, _null, _number, _bool.
-                fields_not_in_import = [field for field in task_presenter_fields
-                                    if field not in import_headers]
+            task_presenter_fields = project.get_presenter_headers()
+            # Check that all task fields used in task presenter are also in import.
+            fields_not_in_import = [field for field in task_presenter_fields
+                                if field not in import_fields]
 
-                if not fields_not_in_import:
-                    return
+            if not fields_not_in_import:
+                return
 
-                msg = 'Task presenter code uses fields not in import. '
-                additional_msg = 'Fields missing from import: {}'.format((', '.join(fields_not_in_import))[:80])
-                current_app.logger.error(msg)
-                current_app.logger.error(', '.join(fields_not_in_import))
-                return msg + additional_msg
+            msg = 'Task presenter code uses fields not in import. '
+            additional_msg = 'Fields missing from import: {}'.format((', '.join(fields_not_in_import))[:80])
+            current_app.logger.error(msg)
+            current_app.logger.error(', '.join(fields_not_in_import))
+            return msg + additional_msg
 
         msg = get_error_message()
 

--- a/pybossa/importers/s3.py
+++ b/pybossa/importers/s3.py
@@ -26,6 +26,7 @@ class BulkTaskS3Import(BulkTaskImport):
     importer_id = "s3"
 
     def __init__(self, files, bucket, last_import_meta=None):
+        BulkTaskImport.__init__(self)
         self.files = files
         self.bucket = bucket
         self.last_import_meta = last_import_meta

--- a/pybossa/importers/twitterapi.py
+++ b/pybossa/importers/twitterapi.py
@@ -27,6 +27,7 @@ class BulkTaskTwitterImport(BulkTaskImport):
 
     def __init__(self, consumer_key, consumer_secret, source,
                  max_tweets=None, last_import_meta=None, user_credentials=None):
+        BulkTaskImport.__init__(self)
         if user_credentials:
             self.client = UserCredentialsClient(consumer_key, consumer_secret,
                                                 user_credentials)

--- a/pybossa/importers/youtubeapi.py
+++ b/pybossa/importers/youtubeapi.py
@@ -28,6 +28,7 @@ class BulkTaskYoutubeImport(BulkTaskImport):
     importer_id = "youtube"
 
     def __init__(self, playlist_url, youtube_api_server_key):
+        BulkTaskImport.__init__(self)
         self.playlist_url = playlist_url
         self.youtube_api_server_key = youtube_api_server_key
 

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -741,9 +741,10 @@ def import_tasks(project_id, current_user_fullname, from_auto=False, **form_data
 
     try:
         with current_app.test_request_context():
-            report = importer.validate_headers(project, **form_data)
-            if not report:
-                report = importer.create_tasks(task_repo, project, **form_data)
+            report = (
+                importer.validate_headers(project, **form_data)
+                or importer.create_tasks(task_repo, project, **form_data)
+            )
     except JobTimeoutException:
         from pybossa.core import db
         db.session.rollback()

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -741,10 +741,7 @@ def import_tasks(project_id, current_user_fullname, from_auto=False, **form_data
 
     try:
         with current_app.test_request_context():
-            report = (
-                importer.validate_headers(project, **form_data)
-                or importer.create_tasks(task_repo, project, **form_data)
-            )
+            report = importer.create_tasks(task_repo, project, **form_data)
     except JobTimeoutException:
         from pybossa.core import db
         db.session.rollback()

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -741,7 +741,9 @@ def import_tasks(project_id, current_user_fullname, from_auto=False, **form_data
 
     try:
         with current_app.test_request_context():
-            report = importer.create_tasks(task_repo, project, **form_data)
+            report = importer.validate_headers(project, **form_data)
+            if not report:
+                report = importer.create_tasks(task_repo, project, **form_data)
     except JobTimeoutException:
         from pybossa.core import db
         db.session.rollback()

--- a/pybossa/model/project.py
+++ b/pybossa/model/project.py
@@ -148,12 +148,12 @@ class Project(db.Model, DomainObject):
         else:
             return default
 
-    def get_presenter_headers(self):
-        headers = set()
+    def get_presenter_field_set(self):
+        fields = set()
         task_presenter = self.info.get('task_presenter')
 
         if not task_presenter:
-            return headers
+            return fields
 
         search_backward_stop = 0
         for match in re.finditer('\.info\.([a-zA-Z0-9_]+)', task_presenter):
@@ -174,12 +174,12 @@ class Project(db.Model, DomainObject):
                     '*/', search_backward_stop, match.start())
                 if comment_end < 0:
                     continue
-            header = match.group(1)
-            if not header.endswith('__upload_url'):
-                headers.add(header)
+            field = match.group(1)
+            if not field.endswith('__upload_url'):
+                fields.add(header)
             search_backward_stop = match.end()
 
-        return headers
+        return fields
 
     def set_project_users(self, users):
         from pybossa.cache.users import get_users_access_levels

--- a/pybossa/model/project.py
+++ b/pybossa/model/project.py
@@ -176,7 +176,7 @@ class Project(db.Model, DomainObject):
                     continue
             field = match.group(1)
             if not field.endswith('__upload_url'):
-                fields.add(header)
+                fields.add(field)
             search_backward_stop = match.end()
 
         return fields

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1072,12 +1072,13 @@ def import_task(short_name):
 def _import_tasks(project, **form_data):
     number_of_tasks = importer.count_tasks_to_import(**form_data)
     if number_of_tasks <= MAX_NUM_SYNCHRONOUS_TASKS_IMPORT:
-        report = importer.validate_headers(project, **form_data)
-        if not report:
-            report = importer.create_tasks(task_repo, project, **form_data)
-            flash(report.message)
-            if report.total > 0:
-                cached_projects.delete_browse_tasks(project.id)
+        report = (
+            importer.validate_headers(project, **form_data)
+            or importer.create_tasks(task_repo, project, **form_data)
+        )
+        flash(report.message)
+        if report.total > 0:
+            cached_projects.delete_browse_tasks(project.id)
     else:
         importer_queue.enqueue(import_tasks, project.id, current_user.fullname, **form_data)
         flash(gettext("You're trying to import a large amount of tasks, so please be patient.\

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1070,12 +1070,13 @@ def import_task(short_name):
 
 
 def _import_tasks(project, **form_data):
-    number_of_tasks = importer.count_tasks_to_import(**form_data)
-    if number_of_tasks <= MAX_NUM_SYNCHRONOUS_TASKS_IMPORT:
-        report = (
-            importer.validate_headers(project, **form_data)
-            or importer.create_tasks(task_repo, project, **form_data)
-        )
+    report = importer.import_if_not_more_than(
+        MAX_NUM_SYNCHRONOUS_TASKS_IMPORT,
+        task_repo,
+        project,
+        **form_data
+    )
+    if report:
         flash(report.message)
         if report.total > 0:
             cached_projects.delete_browse_tasks(project.id)

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1071,7 +1071,10 @@ def import_task(short_name):
 
 def _import_tasks(project, **form_data):
     number_of_tasks = importer.count_tasks_to_import(**form_data)
-    if number_of_tasks <= MAX_NUM_SYNCHRONOUS_TASKS_IMPORT:
+    header_report = importer.validate_headers(project, **form_data):
+    if header_report:
+        flash(header_report.message)
+    elif number_of_tasks <= MAX_NUM_SYNCHRONOUS_TASKS_IMPORT:
         report = importer.create_tasks(task_repo, project, **form_data)
         flash(report.message)
         if report.total > 0:

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1071,14 +1071,13 @@ def import_task(short_name):
 
 def _import_tasks(project, **form_data):
     number_of_tasks = importer.count_tasks_to_import(**form_data)
-    header_report = importer.validate_headers(project, **form_data)
-    if header_report:
-        flash(header_report.message)
-    elif number_of_tasks <= MAX_NUM_SYNCHRONOUS_TASKS_IMPORT:
-        report = importer.create_tasks(task_repo, project, **form_data)
-        flash(report.message)
-        if report.total > 0:
-            cached_projects.delete_browse_tasks(project.id)
+    if number_of_tasks <= MAX_NUM_SYNCHRONOUS_TASKS_IMPORT:
+        report = importer.validate_headers(project, **form_data)
+        if not report:
+            report = importer.create_tasks(task_repo, project, **form_data)
+            flash(report.message)
+            if report.total > 0:
+                cached_projects.delete_browse_tasks(project.id)
     else:
         importer_queue.enqueue(import_tasks, project.id, current_user.fullname, **form_data)
         flash(gettext("You're trying to import a large amount of tasks, so please be patient.\

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1085,8 +1085,9 @@ def _import_tasks(project, **form_data):
         importer_queue.enqueue(import_tasks, project.id, current_user.fullname, **form_data)
         flash(gettext("You're trying to import a large amount of tasks, so please be patient.\
             You will receive an email when the tasks are ready."))
-    return redirect_content_type(url_for('.tasks',
-                                         short_name=project.short_name))
+    return redirect_content_type(url_for('.import_task',
+                                         short_name=project.short_name,
+                                         type=form_data['type']))
 
 
 @blueprint.route('/<short_name>/tasks/autoimporter', methods=['GET', 'POST'])

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1071,7 +1071,7 @@ def import_task(short_name):
 
 def _import_tasks(project, **form_data):
     number_of_tasks = importer.count_tasks_to_import(**form_data)
-    header_report = importer.validate_headers(project, **form_data):
+    header_report = importer.validate_headers(project, **form_data)
     if header_report:
         flash(header_report.message)
     elif number_of_tasks <= MAX_NUM_SYNCHRONOUS_TASKS_IMPORT:

--- a/test/test_auditlog.py
+++ b/test/test_auditlog.py
@@ -674,7 +674,7 @@ class TestAuditlogWEB(web.Helper):
 
         attribute = 'autoimporter'
 
-        new_value = '{"csv_filename": null, "type": "localCSV"}'
+        new_value = '{"csv_filename": null, "type": "localCSV", "validate_tp": true}'
 
         old_value = 'Nothing'
 

--- a/test/test_autoimporter.py
+++ b/test/test_autoimporter.py
@@ -439,7 +439,7 @@ class TestAutoimporterBehaviour(web.Helper):
         self.register()
         self.signin()
         owner = user_repo.get(1)
-        autoimporter = {'type': 'localCSV', 'csv_filename': None}
+        autoimporter = {'type': 'localCSV', 'csv_filename': None, 'validate_tp': True}
         project = ProjectFactory.create(owner=owner)
         url = "/project/%s/tasks/autoimporter" % project.short_name
         data = {'form_name': 'localCSV', 'csv_filename': 'http://fakeurl.com'}

--- a/test/test_importers/__init__.py
+++ b/test/test_importers/__init__.py
@@ -16,8 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 from mock import patch, Mock
-from nose.tools import assert_raises
-from pybossa.importers import Importer, BulkImportException
+from pybossa.importers import Importer
 from default import Test, with_context
 from factories import ProjectFactory, TaskFactory
 from pybossa.repositories import TaskRepository

--- a/test/test_importers/__init__.py
+++ b/test/test_importers/__init__.py
@@ -237,7 +237,7 @@ class TestImporterPublicMethods(Test):
             'gold_answers': {u'ans2': u'e', u'ans': u'b'}, 'calibration': 1, 'exported': True, 'state': u'enrich'}]
 
         importer_factory.return_value = mock_importer
-        project = ProjectFactory.create()
+        project = ProjectFactory.create(info={'enrichments':[{'out_field_name':'enriched'}]})
         form_data = dict(type='localCSV', csv_filename='fakefile.csv', validate_tp=False)
 
         with patch.dict(

--- a/test/test_importers/__init__.py
+++ b/test/test_importers/__init__.py
@@ -353,7 +353,7 @@ class TestImporterPublicMethods(Test):
             'gold_answers': {u'ans2': u'e', u'ans': u'b'}, 'calibration': 1, 'exported': True, 'state': u'enriched'}]
 
         importer_factory.return_value = mock_importer
-        project = ProjectFactory.create(info={'enrichments':[{'out_field_name':'enriched'}]})
+        project = ProjectFactory.create()
         form_data = dict(type='localCSV', csv_filename='fakefile.csv')
 
         with patch.dict(

--- a/test/test_importers/__init__.py
+++ b/test/test_importers/__init__.py
@@ -37,7 +37,7 @@ class TestImporterPublicMethods(Test):
                                             'n_answers': 20}]
         importer_factory.return_value = mock_importer
         project = ProjectFactory.create()
-        form_data = dict(type='csv', csv_url='http://fakecsv.com')
+        form_data = dict(type='csv', csv_url='http://fakecsv.com', validate_tp=False)
         self.importer.create_tasks(task_repo, project, **form_data)
         task = task_repo.get_task(1)
 
@@ -55,7 +55,7 @@ class TestImporterPublicMethods(Test):
                                             {'info': {'question': 'question2'}}]
         importer_factory.return_value = mock_importer
         project = ProjectFactory.create()
-        form_data = dict(type='gdocs', googledocs_url='http://ggl.com')
+        form_data = dict(type='gdocs', googledocs_url='http://ggl.com', validate_tp=False)
         result = self.importer.create_tasks(task_repo, project, **form_data)
         tasks = task_repo.filter_tasks_by(project_id=project.id)
 
@@ -70,7 +70,7 @@ class TestImporterPublicMethods(Test):
         importer_factory.return_value = mock_importer
         project = ProjectFactory.create()
         TaskFactory.create(project=project, info={'question': 'question'})
-        form_data = dict(type='flickr', album_id='1234')
+        form_data = dict(type='flickr', album_id='1234', validate_tp=False)
 
         result = self.importer.create_tasks(task_repo, project, **form_data)
         tasks = task_repo.filter_tasks_by(project_id=project.id)
@@ -87,7 +87,7 @@ class TestImporterPublicMethods(Test):
         mock_importer.import_metadata.return_value = metadata
         importer_factory.return_value = mock_importer
         project = ProjectFactory.create()
-        form_data = dict(type='flickr', album_id='1234')
+        form_data = dict(type='flickr', album_id='1234', validate_tp=False)
 
         result = self.importer.create_tasks(task_repo, project, **form_data)
 
@@ -103,7 +103,7 @@ class TestImporterPublicMethods(Test):
         mock_importer.import_metadata.return_value = metadata
         importer_factory.return_value = mock_importer
         project = ProjectFactory.create()
-        form_data = dict(type='flickr', album_id='1234')
+        form_data = dict(type='flickr', album_id='1234', validate_tp=False)
         with patch.object(task_repo, 'save', side_effect=Exception('a')):
             result = self.importer.create_tasks(task_repo, project, **form_data)
         assert '1 task import failed due to a' in result.message, result.message
@@ -180,7 +180,7 @@ class TestImporterPublicMethods(Test):
 
         importer_factory.return_value = mock_importer
         project = ProjectFactory.create()
-        form_data = dict(type='localCSV', csv_filename='fakefile.csv')
+        form_data = dict(type='localCSV', csv_filename='fakefile.csv', validate_tp=False)
 
         with patch.dict(
             self.flask_app.config,
@@ -238,7 +238,7 @@ class TestImporterPublicMethods(Test):
 
         importer_factory.return_value = mock_importer
         project = ProjectFactory.create()
-        form_data = dict(type='localCSV', csv_filename='fakefile.csv')
+        form_data = dict(type='localCSV', csv_filename='fakefile.csv', validate_tp=False)
 
         with patch.dict(
             self.flask_app.config,
@@ -296,7 +296,7 @@ class TestImporterPublicMethods(Test):
 
         importer_factory.return_value = mock_importer
         project = ProjectFactory.create()
-        form_data = dict(type='localCSV', csv_filename='fakefile.csv')
+        form_data = dict(type='localCSV', csv_filename='fakefile.csv', validate_tp=False)
 
         with patch.dict(
             self.flask_app.config,
@@ -325,7 +325,7 @@ class TestImporterPublicMethods(Test):
 
         importer_factory.return_value = mock_importer
         project = ProjectFactory.create(info={'enrichments':[{'out_field_name':'enriched'}]})
-        form_data = dict(type='localCSV', csv_filename='fakefile.csv')
+        form_data = dict(type='localCSV', csv_filename='fakefile.csv', validate_tp=False)
 
         with patch.dict(
             self.flask_app.config,
@@ -354,7 +354,7 @@ class TestImporterPublicMethods(Test):
 
         importer_factory.return_value = mock_importer
         project = ProjectFactory.create()
-        form_data = dict(type='localCSV', csv_filename='fakefile.csv')
+        form_data = dict(type='localCSV', csv_filename='fakefile.csv', validate_tp=False)
 
         with patch.dict(
             self.flask_app.config,
@@ -408,7 +408,6 @@ class TestImporterPublicMethods(Test):
     ):
         mock_importer = Mock()
         mock_importer.fields.return_value = {'Foo', 'Bar2', 'Bar'}
-        importer_factory.return_value = mock_importer
         project = ProjectFactory.create(info={
             'enrichments':[{'out_field_name':'enriched'}],
             'task_presenter':'task.info.enriched task.info.Bar'
@@ -423,7 +422,7 @@ class TestImporterPublicMethods(Test):
                 'ENABLE_ENCRYPTION': True
             }
         ):
-            import_report = self.importer.validate_headers(project, **form_data)
+            import_report = self.importer._validate_headers(mock_importer, project, **form_data)
             assert import_report is None
 
     @with_context

--- a/test/test_importers/__init__.py
+++ b/test/test_importers/__init__.py
@@ -251,7 +251,7 @@ class TestImporterPublicMethods(Test):
             result = self.importer.create_tasks(task_repo, project, **form_data)
             importer_factory.assert_called_with(**form_data)
             upload_from_string.assert_called()
-            assert result.message == '1 new task was imported successfully ', result
+            assert result.message == '1 new task was imported successfully ', result.message
 
             # validate task created has private fields url, gold_answers url
             # calibration and exported flag set
@@ -379,7 +379,6 @@ class TestImporterPublicMethods(Test):
     ):
         mock_importer = Mock()
         mock_importer.fields.return_value = {'Foo', 'Bar2', 'Bar'}
-        importer_factory.return_value = mock_importer
         project = ProjectFactory.create(info={
             'task_presenter':'task.info.bar'
         })
@@ -393,7 +392,7 @@ class TestImporterPublicMethods(Test):
                 'ENABLE_ENCRYPTION': True
             }
         ):
-            import_report = self.importer.validate_headers(project, **form_data)
+            import_report = self.importer._validate_headers(mock_importer, project, **form_data)
             print import_report.message
             assert import_report.message
 
@@ -436,7 +435,6 @@ class TestImporterPublicMethods(Test):
     ):
         mock_importer = Mock()
         mock_importer.fields.return_value = {'Foo', 'Bar2', 'Bar'}
-        importer_factory.return_value = mock_importer
         project = ProjectFactory.create(info={
             'task_presenter':'task.info.enriched task.info.bar'
         })
@@ -450,5 +448,5 @@ class TestImporterPublicMethods(Test):
                 'ENABLE_ENCRYPTION': True
             }
         ):
-            import_report = self.importer.validate_headers(project, **form_data)
+            import_report = self.importer._validate_headers(mock_importer, project, **form_data)
             assert import_report is None

--- a/test/test_importers/test_csv_importer.py
+++ b/test/test_importers/test_csv_importer.py
@@ -58,11 +58,9 @@ class TestBulkTaskCSVImport(object):
         request.return_value = forbidden_request
         msg = "Oops! It looks like you don't have permission to access that file"
 
-        assert_raises(BulkImportException, self.importer.count_tasks)
-        try:
+        with assert_raises(BulkImportException) as context:
             self.importer.count_tasks()
-        except BulkImportException as e:
-            assert e[0] == msg, e
+        assert context.exception[0] == msg, context.exception
 
     def test_count_tasks_raises_exception_if_not_CSV_file(self, request):
         html_request = FakeResponse(text='Not a CSV', status_code=200,
@@ -71,11 +69,9 @@ class TestBulkTaskCSVImport(object):
         request.return_value = html_request
         msg = "Oops! That file doesn't look like the right file."
 
-        assert_raises(BulkImportException, self.importer.count_tasks)
-        try:
+        with assert_raises(BulkImportException) as context:
             self.importer.count_tasks()
-        except BulkImportException as e:
-            assert e[0] == msg, e
+        assert context.exception[0] == msg, context.exception
 
     def test_count_tasks_raises_exception_if_dup_header(self, request):
         csv_file = FakeResponse(text='Foo,Bar,Foo\n1,2,3', status_code=200,
@@ -95,11 +91,9 @@ class TestBulkTaskCSVImport(object):
         request.return_value = forbidden_request
         msg = "Oops! It looks like you don't have permission to access that file"
 
-        assert_raises(BulkImportException, self.importer.tasks)
-        try:
+        with assert_raises(BulkImportException) as context:
             self.importer.tasks()
-        except BulkImportException as e:
-            assert e[0] == msg, e
+        assert context.exception[0] == msg, context.exception
 
     def test_tasks_raises_exception_if_not_CSV_file(self, request):
         html_request = FakeResponse(text='Not a CSV', status_code=200,
@@ -108,11 +102,9 @@ class TestBulkTaskCSVImport(object):
         request.return_value = html_request
         msg = "Oops! That file doesn't look like the right file."
 
-        assert_raises(BulkImportException, self.importer.tasks)
-        try:
+        with assert_raises(BulkImportException) as context:
             self.importer.tasks()
-        except BulkImportException as e:
-            assert e[0] == msg, e
+        assert context.exception[0] == msg, context.exception
 
     def test_tasks_raises_exception_if_dup_header(self, request):
         csv_file = FakeResponse(text='Foo,Bar,Foo\n1,2,3', status_code=200,

--- a/test/test_importers/test_csv_importer.py
+++ b/test/test_importers/test_csv_importer.py
@@ -113,14 +113,9 @@ class TestBulkTaskCSVImport(object):
         request.return_value = csv_file
         msg = "The file you uploaded has two headers with the same name."
 
-        raised = False
-        try:
+        with assert_raises(BulkImportException) as context:
             self.importer.tasks().next()
-        except BulkImportException as e:
-            assert e[0] == msg, e
-            raised = True
-        finally:
-            assert raised, "Exception not raised"
+        assert context.exception[0] == msg, context.exception
 
     def test_tasks_raises_exception_if_empty_headers(self, request):
         csv_file = FakeResponse(text='Foo,Bar,\n1,2,3', status_code=200,
@@ -129,14 +124,9 @@ class TestBulkTaskCSVImport(object):
         request.return_value = csv_file
         msg = "The file you uploaded has an empty header on column 3."
 
-        raised = False
-        try:
+        with assert_raises(BulkImportException) as context:
             self.importer.tasks().next()
-        except BulkImportException as e:
-            raised = True
-            assert e[0] == msg, e
-        finally:
-            assert raised, "Exception not raised"
+        assert context.exception[0] == msg, context.exception
 
     @with_context
     def test_tasks_raises_exception_if_headers_row_mismatch(self, request):
@@ -146,14 +136,9 @@ class TestBulkTaskCSVImport(object):
         request.return_value = csv_file
         msg = "The file you uploaded has an extra value on row 2."
 
-        raised = False
-        try:
+        with assert_raises(BulkImportException) as context:
             self.importer.tasks().next()
-        except BulkImportException as e:
-            raised = True
-            assert e[0] == msg, e
-        finally:
-            assert raised, "Exception not raised"
+        assert context.exception[0] == msg, context.exception
 
     @with_context
     def test_tasks_return_tasks_with_only_info_fields(self, request):

--- a/test/test_importers/test_csv_importer.py
+++ b/test/test_importers/test_csv_importer.py
@@ -172,8 +172,7 @@ class TestBulkTaskCSVImport(object):
                                 encoding='utf-8')
         request.return_value = csv_file
 
-        tasks = self.importer.tasks()
-        task = tasks.next()
+        task = self.importer.tasks()[0]
 
         assert task == {"info": {u'Bar': u'2', u'Foo': u'1', u'Baz': u'3'}}, task
 
@@ -185,8 +184,7 @@ class TestBulkTaskCSVImport(object):
                                 encoding='utf-8')
         request.return_value = csv_file
 
-        tasks = self.importer.tasks()
-        task = tasks.next()
+        task = self.importer.tasks()[0]
 
         assert task == {'info': {u'Foo': u'1', u'Bar': u'2'},
                         u'priority_0': u'3'}, task
@@ -198,7 +196,6 @@ class TestBulkTaskCSVImport(object):
                                 encoding='ISO-8859-1')
         request.return_value = csv_file
 
-        tasks = self.importer.tasks()
-        task = tasks.next()
+        task = self.importer.tasks()[0]
 
         assert csv_file.encoding == 'utf-8'

--- a/test/test_importers/test_csv_importer.py
+++ b/test/test_importers/test_csv_importer.py
@@ -172,7 +172,8 @@ class TestBulkTaskCSVImport(object):
                                 encoding='utf-8')
         request.return_value = csv_file
 
-        task = self.importer.tasks()[0]
+        tasks = self.importer.tasks()
+        task = tasks.next()
 
         assert task == {"info": {u'Bar': u'2', u'Foo': u'1', u'Baz': u'3'}}, task
 
@@ -184,7 +185,8 @@ class TestBulkTaskCSVImport(object):
                                 encoding='utf-8')
         request.return_value = csv_file
 
-        task = self.importer.tasks()[0]
+        tasks = self.importer.tasks()
+        task = tasks.next()
 
         assert task == {'info': {u'Foo': u'1', u'Bar': u'2'},
                         u'priority_0': u'3'}, task
@@ -196,6 +198,7 @@ class TestBulkTaskCSVImport(object):
                                 encoding='ISO-8859-1')
         request.return_value = csv_file
 
-        task = self.importer.tasks()[0]
+        tasks = self.importer.tasks()
+        task = tasks.next()
 
         assert csv_file.encoding == 'utf-8'

--- a/test/test_importers/test_csv_importer.py
+++ b/test/test_importers/test_csv_importer.py
@@ -84,11 +84,9 @@ class TestBulkTaskCSVImport(object):
         request.return_value = csv_file
         msg = "The file you uploaded has two headers with the same name."
 
-        assert_raises(BulkImportException, self.importer.count_tasks)
-        try:
+        with assert_raises(BulkImportException) as context:
             self.importer.count_tasks()
-        except BulkImportException as e:
-            assert e[0] == msg, e
+        assert context.exception[0] == msg, context.exception
 
     def test_tasks_raises_exception_if_file_forbidden(self, request):
         forbidden_request = FakeResponse(text='Forbidden', status_code=403,

--- a/test/test_importers/test_googledocs_importer.py
+++ b/test/test_importers/test_googledocs_importer.py
@@ -132,7 +132,7 @@ class TestBulkTaskGDImport(object):
 
         raised = False
         try:
-            self.importer.tasks().next()
+            self.importer.tasks()
         except BulkImportException as e:
             assert e[0] == msg, e
             raised = True
@@ -146,8 +146,7 @@ class TestBulkTaskGDImport(object):
                                 encoding='utf-8')
         request.return_value = csv_file
 
-        tasks = self.importer.tasks()
-        task = tasks.next()
+        task = self.importer.tasks()[0]
 
         assert task == {"info": {u'Bar': u'2', u'Foo': u'1', u'Baz': u'3'}}, task
 
@@ -159,8 +158,7 @@ class TestBulkTaskGDImport(object):
                                 encoding='utf-8')
         request.return_value = csv_file
 
-        tasks = self.importer.tasks()
-        task = tasks.next()
+        task = self.importer.tasks()[0]
 
         assert task == {'info': {u'Foo': u'1', u'Bar': u'2'},
                         u'priority_0': u'3'}, task
@@ -172,7 +170,6 @@ class TestBulkTaskGDImport(object):
                                 encoding='ISO-8859-1')
         request.return_value = csv_file
 
-        tasks = self.importer.tasks()
-        task = tasks.next()
+        task = self.importer.tasks()[0]
 
         assert csv_file.encoding == 'utf-8'

--- a/test/test_importers/test_googledocs_importer.py
+++ b/test/test_importers/test_googledocs_importer.py
@@ -132,7 +132,7 @@ class TestBulkTaskGDImport(object):
 
         raised = False
         try:
-            self.importer.tasks()
+            self.importer.tasks().next()
         except BulkImportException as e:
             assert e[0] == msg, e
             raised = True
@@ -146,7 +146,8 @@ class TestBulkTaskGDImport(object):
                                 encoding='utf-8')
         request.return_value = csv_file
 
-        task = self.importer.tasks()[0]
+        tasks = self.importer.tasks()
+        task = tasks.next()
 
         assert task == {"info": {u'Bar': u'2', u'Foo': u'1', u'Baz': u'3'}}, task
 
@@ -158,7 +159,8 @@ class TestBulkTaskGDImport(object):
                                 encoding='utf-8')
         request.return_value = csv_file
 
-        task = self.importer.tasks()[0]
+        tasks = self.importer.tasks()
+        task = tasks.next()
 
         assert task == {'info': {u'Foo': u'1', u'Bar': u'2'},
                         u'priority_0': u'3'}, task
@@ -170,6 +172,7 @@ class TestBulkTaskGDImport(object):
                                 encoding='ISO-8859-1')
         request.return_value = csv_file
 
-        task = self.importer.tasks()[0]
+        tasks = self.importer.tasks()
+        task = tasks.next()
 
         assert csv_file.encoding == 'utf-8'

--- a/test/test_importers/test_importer_validation.py
+++ b/test/test_importers/test_importer_validation.py
@@ -36,7 +36,7 @@ class TestImporterValidation(Test):
                                             {'info': {'question': 'question2'}}]
         importer_factory.return_value = mock_importer
         project = ProjectFactory.create()
-        form_data = dict(type='gdocs', googledocs_url='http://ggl.com')
+        form_data = dict(type='gdocs', googledocs_url='http://ggl.com', validate_tp=False)
         result = self.importer.create_tasks(task_repo, project, **form_data)
         tasks = task_repo.filter_tasks_by(project_id=project.id)
 
@@ -51,7 +51,7 @@ class TestImporterValidation(Test):
                                             {'info': {'question': 'question2'}}]
         importer_factory.return_value = mock_importer
         project = ProjectFactory.create()
-        form_data = dict(type='gdocs', googledocs_url='http://ggl.com')
+        form_data = dict(type='gdocs', googledocs_url='http://ggl.com', validate_tp=False)
         result = self.importer.create_tasks(task_repo, project, **form_data)
         tasks = task_repo.filter_tasks_by(project_id=project.id)
 
@@ -66,7 +66,7 @@ class TestImporterValidation(Test):
                                             {'info': {'question': 'question2'}}]
         importer_factory.return_value = mock_importer
         project = ProjectFactory.create()
-        form_data = dict(type='gdocs', googledocs_url='http://ggl.com')
+        form_data = dict(type='gdocs', googledocs_url='http://ggl.com', validate_tp=False)
         with patch.dict(self.flask_app.config, { 'ALLOWED_S3_BUCKETS': ['valid'] }):
             result = self.importer.create_tasks(task_repo, project, **form_data)
             tasks = task_repo.filter_tasks_by(project_id=project.id)

--- a/test/test_importers/test_localCSV_importer.py
+++ b/test/test_importers/test_localCSV_importer.py
@@ -195,3 +195,25 @@ class TestBulkTaskLocalCSVImport(Test):
                     with patch('pybossa.importers.csv.io.open', mock_open(read_data= data), create=True):
                         with assert_raises(BulkImportException):
                             [t1] = self.importer.tasks()
+
+    @with_context
+    @patch('pybossa.importers.csv.get_import_csv_file')
+    def test_correct_field_names(self, s3_get):
+        fields = {
+            'ans1_json': 'ans1',
+            'ans2_number': 'ans2',
+            'ans3_bool': 'ans3',
+            'ans4_null': 'ans4',
+            'ans9_priv_json': "ans9",
+            'ans10_priv_number': 'ans10',
+            'ans11_priv_bool': 'ans11',
+            'ans12_priv_null': 'ans12'
+        }
+        form_data = {'type': 'localCSV', 'csv_filename': 'fakefile.csv'}
+
+        for is_private in [True, False]:
+            with patch('pybossa.importers.csv.data_access_levels', is_private):
+                for header, field_name in fields.iteritems():
+                    with patch('pybossa.importers.csv.io.open', mock_open(read_data= unicode(header)), create=True):
+                        field_names = BulkTaskLocalCSVImport(**form_data).fields()
+                        assert field_names == {field_name}, {'field_names': field_names, 'field_name': field_name}

--- a/test/test_importers/test_localCSV_importer.py
+++ b/test/test_importers/test_localCSV_importer.py
@@ -207,7 +207,23 @@ class TestBulkTaskLocalCSVImport(Test):
             'ans9_priv_json': "ans9",
             'ans10_priv_number': 'ans10',
             'ans11_priv_bool': 'ans11',
-            'ans12_priv_null': 'ans12'
+            'ans12_priv_null': 'ans12',
+            'data_access': 'data_access',
+            'state': None,
+            'quorum': None,
+            'calibration': None,
+            'priority_0': None,
+            'n_answers': None,
+            'user_pref': None,
+            'expiration': None,
+            'ans13_priv_gold_json': None,
+            'ans14_priv_gold_number': None,
+            'ans15_priv_gold_bool': None,
+            'ans16_priv_gold_null': None,
+            'ans5_gold_json': None,
+            'ans6_gold_number': None,
+            'ans7_gold_bool': None,
+            'ans8_gold_null': None
         }
         form_data = {'type': 'localCSV', 'csv_filename': 'fakefile.csv'}
 
@@ -216,4 +232,4 @@ class TestBulkTaskLocalCSVImport(Test):
                 for header, field_name in fields.iteritems():
                     with patch('pybossa.importers.csv.io.open', mock_open(read_data= unicode(header)), create=True):
                         field_names = BulkTaskLocalCSVImport(**form_data).fields()
-                        assert field_names == {field_name}, {'field_names': field_names, 'field_name': field_name}
+                        assert field_names == ({field_name} if field_name else set()), {'field_names': field_names, 'field_name': field_name}

--- a/test/test_importers/test_localCSV_importer.py
+++ b/test/test_importers/test_localCSV_importer.py
@@ -42,10 +42,6 @@ class TestBulkTaskLocalCSVImport(Test):
         # confirm object is not of type other than BulkTaskLocalCSVImport
         assert isinstance(self.importer, BulkTaskGDImport) is False
 
-    def test_importer_form_data_csv_filename(self):
-        csv_file = self.importer._get_data()
-        assert csv_file == 'fakefile.csv'
-
     @with_context
     @patch('pybossa.importers.csv.get_import_csv_file')
     def test_count_tasks_returns_0_row(self, s3_get):
@@ -151,10 +147,12 @@ class TestBulkTaskLocalCSVImport(Test):
             rows.append(','.join(map(lambda x: x[i], fields.itervalues())))
         data = unicode('\n'.join(rows))
         print data
+        form_data = {'type': 'localCSV', 'csv_filename': 'fakefile.csv'}
+
         with patch('pybossa.importers.csv.io.open', mock_open(read_data= data), create=True):
             for is_private in [True, False]:
                 with patch('pybossa.importers.csv.data_access_levels', is_private):
-                    [t1, t2, t3, t4, t5, t6] = self.importer.tasks()
+                    [t1, t2, t3, t4, t5, t6] = BulkTaskLocalCSVImport(**form_data).tasks()
                     if is_private:
                         assert_equal(t1['private_fields'], expected_t1_priv_field), t1
                         assert_equal(t2['private_fields'], expected_t2_priv_field), t2

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -6246,7 +6246,7 @@ class TestWeb(web.Helper):
                                        'formtype': 'csv', 'form_name': 'csv'},
                             follow_redirects=True)
 
-        assert "1 new task was imported successfully" in res.data
+        assert "1 new task was imported successfully" in res.data, res.data
         redirect.assert_called_with('/project/%s/tasks/' % project.short_name)
 
     @with_context

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -6269,7 +6269,7 @@ class TestWeb(web.Helper):
 
     @with_context
     @patch('pybossa.view.projects.importer_queue', autospec=True)
-    @patch('pybossa.importers.csv.BulkTaskCSVImportBase.count_tasks')
+    @patch('pybossa.view.projects.importer.count_tasks_to_import')
     def test_import_tasks_as_background_job(self, count_tasks, queue):
         """Test WEB importing a big amount of tasks is done in the background"""
         from pybossa.view.projects import MAX_NUM_SYNCHRONOUS_TASKS_IMPORT

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -6265,11 +6265,11 @@ class TestWeb(web.Helper):
                                        'formtype': 'csv', 'form_name': 'csv'},
                             follow_redirects=True)
 
-        assert "1 new task was imported successfully" in res.data
+        assert "1 new task was imported successfully" in res.data, res.data
 
     @with_context
     @patch('pybossa.view.projects.importer_queue', autospec=True)
-    @patch('pybossa.view.projects.importer.count_tasks_to_import')
+    @patch('pybossa.importers.csv.BulkTaskCSVImportBase.count_tasks')
     def test_import_tasks_as_background_job(self, count_tasks, queue):
         """Test WEB importing a big amount of tasks is done in the background"""
         from pybossa.view.projects import MAX_NUM_SYNCHRONOUS_TASKS_IMPORT


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-2140*

**Describe your changes**
We want to be able to turn off the validation of CSV import headers against the fields used in task presenter. We also need to do more validation of headers related to enrichment. For tasks to be enriched, the enrichment output field can not have a value in the import. Also validating the task state to be either "enrich" or "ongoing" or missing. Also, for empty cells we are ignoring the value instead of importing an empty string.

We are also fixing the bug where validation of import fields against the fields used in the task presenter code was not comparing the actual field name when the header field contained a suffix. We now strip off the suffix before comparing.

**Testing performed**
Manual and unit tests

