### PR TITLE
add opt-in annotation store option. refactor annotation configs under…

### DIFF
--- a/pybossa/data_access.py
+++ b/pybossa/data_access.py
@@ -18,6 +18,7 @@
 """Module with data access helper functions."""
 from functools import wraps
 from werkzeug.exceptions import BadRequest
+import six
 
 import app_settings
 
@@ -157,6 +158,24 @@ def ensure_data_access_assignment_from_form(obj, form):
         raise BadRequest('Invalid access levels')
     obj['data_access'] = access_levels
 
+
+@when_data_access()
+def ensure_annotation_config_from_form(obj, form):
+    obj['annotation_config'] = obj.get('annotation_config', {})
+    if form.amp_store.data:
+        obj['annotation_config']['amp_store'] = form.amp_store.data
+        obj['annotation_config']['amp_pvf'] = form.amp_pvf.data or ''
+    else:
+        obj['annotation_config'].pop('amp_store', None)
+        obj['annotation_config'].pop('amp_pvf', None)
+    if not obj['annotation_config']:
+        obj.pop('annotation_config', None)
+
+
+@when_data_access()
+def ensure_amp_config_applied_to_project(project, amp_config):
+    project.amp_store = amp_config.get('amp_store', False)
+    project.amp_pvf = amp_config.get('amp_pvf', '')
 
 @when_data_access()
 def ensure_task_assignment_to_project(task, project):

--- a/pybossa/forms/dynamic_forms.py
+++ b/pybossa/forms/dynamic_forms.py
@@ -1,6 +1,6 @@
 from flask_babel import lazy_gettext
 from flask_wtf import FlaskForm as Form
-from wtforms import SelectField, validators
+from wtforms import SelectField, validators, TextField, BooleanField
 from pybossa.forms.fields.select_two import Select2Field
 
 import wtforms
@@ -36,6 +36,12 @@ def dynamic_project_form(class_type, form_data, data_access_levels, products=Non
             choices=data_access_levels['valid_access_levels'],
             default=[])
         ProjectFormExtraInputs.data_access = data_access
+        ProjectFormExtraInputs.amp_store = BooleanField(
+            lazy_gettext('Opt in to store annotations on Annotation Management Platform'))
+        ProjectFormExtraInputs.amp_pvf = TextField(
+            lazy_gettext('Annotation Store PVF'),
+            [validators.Regexp('^([A-Z]{3,4}\s\d+)?$')]) #[validators.Regexp('^$|[A-Z]\s\d')])
+
 
     return ProjectFormExtraInputs(form_data, obj=obj)
 

--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -128,6 +128,8 @@ class ProjectUpdateForm(ProjectForm):
     webhook = TextField(lazy_gettext('Webhook'),
                         [pb_validator.Webhook()])
     sync_enabled = BooleanField(lazy_gettext('Enable Project Syncing'))
+
+class AnnotationForm(Form):
     dataset_description = TextAreaField(lazy_gettext('Dataset Description'))
     provider = SelectField(
         lazy_gettext('Annotation Provider'),
@@ -135,7 +137,6 @@ class ProjectUpdateForm(ProjectForm):
         coerce=lambda x: None if x == "None" else x
     )
     restrictions_and_permissioning = TextAreaField(lazy_gettext('Restrictions & Permissioning'))
-    store_pvf = TextField(lazy_gettext('Annotation Store PVF'))
     sampling_method = TextField(lazy_gettext('Sampling Method'))
     sampling_script = TextField(lazy_gettext('Sampling Script Link'))
     label_aggregation_strategy = TextField(lazy_gettext('Label Aggregation Strategy'))

--- a/pybossa/forms/projects_view_forms.py
+++ b/pybossa/forms/projects_view_forms.py
@@ -33,4 +33,5 @@ from forms import (
     GenericBulkTaskImportForm,
     AvatarUploadForm,
     TransferOwnershipForm,
-    DataAccessForm)
+    DataAccessForm,
+    AnnotationForm)

--- a/test/test_view/test_annotations.py
+++ b/test/test_view/test_annotations.py
@@ -1,0 +1,43 @@
+import json
+
+from default import db, with_context
+from factories import ProjectFactory
+from helper import web
+from pybossa.repositories import ProjectRepository
+
+project_repo = ProjectRepository(db)
+
+
+class TestAnnotations(web.Helper):
+
+    @with_context
+    def test_post_annotation_config(self):
+        annotation_config = {
+            "sampling_script": "ddddd",
+            "task_output_schema": "gggggg",
+            "sampling_method": "cccccc",
+            "dataset_description": "aaaaa",
+            "provider": "CONTINGENT_WORKER",
+            "task_input_schema": "fffff",
+            "label_aggregation_strategy": "eeeee",
+            "restrictions_and_permissioning": "bbbbb"
+        }
+
+        project = ProjectFactory.create(published=True)
+        url = '/project/%s/annotconfig?api_key=%s' % (project.short_name, project.owner.api_key)
+        res = self.app_get_json(url)
+        data = json.loads(res.data)
+        assert res.status_code == 200        
+        assert all([ak in data['form'].keys() for ak in annotation_config.keys()]), res
+        
+        csrf = data['csrf']
+        res = self.app.post(url, content_type='application/json',
+                            data=json.dumps(annotation_config),
+                            headers={'X-CSRFToken': csrf})
+        data = json.loads(res.data)
+        assert res.status_code == 200 and \
+            data['flash'] == 'Project annotation configurations updated', res
+
+        project = project_repo.get(project.id)
+        updated_annotation_config = project.info['annotation_config']
+        assert annotation_config == updated_annotation_config, 'Updated annotation configurations do not match'


### PR DESCRIPTION
**Describe your changes**
Add option for opt-in to store annotations on amp. Opt-in and pvf to be accessible and cleary visible, hence are part of project settings. Rest of annotation configs are optional and are refactored to be part of a new form that can be loaded from a new tile - annotation configs under proj settings

**Testing performed**
create/update form w/ and w/o annotation configs. test through project details and api that updated configs are available.