### PR TITLE
RDISCROWD-2636 Turning off project quiz mode should allow users normal tasks

### DIFF
--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -266,6 +266,9 @@ def _retrieve_new_task(project_id):
     # with the user. So we want to commit that snapshot if this is the first access.
     user_repo.update(user)
 
+    # Allow scheduling a gold-only task if quiz mode is enabled for the user and the project.
+    quiz_mode_enabled = user.get_quiz_in_progress(project) and project.info["quiz"]["enabled"]
+
     task = sched.new_task(project.id,
                           project.info.get('sched'),
                           user_id,
@@ -276,7 +279,7 @@ def _retrieve_new_task(project_id):
                           orderby=orderby,
                           desc=desc,
                           rand_within_priority=sched_rand_within_priority,
-                          gold_only=user.get_quiz_in_progress(project))
+                          gold_only=quiz_mode_enabled)
 
     handler = partial(pwd_manager.update_response, project=project,
                       user=user_id_or_ip)

--- a/settings_local.py.tmpl
+++ b/settings_local.py.tmpl
@@ -458,7 +458,7 @@ WIZARD_STEPS = OrderedDict([
         'visible_checks': {'and': ['project_exist'], 'or': []}
     }),
     ('task_imports', {
-        'title': 'Task Imports',
+        'title': 'Import Tasks',
         'icon': 'fa fa-file',
         'href': {'url_for': 'project.import_task',
                  'args': ['short_name']},
@@ -471,14 +471,14 @@ WIZARD_STEPS = OrderedDict([
         'icon': 'fa fa-pencil',
         'href': {'url_for': 'project.task_presenter_editor',
                  'args': ['short_name']},
-        'done_checks': {'and': ['task_presenter'], 'or': []},
-        'enable_checks': {'and': ['tasks_amount'], 'or': ['task_presenter', 'project_publish']},
+        'done_checks': {'and': ['task_presenter', 'task_guidelines'], 'or': []},
+        'enable_checks': {'and': ['tasks_amount'], 'or': ['task_presenter', 'task_guidelines', 'project_publish']},
         'visible_checks': {'always': True}
     }),
     ('task_settings', {
-        'title': 'Task Settings',
+        'title': 'Settings',
         'icon': 'fa fa-cogs',
-        'href': {'url_for': 'project.task_settings',
+        'href': {'url_for': 'project.summary',
                  'args': ['short_name']},
         'done_checks': {'and': ['task_presenter', 'tasks_amount'], 'or': ['project_publish']},
         'enable_checks': {'and': ['task_presenter', 'tasks_amount'], 'or': ['project_publish']},
@@ -488,7 +488,7 @@ WIZARD_STEPS = OrderedDict([
         'title': 'Publish',
         'icon': 'fa fa-check',
         'href': {'url_for': 'project.publish',
-                 'args': ['short_name', 'published']},
+                 'args': ['short_name']},
         'done_checks': {'always': False},
         'enable_checks': {'and': ['task_presenter', 'tasks_amount'], 'or': ['project_publish']},
         'visible_checks': {'and': ['not_project_publish'], 'or': ['not_project_exist']},
@@ -496,11 +496,10 @@ WIZARD_STEPS = OrderedDict([
     ('published', {
         'title': 'Published',
         'icon': 'fa fa-check',
-        'href': {'url_for': 'project.details',
+        'href': {'url_for': 'project.publish',
                  'args': ['short_name']},
         'done_checks': {'always': True},
         'enable_checks': {'always': True},
         'visible_checks': {'and': ['project_publish'], 'or': []},
     })]
 )
-

--- a/settings_test.py.tmpl
+++ b/settings_test.py.tmpl
@@ -2,6 +2,7 @@
 from collections import OrderedDict
 
 SERVER_NAME = 'localhost'
+SERVER_TYPE = 'Development QA'
 FORCE_HTTPS = False
 HOST = 'localhost'
 PORT = 5001

--- a/test/test_quiz_mode.py
+++ b/test/test_quiz_mode.py
@@ -67,6 +67,69 @@ class TestScheduler(QuizTest):
         task = json.loads(response.data)
         assert any(task['id'] == non_golden_task.id for non_golden_task in non_golden_tasks)
 
+    @with_context
+    def test_project_quiz_enabled_and_user_quiz_enabled_result_quiz_mode_enabled(self):
+        '''Test that the user can see quiz mode if the user is In Progress for quiz mode and quiz mode is enabled for the project'''
+        '''See also: pybossa/api/__init__.py line 270
+           quiz_mode_enabled = user.get_quiz_in_progress(project) and project.info["quiz"]["enabled"]'''
+        project, user = self.create_project_and_user()
+
+        # Enable quiz mode on the project.
+        quiz = project.get_quiz()
+        quiz["enabled"] = True
+        project.set_quiz(quiz)
+
+        project.info["quiz"]["enabled"] = True
+
+        # Enable quiz mode on the user.
+        user.set_quiz_status(project, 'in_progress')
+
+        # Checks.
+        is_in_progress = user.get_quiz_in_progress(project)
+        is_user_quiz_enabled = user.get_quiz_enabled(project)
+
+        assert is_in_progress == True
+        assert is_user_quiz_enabled == True
+
+        golden_tasks = TaskFactory.create_batch(10, project=project, n_answers=1, calibration=1)
+        non_golden_tasks = TaskFactory.create_batch(10, project=project, n_answers=1, calibration=0)
+        url = '/api/project/{}/newtask'.format(project.id)
+        response = self.app.get(url)
+        task = json.loads(response.data)
+
+        # Verify the user has received a golden task.
+        assert any(task['id'] == golden_task.id for golden_task in golden_tasks)
+
+    @with_context
+    def test_project_quiz_disabled_and_user_quiz_enabled_result_quiz_mode_disabled(self):
+        '''Test that the user receives normal tasks if the project quiz mode is disabled but the user quiz status is in_progress'''
+        '''See also: pybossa/api/__init__.py line 270
+           quiz_mode_enabled = user.get_quiz_in_progress(project) and project.info["quiz"]["enabled"]'''
+        project, user = self.create_project_and_user()
+
+        # Disable quiz mode on the project.
+        quiz = project.get_quiz()
+        quiz["enabled"] = False
+        project.set_quiz(quiz)
+
+        # Enable quiz mode on the user.
+        user.set_quiz_status(project, 'in_progress')
+
+        # Checks.
+        is_in_progress = user.get_quiz_in_progress(project)
+        is_user_quiz_enabled = user.get_quiz_enabled(project)
+
+        assert is_in_progress == True
+        assert is_user_quiz_enabled == False
+
+        golden_tasks = TaskFactory.create_batch(10, project=project, n_answers=1, calibration=1)
+        non_golden_tasks = TaskFactory.create_batch(10, project=project, n_answers=1, calibration=0)
+        url = '/api/project/{}/newtask'.format(project.id)
+        response = self.app.get(url)
+        task = json.loads(response.data)
+
+        # Verify the user has received a normal task.
+        assert any(task['id'] == non_golden_task.id for non_golden_task in non_golden_tasks)
 
 class TestQuizUpdate(QuizTest):
 

--- a/test/test_quiz_mode.py
+++ b/test/test_quiz_mode.py
@@ -79,8 +79,6 @@ class TestScheduler(QuizTest):
         quiz["enabled"] = True
         project.set_quiz(quiz)
 
-        project.info["quiz"]["enabled"] = True
-
         # Enable quiz mode on the user.
         user.set_quiz_status(project, 'in_progress')
 


### PR DESCRIPTION
- Allow scheduling a gold-only task if quiz mode is enabled for the user and the project.