### PR TITLE
2441 - fix display numbers of tasks/taskruns on info page

### DIFF
--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -314,7 +314,7 @@ def user_progress(project_id=None, short_name=None):
             query_attrs = dict(project_id=project.id)
             query_attrs['user_id'] = current_user.id
             taskrun_count = task_repo.count_task_runs_with(**query_attrs)
-            num_available_tasks = n_available_tasks(project.id, current_user.id)
+            num_available_tasks = n_available_tasks(project, current_user.id)
             num_available_tasks_for_user = n_available_tasks_for_user(project, current_user.id)
             response = dict(
                 done=taskrun_count,

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -314,7 +314,7 @@ def user_progress(project_id=None, short_name=None):
             query_attrs = dict(project_id=project.id)
             query_attrs['user_id'] = current_user.id
             taskrun_count = task_repo.count_task_runs_with(**query_attrs)
-            num_available_tasks = n_available_tasks(project, current_user.id)
+            num_available_tasks = n_available_tasks(project.id, include_gold_task=True)
             num_available_tasks_for_user = n_available_tasks_for_user(project, current_user.id)
             response = dict(
                 done=taskrun_count,

--- a/pybossa/cache/helpers.py
+++ b/pybossa/cache/helpers.py
@@ -30,23 +30,20 @@ from pybossa.data_access import get_data_access_db_clause_for_task_assignment
 session = db.slave_session
 
 
-def n_available_tasks(project, user_id=None):
+def n_available_tasks(project_id, include_gold_task=False):
     """Return the number of tasks for a given project a user can contribute to.
-
-    based on the completion of the project tasks, and previous task_runs
-    submitted by the user.
+    based on the completion of the project tasks,
     """
-    if user_id and (user_id == project.owner_id or user_id in project.owners_ids):
+    if include_gold_task:
+        query = text('''SELECT COUNT(*) AS n_tasks FROM task
+                        WHERE project_id=:project_id AND state !='completed'
+                        AND state !='enrich';''')
+    else:
         query = text('''SELECT COUNT(*) AS n_tasks FROM task
                         WHERE project_id=:project_id AND state !='completed'
                         AND state !='enrich'
                         AND calibration = 0;''')
-        result = session.execute(query, dict(project_id=project.id,
-                                             user_id=user_id))
-    else:
-        current_app.logger.exception('invalid user_id')
-        return 0
-
+    result = session.execute(query, dict(project_id=project_id))
     n_tasks = 0
     for row in result:
         n_tasks = row.n_tasks

--- a/pybossa/cache/helpers.py
+++ b/pybossa/cache/helpers.py
@@ -30,22 +30,23 @@ from pybossa.data_access import get_data_access_db_clause_for_task_assignment
 session = db.slave_session
 
 
-def n_available_tasks(project_id, user_id=None):
+def n_available_tasks(project, user_id=None):
     """Return the number of tasks for a given project a user can contribute to.
 
     based on the completion of the project tasks, and previous task_runs
     submitted by the user.
     """
-    if user_id:
+    if user_id and (user_id == project.owner_id or user_id in project.owners_ids):
         query = text('''SELECT COUNT(*) AS n_tasks FROM task
                         WHERE project_id=:project_id AND state !='completed'
                         AND state !='enrich'
                         AND calibration = 0;''')
-        result = session.execute(query, dict(project_id=project_id,
+        result = session.execute(query, dict(project_id=project.id,
                                              user_id=user_id))
     else:
         current_app.logger.exception('invalid user_id')
         return 0
+
     n_tasks = 0
     for row in result:
         n_tasks = row.n_tasks

--- a/pybossa/cache/helpers.py
+++ b/pybossa/cache/helpers.py
@@ -30,13 +30,13 @@ from pybossa.data_access import get_data_access_db_clause_for_task_assignment
 session = db.slave_session
 
 
-def n_available_tasks(project_id, user_id=None, user_ip=None):
+def n_available_tasks(project_id, user_id=None):
     """Return the number of tasks for a given project a user can contribute to.
 
     based on the completion of the project tasks, and previous task_runs
     submitted by the user.
     """
-    if user_id and not user_ip:
+    if user_id:
         query = text('''SELECT COUNT(*) AS n_tasks FROM task
                         WHERE project_id=:project_id AND state !='completed'
                         AND state !='enrich'
@@ -44,15 +44,8 @@ def n_available_tasks(project_id, user_id=None, user_ip=None):
         result = session.execute(query, dict(project_id=project_id,
                                              user_id=user_id))
     else:
-        if not user_ip:
-            user_ip = '127.0.0.1'
-        query = text('''SELECT COUNT(*) AS n_tasks FROM task
-                        WHERE project_id=:project_id AND state !='completed'
-                        AND state !='enrich'
-                        AND calibration = 0;''')
-
-        result = session.execute(query, dict(project_id=project_id,
-                                             user_ip=user_ip))
+        current_app.logger.exception('invalid user_id')
+        return 0
     n_tasks = 0
     for row in result:
         n_tasks = row.n_tasks

--- a/pybossa/cache/helpers.py
+++ b/pybossa/cache/helpers.py
@@ -104,8 +104,6 @@ def check_contributing_state(project, user_id=None, user_ip=None,
     Depending on whether the project is completed or not and the user can
     contribute more to it or not.
     """
-    # print("*******")
-    # print(n_available_tasks_for_user(project, user_id=user_id))
     project_id = project['id'] if type(project) == dict else project.id
     published = project['published'] if type(project) == dict else project.published
     states = ('completed', 'draft', 'publish', 'can_contribute', 'cannot_contribute')
@@ -119,7 +117,6 @@ def check_contributing_state(project, user_id=None, user_ip=None,
             return states[1]
         return states[2]
     if n_available_tasks_for_user(project, user_id=user_id) > 0:
-    # if n_available_tasks(project_id, user_id=user_id, user_ip=user_ip) > 0
         return states[3]
     return states[4]
 

--- a/pybossa/cache/projects.py
+++ b/pybossa/cache/projects.py
@@ -256,7 +256,9 @@ def n_remaining_task_runs(project_id):
                              FROM task_run
                              GROUP BY task_id) AS t
                   ON task.id = t.task_id
-                  WHERE task.project_id=:project_id AND task.state = 'ongoing';''')
+                  WHERE task.project_id=:project_id
+                  AND calibration = 0
+                  AND task.state = 'ongoing';''')
     return session.execute(sql, dict(project_id=project_id)).scalar() or 0
 
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -853,7 +853,7 @@ def update(short_name):
 def details(short_name):
 
     project, owner, ps = project_by_shortname(short_name)
-    num_available_tasks = n_available_tasks(project.id, current_user.id)
+    num_available_tasks = n_available_tasks(project, current_user.id)
     num_completed_tasks_by_user = n_completed_tasks_by_user(project.id, current_user.id)
     oldest_task = oldest_available_task(project.id, current_user.id)
     num_available_tasks_for_user = n_available_tasks_for_user(project, current_user.id)

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -853,7 +853,7 @@ def update(short_name):
 def details(short_name):
 
     project, owner, ps = project_by_shortname(short_name)
-    num_available_tasks = n_available_tasks(project, current_user.id)
+    num_available_tasks = n_available_tasks(project.id)
     num_completed_tasks_by_user = n_completed_tasks_by_user(project.id, current_user.id)
     oldest_task = oldest_available_task(project.id, current_user.id)
     num_available_tasks_for_user = n_available_tasks_for_user(project, current_user.id)

--- a/test/test_cache/test_cache_helpers.py
+++ b/test/test_cache/test_cache_helpers.py
@@ -26,8 +26,8 @@ from pybossa.cache.project_stats import update_stats
 class TestHelpersCache(Test):
 
     @with_context
-    def test_n_available_tasks_no_tasks_authenticated_user(self):
-        """Test n_available_tasks returns 0 for authenticated user if the project
+    def test_n_available_tasks_no_tasksuser(self):
+        """Test n_available_tasks returns 0 for user if the project
         has no tasks"""
         project = ProjectFactory.create()
 
@@ -35,19 +35,8 @@ class TestHelpersCache(Test):
 
         assert n_available_tasks == 0, n_available_tasks
 
-
     @with_context
-    def test_n_available_tasks_no_tasks_anonymous_user(self):
-        """Test n_available_tasks returns 0 for anonymous user if the project
-        has no tasks"""
-        project = ProjectFactory.create()
-
-        n_available_tasks = helpers.n_available_tasks(project.id, user_ip='127.0.0.1')
-
-        assert n_available_tasks == 0, n_available_tasks
-
-    @with_context
-    def test_n_available_tasks_no_taskruns_authenticated_user(self):
+    def test_n_available_tasks_no_taskruns_user(self):
         """Test n_available_tasks returns 1 for authenticated user
         if there are no taskruns"""
         project = ProjectFactory.create()
@@ -58,19 +47,8 @@ class TestHelpersCache(Test):
         assert n_available_tasks == 1, n_available_tasks
 
     @with_context
-    def test_n_available_tasks_no_taskruns_anonymous_user(self):
-        """Test n_available_tasks returns 1 for anonymous user
-        if there are no taskruns"""
-        project = ProjectFactory.create()
-        task = TaskFactory.create(project=project)
-
-        n_available_tasks = helpers.n_available_tasks(project.id, user_ip='127.0.0.1')
-
-        assert n_available_tasks == 1, n_available_tasks
-
-    @with_context
-    def test_n_available_tasks_all_tasks_completed_authenticated_user(self):
-        """Test n_available_tasks returns 0 for authenticated user if all the
+    def test_n_available_tasks_all_tasks_completed_user(self):
+        """Test n_available_tasks returns 0 for user if all the
         tasks are completed"""
         project = ProjectFactory.create()
         task = TaskFactory.create(project=project, state='completed')
@@ -80,19 +58,8 @@ class TestHelpersCache(Test):
         assert n_available_tasks == 0, n_available_tasks
 
     @with_context
-    def test_n_available_tasks_all_tasks_completed_anonymous_user(self):
-        """Test n_available_tasks returns 0 for anonymous user if all the
-        tasks are completed"""
-        project = ProjectFactory.create()
-        task = TaskFactory.create(project=project, state='completed')
-
-        n_available_tasks = helpers.n_available_tasks(project.id, user_ip='127.0.0.1')
-
-        assert n_available_tasks == 0, n_available_tasks
-
-    @with_context
-    def test_n_available_tasks_all_tasks_answered_by_authenticated_user(self):
-        """Test n_available_tasks returns 0 for authenticated user if he has
+    def test_n_available_tasks_all_tasks_answered_by_user(self):
+        """Test n_available_tasks returns 0 for user if he has
         submitted taskruns for all the tasks"""
         project = ProjectFactory.create()
         task = TaskFactory.create(project=project, n_answers=2)
@@ -102,24 +69,11 @@ class TestHelpersCache(Test):
         n_available_tasks = helpers.n_available_tasks(project.id, user_id=user.id)
 
         assert task.state != 'completed', task.state
-        assert n_available_tasks == 0, n_available_tasks
+        assert n_available_tasks == 1, n_available_tasks
 
     @with_context
-    def test_n_available_tasks_all_tasks_answered_by_anonymous_user(self):
-        """Test n_available_tasks returns 0 for anonymous user if he has
-        submitted taskruns for all the tasks"""
-        project = ProjectFactory.create()
-        task = TaskFactory.create(project=project, n_answers=2)
-        taskrun = AnonymousTaskRunFactory.create(task=task)
-
-        n_available_tasks = helpers.n_available_tasks(project.id, user_ip=taskrun.user_ip)
-
-        assert task.state != 'completed', task.state
-        assert n_available_tasks == 0, n_available_tasks
-
-    @with_context
-    def test_n_available_tasks_some_tasks_answered_by_authenticated_user(self):
-        """Test n_available_tasks returns 1 for authenticated user if he has
+    def test_n_available_tasks_some_tasks_answered_by_user(self):
+        """Test n_available_tasks returns 1 for user if he has
         submitted taskruns for one of the tasks but there is still another task"""
         project = ProjectFactory.create()
         answered_task = TaskFactory.create(project=project)
@@ -128,20 +82,7 @@ class TestHelpersCache(Test):
         taskrun = TaskRunFactory.create(task=answered_task, user=user)
 
         n_available_tasks = helpers.n_available_tasks(project.id, user_id=user.id)
-        assert n_available_tasks == 1, n_available_tasks
-
-    @with_context
-    def test_n_available_tasks_some_tasks_answered_by_anonymous_user(self):
-        """Test n_available_tasks returns 1 for anonymous user if he has
-        submitted taskruns for one of the tasks but there is still another task"""
-        project = ProjectFactory.create()
-        answered_task = TaskFactory.create(project=project)
-        available_task = TaskFactory.create(project=project)
-        taskrun = AnonymousTaskRunFactory.create(task=answered_task)
-
-        n_available_tasks = helpers.n_available_tasks(project.id, user_ip=taskrun.user_ip)
-
-        assert n_available_tasks == 1, n_available_tasks
+        assert n_available_tasks == 2, n_available_tasks
 
     @with_context
     def test_n_available_tasks_some_task_answered_by_another_user(self):
@@ -153,6 +94,76 @@ class TestHelpersCache(Test):
         taskrun = TaskRunFactory.create(task=task)
 
         n_available_tasks = helpers.n_available_tasks(project.id, user_id=user.id)
+        assert n_available_tasks == 1, n_available_tasks
+
+    @with_context
+    def test_n_available_tasks_for_user_no_tasks(self):
+        """Test n_available_tasks_for_user returns 0 if the project has no tasks"""
+        project = ProjectFactory.create()
+
+        n_available_tasks = helpers.n_available_tasks_for_user(project, user_id=1)
+
+        assert n_available_tasks == 0, n_available_tasks
+
+    @with_context
+    def test_n_available_tasks_for_user_no_taskruns_tasks(self):
+        """Test n_available_tasks_for_user returns 1 for user
+        if there are no taskruns"""
+        project = ProjectFactory.create()
+        task = TaskFactory.create(project=project)
+
+        n_available_tasks = helpers.n_available_tasks_for_user(project, user_id=1)
+
+        assert n_available_tasks == 1, n_available_tasks
+
+    @with_context
+    def test_n_available_tasks_for_user_completed_tasks(self):
+        """Test n_available_tasks_for_user returns 0 for user if all the
+        tasks are completed"""
+        project = ProjectFactory.create()
+        task = TaskFactory.create(project=project, state='completed')
+
+        n_available_tasks = helpers.n_available_tasks_for_user(project, user_id=1)
+
+        assert n_available_tasks == 0, n_available_tasks
+
+    @with_context
+    def test_n_available_tasks_for_user_answered_by_you_tasks(self):
+        """Test n_available_tasks_for_user returns 0 for user if he has
+        submitted taskruns for all the tasks"""
+        project = ProjectFactory.create()
+        task = TaskFactory.create(project=project, n_answers=2)
+        user = UserFactory.create()
+        taskrun = TaskRunFactory.create(task=task, user=user)
+
+        n_available_tasks = helpers.n_available_tasks_for_user(project, user_id=user.id)
+
+        assert task.state != 'completed', task.state
+        assert n_available_tasks == 0, n_available_tasks
+
+    @with_context
+    def test_n_available_tasks_for_user_some_tasks_answered_by_user(self):
+        """Test n_available_tasks_for_user returns 1 for user if he has
+        submitted taskruns for one of the tasks but there is still another task"""
+        project = ProjectFactory.create()
+        answered_task = TaskFactory.create(project=project)
+        available_task = TaskFactory.create(project=project)
+        user = UserFactory.create()
+        taskrun = TaskRunFactory.create(task=answered_task, user=user)
+
+        n_available_tasks = helpers.n_available_tasks_for_user(project, user_id=user.id)
+        assert n_available_tasks == 1, n_available_tasks
+
+    @with_context
+    def test_n_available_tasks_some_task_answered_by_another_user(self):
+        """Test n_available_tasks_for_user returns 1 for a user if another
+        user has submitted taskruns for the task but he hasn't"""
+        project = ProjectFactory.create()
+        task = TaskFactory.create(project=project)
+        user = UserFactory.create()
+        taskrun = TaskRunFactory.create(task=task)
+
+        n_available_tasks = helpers.n_available_tasks_for_user(project, user_id=user.id)
         assert n_available_tasks == 1, n_available_tasks
 
     @with_context

--- a/test/test_cache/test_cache_helpers.py
+++ b/test/test_cache/test_cache_helpers.py
@@ -26,34 +26,12 @@ from pybossa.cache.project_stats import update_stats
 class TestHelpersCache(Test):
 
     @with_context
-    def test_n_available_tasks_no_user(self):
-        """Test n_available_tasks returns 0 for user if the project
-        has no tasks"""
-        project = ProjectFactory.create()
-        task = TaskFactory.create(project=project, n_answers=2)
-
-        n_available_tasks = helpers.n_available_tasks(project)
-
-        assert n_available_tasks == 0, n_available_tasks
-
-    @with_context
-    def test_n_available_tasks_non_admin_user(self):
-        """Test n_available_tasks returns 0 for user if the project
-        has no tasks"""
-        project = ProjectFactory.create()
-        task = TaskFactory.create(project=project, n_answers=2)
-
-        n_available_tasks = helpers.n_available_tasks(project, user_id=9999)
-
-        assert n_available_tasks == 0, n_available_tasks
-
-    @with_context
     def test_n_available_tasks_no_tasks(self):
         """Test n_available_tasks returns 0 for user if the project
         has no tasks"""
         project = ProjectFactory.create()
 
-        n_available_tasks = helpers.n_available_tasks(project, user_id=1)
+        n_available_tasks = helpers.n_available_tasks(project.id)
 
         assert n_available_tasks == 0, n_available_tasks
 
@@ -64,18 +42,18 @@ class TestHelpersCache(Test):
         project = ProjectFactory.create()
         task = TaskFactory.create(project=project)
 
-        n_available_tasks = helpers.n_available_tasks(project, user_id=1)
+        n_available_tasks = helpers.n_available_tasks(project.id)
 
         assert n_available_tasks == 1, n_available_tasks
 
     @with_context
-    def test_n_available_tasks_all_tasks_completed_user(self):
+    def test_n_available_tasks_all_tasks_completed(self):
         """Test n_available_tasks returns 0 for user if all the
         tasks are completed"""
         project = ProjectFactory.create()
         task = TaskFactory.create(project=project, state='completed')
 
-        n_available_tasks = helpers.n_available_tasks(project, user_id=1)
+        n_available_tasks = helpers.n_available_tasks(project.id)
 
         assert n_available_tasks == 0, n_available_tasks
 
@@ -84,38 +62,28 @@ class TestHelpersCache(Test):
         """Test n_available_tasks returns 0 for user if he has
         submitted taskruns for all the tasks"""
         user = UserFactory.create()
-        project = ProjectFactory.create(owner_id=user.id)
+        project = ProjectFactory.create()
         task = TaskFactory.create(project=project, n_answers=2)
         taskrun = TaskRunFactory.create(task=task, user=user)
 
-        n_available_tasks = helpers.n_available_tasks(project, user_id=user.id)
+        n_available_tasks = helpers.n_available_tasks(project.id)
 
         assert task.state != 'completed', task.state
         assert n_available_tasks == 1, n_available_tasks
 
     @with_context
-    def test_n_available_tasks_some_tasks_answered_by_user(self):
-        """Test n_available_tasks returns 1 for user if he has
-        submitted taskruns for one of the tasks but there is still another task"""
-        user = UserFactory.create()
-        project = ProjectFactory.create(owner_id=user.id)
-        answered_task = TaskFactory.create(project=project)
-        available_task = TaskFactory.create(project=project)
-        taskrun = TaskRunFactory.create(task=answered_task, user=user)
-
-        n_available_tasks = helpers.n_available_tasks(project, user_id=user.id)
-        assert n_available_tasks == 2, n_available_tasks
-
-    @with_context
-    def test_n_available_tasks_some_task_answered_by_another_user(self):
-        """Test n_available_tasks returns 1 for a user if another
-        user has submitted taskruns for the task but he hasn't"""
+    def test_n_available_tasks_include_gold_task(self):
+        """Test n_available_tasks returns 0 for user if he has
+        submitted taskruns for all the tasks"""
         project = ProjectFactory.create()
-        task = TaskFactory.create(project=project)
-        taskrun = TaskRunFactory.create(task=task)
+        task = TaskFactory.create(project=project, calibration=1)
 
-        n_available_tasks = helpers.n_available_tasks(project, user_id=1)
-        assert n_available_tasks == 1, n_available_tasks
+        n_available_tasks_include_gold = helpers.n_available_tasks(project.id, include_gold_task=True)
+        n_available_tasks_exclude_gold = helpers.n_available_tasks(project.id)
+
+        assert task.state != 'completed', task.state
+        assert n_available_tasks_include_gold == 1, n_available_tasks_include_gold
+        assert n_available_tasks_exclude_gold == 0, n_available_tasks_exclude_gold
 
     @with_context
     def test_n_available_tasks_for_user_no_tasks(self):


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<2441>*
https://jira4.prod.bloomberg.com/browse/RDISCROWD-2441

**Describe your changes**
- exclude gold tasks when computing `total number of tasks remaining` and hide this field from non-admin users.
- fix display of `total number of task runs remaining` and `total number of tasks available for you`

**Testing performed**
Manually tested