### PR TITLE
Replace short name that is between [' or"]

### DIFF
--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -449,13 +449,15 @@ def clone_project(project, form):
 
     proj_dict['owner_id'] = current_user.id
     proj_dict['owners_ids'] = [current_user.id]
-    proj_dict['short_name'] = form['short_name']
     proj_dict['name'] = form['name']
-    replacement = 'pybossa.run("%s")' % proj_dict['short_name']
-    pybossa_re = "(pybossa\.run\(\s*)(['\"]\S+['\"]\))"
-    proj_dict['info']['task_presenter'] = re.sub(pybossa_re,
-                                                 replacement,
-                                                 proj_dict['info'].get('task_presenter', ''))
+
+    task_presenter = proj_dict['info'].get('task_presenter', '')
+    for quoted_part in re.findall(r"[\'\"](.*?)[\"\']", task_presenter):
+        task_presenter = task_presenter.replace(quoted_part, quoted_part.replace(proj_dict['short_name'], form['short_name']))
+
+    proj_dict['short_name'] = form['short_name']
+    proj_dict['info']['task_presenter'] = task_presenter
+
     new_project = Project(**proj_dict)
     new_project.set_password(form['password'])
     project_repo.save(new_project)

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -452,11 +452,10 @@ def clone_project(project, form):
     proj_dict['name'] = form['name']
 
     task_presenter = proj_dict['info'].get('task_presenter', '')
-    for quoted_part in re.findall(r"[\'\"](.*?)[\"\']", task_presenter):
-        task_presenter = task_presenter.replace(quoted_part, quoted_part.replace(proj_dict['short_name'], form['short_name']))
+    regex = r"([\"\'\/])({})([\"\'\/])".format(proj_dict['short_name'])
+    proj_dict['info']['task_presenter'] = re.sub(regex, r"\1{}\3".format(form['short_name']), task_presenter)
 
     proj_dict['short_name'] = form['short_name']
-    proj_dict['info']['task_presenter'] = task_presenter
 
     new_project = Project(**proj_dict)
     new_project.set_password(form['password'])

--- a/test/test_view/test_project_clone.py
+++ b/test/test_view/test_project_clone.py
@@ -117,7 +117,7 @@ class TestProjectClone(Helper):
         admin = UserFactory.create(admin=False, subadmin=True)
         user2 = UserFactory.create()
         assign_users = [user2.id]
-        task_presenter = 'test; url="project/oldname/" pybossa.run("oldname"); test;'
+        task_presenter = 'test"; url="project/oldname/" pybossa.run("oldname"); test;'
         project = ProjectFactory.create(id=40,
                                         short_name='oldname',
                                         info={'task_presenter': task_presenter,
@@ -134,7 +134,7 @@ class TestProjectClone(Helper):
             res = self.app.post(url, data=data)
             new_project = project_repo.get(1)
             old_project = project_repo.get(40)
-            task_presenter_expected = 'test; url="project/newproj/" pybossa.run("newproj"); test;'
+            task_presenter_expected = 'test"; url="project/newproj/" pybossa.run("newproj"); test;'
             assert old_project.owner_id == user2.id, old_project.owner_id
             assert old_project.info['passwd_hash'] == 'testpass', old_project.info['passwd_hash']
             assert new_project.info['task_presenter'] == task_presenter_expected, new_project.info['task_presenter']

--- a/test/test_view/test_project_clone.py
+++ b/test/test_view/test_project_clone.py
@@ -80,7 +80,7 @@ class TestProjectClone(Helper):
         admin = UserFactory.create()
         user2 = UserFactory.create()
         assign_users = [admin.id, user2.id]
-        task_presenter = 'test; pybossa.run("oldname"); test;'
+        task_presenter = 'test; url="project/oldname/" pybossa.run("oldname"); test;'
         project = ProjectFactory.create(id=40,
                                         short_name='oldname',
                                         info={'task_presenter': task_presenter,
@@ -98,7 +98,7 @@ class TestProjectClone(Helper):
             res = self.app.post(url, data=data)
             new_project = project_repo.get(1)
             old_project = project_repo.get(40)
-            task_presenter_expected = 'test; pybossa.run("newproj"); test;'
+            task_presenter_expected = 'test; url="project/newproj/" pybossa.run("newproj"); test;'
             assert old_project.info['passwd_hash'] == 'testpass', old_project.info['passwd_hash']
             assert new_project.get_project_users() == assign_users, new_project.get_project_users()
             assert new_project.info['task_presenter'] == task_presenter_expected, new_project.info['task_presenter']
@@ -117,7 +117,7 @@ class TestProjectClone(Helper):
         admin = UserFactory.create(admin=False, subadmin=True)
         user2 = UserFactory.create()
         assign_users = [user2.id]
-        task_presenter = 'test; pybossa.run("oldname"); test;'
+        task_presenter = 'test; url="project/oldname/" pybossa.run("oldname"); test;'
         project = ProjectFactory.create(id=40,
                                         short_name='oldname',
                                         info={'task_presenter': task_presenter,
@@ -134,7 +134,7 @@ class TestProjectClone(Helper):
             res = self.app.post(url, data=data)
             new_project = project_repo.get(1)
             old_project = project_repo.get(40)
-            task_presenter_expected = 'test; pybossa.run("newproj"); test;'
+            task_presenter_expected = 'test; url="project/newproj/" pybossa.run("newproj"); test;'
             assert old_project.owner_id == user2.id, old_project.owner_id
             assert old_project.info['passwd_hash'] == 'testpass', old_project.info['passwd_hash']
             assert new_project.info['task_presenter'] == task_presenter_expected, new_project.info['task_presenter']


### PR DESCRIPTION
- Replace all instances of old_name in the task presenter HTML with new_name when cloning a project.