### PR TITLE
RDISCROWD-893 Chat integration

### DIFF
--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -394,9 +394,9 @@ def chat_notify(short_name):
 
     try:
         data = request.json
-        subject = 'Chat session started for project ' + short_name + ' by ' + current_user.email_addr
+        subject = u'Chat session started for project {} by {}'.format(short_name, current_user.email_addr)
         success_body = (
-            'A user has started a chat session on a project that you an owner/co-owner for.\n\n'
+            u'A user has started a chat session on a project that you an owner/co-owner for.\n\n'
             '    Project Short Name: {short_name}\n'
             '    User requesting assistance: {user}\n'
             '    Message: {message}\n\n'

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -402,20 +402,19 @@ def chat_notify(short_name):
             '    User requesting assistance: {user}\n'
             '    Message: {message}\n\n'
             'Slack Url\n'
-            'https://gigwork-dev.slack.com\n'
+            '{url}\n'
             )
 
         body = success_body.format(
             short_name=project.short_name,
             user=current_user.email_addr,
-            message=data.get('message'))
+            message=data.get('message'),
+            url=current_app.config.get('CHAT_URL', None))
 
         # Get email addresses for all owners of the project.
-        recipients = []
-        for user in user_repo.get_users(project.owners_ids):
-            recipients.append(user.email_addr)
-        import pdb
-        pdb.set_trace()
+        recipients = [user.email_addr for user in user_repo.get_users(project.owners_ids)]
+
+        # Send email.
         email = dict(recipients=recipients,
                      subject=subject,
                      body=body)

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -58,6 +58,7 @@ from pybossa.api.performance_stats import PerformanceStatsAPI
 from user import UserAPI
 from token import TokenAPI
 from result import ResultAPI
+from rq import Queue
 from project_stats import ProjectStatsAPI
 from helpingmaterial import HelpingMaterialAPI
 from pybossa.core import project_repo, task_repo, user_repo
@@ -70,6 +71,7 @@ from pybossa.cache.helpers import (n_available_tasks, n_available_tasks_for_user
     n_unexpired_gold_tasks)
 from pybossa.sched import (get_project_scheduler_and_timeout, get_scheduler_and_timeout,
                            has_lock, release_lock, Schedulers, get_locks)
+from pybossa.jobs import send_mail
 from pybossa.api.project_by_name import ProjectByNameAPI
 from pybossa.api.pwd_manager import get_pwd_manager
 from pybossa.data_access import data_access_levels
@@ -82,6 +84,7 @@ import requests
 blueprint = Blueprint('api', __name__)
 
 error = ErrorStatus()
+mail_queue = Queue('email', connection=sentinel.master)
 
 
 @blueprint.route('/')
@@ -374,6 +377,57 @@ def get_disqus_sso_api():
     except MethodNotAllowed as e:
         e.message = "Disqus keys are missing"
         return error.format_exception(e, target='DISQUS_SSO', action='GET')
+
+
+@jsonpify
+@csrf.exempt
+@blueprint.route('/project/<short_name>/chat', methods=['POST'])
+@ratelimit(limit=ratelimits.get('LIMIT'), per=ratelimits.get('PER'))
+def chat_notify(short_name):
+    """Email project owners upon a user initiating a chat session."""
+    if not current_user.is_authenticated:
+        return abort(401)
+
+    data = request.json
+    project = project_repo.get_by_shortname(short_name)
+    if not project:
+        return abort(400)
+
+    try:
+        data = request.json
+        subject = 'Chat session started for project ' + short_name + ' by ' + current_user.email_addr
+        success_body = (
+            'A user has started a chat session on a project that you an owner/co-owner for.\n\n'
+            '    Project Short Name: {short_name}\n'
+            '    User requesting assistance: {user}\n'
+            '    Message: {message}\n\n'
+            'Slack Url\n'
+            'https://gigwork-dev.slack.com\n'
+            )
+
+        body = success_body.format(
+            short_name=project.short_name,
+            user=current_user.email_addr,
+            message=data.get('message'))
+
+        # Get email addresses for all owners of the project.
+        recipients = []
+        for user in user_repo.get_users(project.owners_ids):
+            recipients.append(user.email_addr)
+        import pdb
+        pdb.set_trace()
+        email = dict(recipients=recipients,
+                     subject=subject,
+                     body=body)
+        mail_queue.enqueue(send_mail, email)
+
+        return Response(json.dumps({'success': True}), 200, mimetype="application/json")
+    except Exception:
+        current_app.logger.exception(
+            'An error occurred while sending chat notification for project {}'
+            .format(project.short_name))
+
+        return Response(json.dumps({'success': False}), 500, mimetype="application/json")
 
 
 @jsonpify

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -392,40 +392,33 @@ def chat_notify(short_name):
     if not project:
         return abort(400)
 
-    try:
-        data = request.json
-        subject = u'Chat session started for project {} by {}'.format(short_name, current_user.email_addr)
-        success_body = (
-            u'A user has started a chat session on a project that you an owner/co-owner for.\n\n'
-            '    Project Short Name: {short_name}\n'
-            '    User requesting assistance: {user}\n'
-            '    Message: {message}\n\n'
-            'Slack Url\n'
-            '{url}\n'
-            )
+    data = request.json
+    subject = u'Chat session started for project {} by {}'.format(short_name, current_user.email_addr)
+    success_body = (
+        u'A user has started a chat session on a project that you an owner/co-owner for.\n\n'
+        '    Project Short Name: {short_name}\n'
+        '    User requesting assistance: {user}\n'
+        '    Message: {message}\n\n'
+        'Slack Url\n'
+        '{url}\n'
+        )
 
-        body = success_body.format(
-            short_name=project.short_name,
-            user=current_user.email_addr,
-            message=data.get('message'),
-            url=current_app.config.get('CHAT_URL', None))
+    body = success_body.format(
+        short_name=project.short_name,
+        user=current_user.email_addr,
+        message=data.get('message'),
+        url=current_app.config.get('CHAT_URL', None))
 
-        # Get email addresses for all owners of the project.
-        recipients = [user.email_addr for user in user_repo.get_users(project.owners_ids)]
+    # Get email addresses for all owners of the project.
+    recipients = [user.email_addr for user in user_repo.get_users(project.owners_ids)]
 
-        # Send email.
-        email = dict(recipients=recipients,
-                     subject=subject,
-                     body=body)
-        mail_queue.enqueue(send_mail, email)
+    # Send email.
+    email = dict(recipients=recipients,
+                 subject=subject,
+                 body=body)
+    mail_queue.enqueue(send_mail, email)
 
-        return Response(json.dumps({'success': True}), 200, mimetype="application/json")
-    except Exception:
-        current_app.logger.exception(
-            'An error occurred while sending chat notification for project {}'
-            .format(project.short_name))
-
-        return Response(json.dumps({'success': False}), 500, mimetype="application/json")
+    return Response(json.dumps({'success': True}), 200, mimetype="application/json")
 
 
 @jsonpify

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -380,7 +380,6 @@ def get_disqus_sso_api():
 
 
 @jsonpify
-@csrf.exempt
 @blueprint.route('/project/<short_name>/chat', methods=['POST'])
 @ratelimit(limit=ratelimits.get('LIMIT'), per=ratelimits.get('PER'))
 def chat_notify(short_name):

--- a/settings_test.py.tmpl
+++ b/settings_test.py.tmpl
@@ -123,7 +123,8 @@ BSSO_SETTINGS = {
 AVATAR_ABSOLUTE = True
 SPAM = ['fake.com']
 PRODUCTS_SUBPRODUCTS = {'abc': ['def']}
-
+CHAT_ENABLE = ['all']
+CHAT_URL = 'https://gigwork-dev.slack.com'
 
 # Wizard Steps
 # 'step_name': {

--- a/test/default.py
+++ b/test/default.py
@@ -296,6 +296,12 @@ class Test(object):
         cookie = signer.dumps([get_user_id_or_ip(user)])
         self.app.set_cookie('/', '%spswd' % project.short_name, cookie)
 
+    def get_csrf(self, endpoint):
+        """Return csrf token for endpoint."""
+        res = self.app.get(endpoint,
+                           content_type='application/json')
+        csrf = json.loads(res.data).get('form').get('csrf')
+        return csrf
 
 def get_user_id_or_ip(user):
     if not user:

--- a/test/helper/web.py
+++ b/test/helper/web.py
@@ -285,12 +285,6 @@ class Helper(Test):
             return self.app.get("/project/%s/update" % short_name,
                                 follow_redirects=True)
 
-    def get_csrf(self, endpoint):
-        """Return csrf token for endpoint."""
-        res = self.app.get(endpoint,
-                           content_type='application/json')
-        csrf = json.loads(res.data).get('form').get('csrf')
-        return csrf
 
     def check_cookie(self, response, name):
         # Checks for existence of a cookie and verifies the value of it

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -1529,3 +1529,42 @@ class TestProjectAPI(TestAPI):
         res = self.app.get('/api/project?all=1&category_id=%s' % category.id, headers=headers)
         data = json.loads(res.data)
         assert len(data) == 4, data
+
+
+    @with_context
+    def test_chat_notify_success(self):
+        """Test API Project chat_notify_success."""
+        admin, owner, user = UserFactory.create_batch(3)
+        project = ProjectFactory.create(owner=owner)
+
+        # Obtain a CSRF key.
+        csrf = self.get_csrf('/account/signin')
+
+        # Make a request to the api.
+        url = '/api/project/' + project.short_name + '/chat?api_key=' + user.api_key
+        data = dict(message=u'hello')
+        res = self.app.post(url, headers={'X-CSRFToken': csrf}, content_type='application/json', data=json.dumps(data))
+
+        # Verify status code from response.
+        assert res.status_code == 200
+
+        # Verify contents of response contains: { "success": True }
+        data = json.loads(res.data)
+        assert data.get('success') is True
+
+
+    @with_context
+    def test_chat_notify_no_project(self):
+        """Test API Project chat_notify_no_project."""
+        admin, owner, user = UserFactory.create_batch(3)
+
+        # Obtain a CSRF key.
+        csrf = self.get_csrf('/account/signin')
+
+        # Make a request to the api.
+        url = '/api/project/invalid/chat?api_key=' + user.api_key
+        data = dict(message=u'hello')
+        res = self.app.post(url, headers={'X-CSRFToken': csrf}, content_type='application/json', data=json.dumps(data))
+
+        # Verify status code from response.
+        assert res.status_code == 400

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -1568,3 +1568,16 @@ class TestProjectAPI(TestAPI):
 
         # Verify status code from response.
         assert res.status_code == 400
+
+    @with_context
+    def test_chat_notify_no_auth(self):
+        """Test API Project chat_notify_no_auth."""
+        # Obtain a CSRF key.
+        csrf = self.get_csrf('/account/signin')
+
+        # Make a request to the api.
+        url = '/api/project/invalid/chat'
+        res = self.app.post(url, headers={'X-CSRFToken': csrf}, content_type='application/json', data=None)
+
+        # Verify status code from response.
+        assert res.status_code == 401


### PR DESCRIPTION
- Added chat integration with Slack and Chatlio.

## Enable Chatlio and Slack integration

For a specific list of projects by `short_name` or `all`.

```
CHAT_ENABLE = ['all']
CHAT_URL = 'https://gigwork-dev.slack.com'
```

```
CHAT_ENABLE = ['project1', 'project2']
CHAT_URL = 'https://gigwork-dev.slack.com'
```

Related https://github.com/bloomberg/pybossa-default-theme/pull/218