### PR TITLE
RDISCROWD-2065 Prevent whitespace in form submissions

### DIFF
--- a/pybossa/forms/validator.py
+++ b/pybossa/forms/validator.py
@@ -37,7 +37,10 @@ class Unique(object):
         self.message = message
 
     def __call__(self, form, form_field):
-        filters = {self.field_name: form_field.data}
+        field_value = form_field.data
+        if isinstance(field_value, basestring):
+            field_value = form_field.data.strip()
+        filters = {self.field_name: field_value}
         check = self.query_function(**filters)
         if 'id' in form:
             if check:
@@ -61,18 +64,18 @@ class UniqueCaseInsensitive(Unique):
     def __call__(self, form, form_field):
         if not isinstance(form_field.data, basestring):
             return False
-        form_field.data = form_field.data.lower()
+        form_field.data = form_field.data.strip().lower()
         super(UniqueCaseInsensitive, self).__call__(form, form_field)
 
 
 class NotAllowedChars(object):
     """Validator that checks field not allowed chars"""
-    not_valid_chars = '$#&\/| '
+    not_valid_chars = '$#&\/| \t'
 
     def __init__(self, message=None):
         if not message:
-            self.message = lazy_gettext(u'%sand space symbols are forbidden'
-                                        % self.not_valid_chars)
+            self.message = lazy_gettext(u'%s and whitespace symbols are forbidden'
+                                        % self.not_valid_chars.strip())
         else:  # pragma: no cover
             self.message = message
 

--- a/test/test_forms.py
+++ b/test/test_forms.py
@@ -46,7 +46,7 @@ class TestValidator(Test):
         """Test VALIDATOR Unique works."""
         with self.flask_app.test_request_context('/'):
             f = LoginForm()
-            f.email.data = self.email_addr
+            f.email.data = self.email_addr + '\t'
             u = validator.Unique(user_repo.get_by, 'email_addr')
             u.__call__(f, f.email)
 
@@ -185,7 +185,7 @@ class TestRegisterForm(Test):
         form = RegisterForm(**self.fill_in_data)
 
         assert not form.validate()
-        assert "$#&\\/| and space symbols are forbidden" in form.errors['name'], form.errors
+        assert "$#&\\/| and whitespace symbols are forbidden" in form.errors['name'], form.errors
 
     @with_context
     def test_register_name_reserved_name(self):

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -2523,7 +2523,7 @@ class TestWeb(web.Helper):
         # Issue the error for the project.short_name
         res = self.new_project(short_name='$#/|')
         err_msg = "A project must have a short_name without |/$# chars"
-        assert '$#&amp;\/| and space symbols are forbidden' in res.data, err_msg
+        assert '$#&amp;\/| and whitespace symbols are forbidden' in res.data, err_msg
 
         # Now Unique checks
         self.new_project()


### PR DESCRIPTION
- Resolves an issue with duplicate users by name and email address, due to whitespace included within the name.

_".. admin user export csv file that the following people have two accounts with the same usernames and email addresses.. It appears that the names and fullnames have some bad characters at the end."_