### PR TITLE
amp opt-in default checked

### DIFF
--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -32,7 +32,7 @@ from pybossa.cache.categories import get_all as get_categories
 from pybossa.util import is_reserved_name
 from pybossa.core import auditlog_repo, result_repo, http_signer
 from pybossa.auditlogger import AuditLogger
-from pybossa.data_access import ensure_user_assignment_to_project
+from pybossa.data_access import ensure_user_assignment_to_project, set_default_amp_store
 
 auditlogger = AuditLogger(auditlog_repo, caller='api')
 
@@ -51,6 +51,13 @@ class ProjectAPI(APIBase):
                          'published', 'secret_key'])
     private_keys = set(['secret_key'])
     restricted_keys = set()
+
+    def _preprocess_post_data(self, data):
+        # set amp_store default as true when not passed as input param
+        amp_config = data.get('info', {}).get('annotation_config', {}).get('amp_store')
+        if amp_config is None:
+            set_default_amp_store(data)
+
 
     def _create_instance_from_request(self, data):
         inst = super(ProjectAPI, self)._create_instance_from_request(data)

--- a/pybossa/data_access.py
+++ b/pybossa/data_access.py
@@ -149,6 +149,9 @@ def ensure_data_access_assignment_to_form(obj, form):
     if not valid_access_levels(access_levels):
         raise BadRequest('Invalid access levels')
     form.data_access.data = access_levels
+    if 'checked' in form.amp_store.render_kw:
+        amp_store_status = obj.get('annotation_config', {}).get('amp_store', False)
+        form.amp_store.render_kw['checked'] = amp_store_status
 
 
 @when_data_access()
@@ -236,3 +239,9 @@ def subadmins_are_privileged(user):
 def valid_user_type_based_data_access(user_type, access_levels):
     valid_data_access = data_access_levels['valid_access_levels_for_user_types'].get(user_type)
     return all(l in valid_data_access for l in access_levels), valid_data_access
+
+@when_data_access()
+def set_default_amp_store(project):
+    annotation_config = project['info'].get('annotation_config', {})
+    annotation_config['amp_store'] = True
+    project['info']['annotation_config'] = annotation_config

--- a/pybossa/forms/dynamic_forms.py
+++ b/pybossa/forms/dynamic_forms.py
@@ -37,7 +37,8 @@ def dynamic_project_form(class_type, form_data, data_access_levels, products=Non
             default=[])
         ProjectFormExtraInputs.data_access = data_access
         ProjectFormExtraInputs.amp_store = BooleanField(
-            lazy_gettext('Opt in to store annotations on Annotation Management Platform'))
+            lazy_gettext('Opt in to store annotations on Annotation Management Platform'),
+            render_kw={'checked': True})
         ProjectFormExtraInputs.amp_pvf = TextField(
             lazy_gettext('Annotation Store PVF'),
             [validators.Regexp('^([A-Z]{3,4}\s\d+)?$')]) #[validators.Regexp('^$|[A-Z]\s\d')])

--- a/test/test_view/test_project_settings.py
+++ b/test/test_view/test_project_settings.py
@@ -1,0 +1,38 @@
+# -*- coding: utf8 -*-
+import json
+from mock import patch
+
+from default import db, with_context
+from factories import ProjectFactory
+from helper import web
+from pybossa import data_access
+
+
+class TestProjectSettings(web.Helper):
+
+    @staticmethod
+    def patched_levels(**kwargs):
+        patch_data_access_levels = dict(
+            valid_access_levels=[("L1", "L1"), ("L2", "L2"),("L3", "L3"), ("L4", "L4")],
+            valid_user_levels_for_project_task_level=dict(
+                L1=[], L2=["L1"], L3=["L1", "L2"], L4=["L1", "L2", "L3"]),
+            valid_task_levels_for_user_level=dict(
+                L1=["L2", "L3", "L4"], L2=["L3", "L4"], L3=["L4"], L4=[]),
+            valid_project_levels_for_task_level=dict(
+                L1=["L1"], L2=["L1", "L2"], L3=["L1", "L2", "L3"], L4=["L1", "L2", "L3", "L4"]),
+            valid_task_levels_for_project_level=dict(
+                L1=["L1", "L2", "L3", "L4"], L2=["L2", "L3", "L4"], L3=["L3", "L4"], L4=["L4"])
+        )
+        patch_data_access_levels.update(kwargs)
+        return patch_data_access_levels
+    
+    @with_context
+    def test_project_update_amp_store(self):
+        with patch.dict(data_access.data_access_levels, self.patched_levels()):        
+            project = ProjectFactory.create(
+                published=True, info={'data_access': ['L1'],
+                'annotation_config': {'amp_store': True}})
+            url = '/project/%s/update?api_key=%s' % (project.short_name, project.owner.api_key)
+            res = self.app_get_json(url)
+            data = json.loads(res.data)
+            assert data['form']['amp_store'], 'opt-in amp store should be checked'


### PR DESCRIPTION
**Describe your changes**
Opt in amp storage by default from ui and through api 

**Testing performed**
create new project, opt-in amp store option checked. updated existing project and confirmed from ui and api, opt-in config set as expected. created project via api, opt-in was set.

