### PR TITLE
Task reminder

### DIFF
--- a/pybossa/cache/projects.py
+++ b/pybossa/cache/projects.py
@@ -55,6 +55,23 @@ def get_top(n=4):
     return top_projects
 
 
+@memoize(timeout=timeouts.get('APP_TIMEOUT'))
+def get_project_by_id(project_id):
+    sql = text('''SELECT project.id, project.name, project.short_name, project.description,
+               project.info
+               FROM project
+               WHERE project.id IS NOT NULL
+               AND project.id=:project_id
+               AND project.published=True''')
+    results = session.execute(sql, dict(project_id=project_id))
+    projects = []
+    for row in results:
+        project = dict(id=row.id, name=row.name, short_name=row.short_name,
+                       description=row.description,
+                       info=row.info)
+        projects.append(Project().to_public_json(project))
+    return projects[0] if projects else None
+
 @memoize_essentials(timeout=timeouts.get('BROWSE_TASKS_TIMEOUT'), essentials=[0],
                     cache_group_keys=[[0]])
 @static_vars(allowed_fields=allowed_fields)

--- a/pybossa/cache/projects.py
+++ b/pybossa/cache/projects.py
@@ -55,23 +55,6 @@ def get_top(n=4):
     return top_projects
 
 
-@memoize(timeout=timeouts.get('APP_TIMEOUT'))
-def get_project_by_id(project_id):
-    sql = text('''SELECT project.id, project.name, project.short_name, project.description,
-               project.info
-               FROM project
-               WHERE project.id IS NOT NULL
-               AND project.id=:project_id
-               AND project.published=True''')
-    results = session.execute(sql, dict(project_id=project_id))
-    projects = []
-    for row in results:
-        project = dict(id=row.id, name=row.name, short_name=row.short_name,
-                       description=row.description,
-                       info=row.info)
-        projects.append(Project().to_public_json(project))
-    return projects[0] if projects else None
-
 @memoize_essentials(timeout=timeouts.get('BROWSE_TASKS_TIMEOUT'), essentials=[0],
                     cache_group_keys=[[0]])
 @static_vars(allowed_fields=allowed_fields)

--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -267,8 +267,8 @@ class TaskTimeoutForm(Form):
         return self.min_seconds <= minutes*60 + seconds <= self.max_minutes*60
 
 
-class ProgressReminderForm(Form):
-    remaining = IntegerField(lazy_gettext('Notify when incomplete tasks drops to the following number'))
+class TaskNotificationForm(Form):
+    remaining = IntegerField(lazy_gettext('Notify when the number of remaining tasks is less than or equal to'))
 
 
 class TaskSchedulerForm(Form):

--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -22,7 +22,7 @@ from flask import request
 from flask_wtf import FlaskForm as Form
 from flask_wtf.file import FileField, FileRequired, FileAllowed
 from werkzeug.utils import secure_filename
-from wtforms import IntegerField, DecimalField, TextField, BooleanField, \
+from wtforms import IntegerField, DecimalField, TextField, BooleanField, RadioField, \
     SelectField, validators, TextAreaField, PasswordField, FieldList, SelectMultipleField
 from wtforms import SelectMultipleField
 from wtforms.fields.html5 import EmailField, URLField
@@ -266,6 +266,14 @@ class TaskTimeoutForm(Form):
         seconds = self.seconds.data or 0
         return self.min_seconds <= minutes*60 + seconds <= self.max_minutes*60
 
+
+class ProgressReminderForm(Form):
+    recipients_choices = [('None', 'Do not notify'),
+                          ('owner','Notify only project owner'),
+                          ('coowners', 'Notify all project coowners')]
+    recipients_group = RadioField('TEST_LABEL', choices=recipients_choices, coerce=unicode)
+    percentage = IntegerField(lazy_gettext('Notify once the following percentage of tasks are completed (0 - 100)'),
+                           [validators.NumberRange(min=0, max=100)])
 
 
 class TaskSchedulerForm(Form):

--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -271,7 +271,8 @@ class ProgressReminderForm(Form):
     recipients_choices = [('None', 'Do not notify'),
                           ('owner','Notify only project owner'),
                           ('coowners', 'Notify all project coowners')]
-    recipients_group = RadioField('TEST_LABEL', choices=recipients_choices, coerce=unicode)
+    recipients_group = RadioField(lazy_gettext('Choose recipients'),
+                                  choices=recipients_choices)
     percentage = IntegerField(lazy_gettext('Notify once the following percentage of tasks are completed (0 - 100)'),
                            [validators.NumberRange(min=0, max=100)])
 

--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -268,7 +268,7 @@ class TaskTimeoutForm(Form):
 
 
 class ProgressReminderForm(Form):
-    remaining = IntegerField(lazy_gettext('Notify when number of incomplete tasks drops to'))
+    remaining = IntegerField(lazy_gettext('Notify when incomplete tasks drops to the following number'))
 
 
 class TaskSchedulerForm(Form):

--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -268,13 +268,7 @@ class TaskTimeoutForm(Form):
 
 
 class ProgressReminderForm(Form):
-    recipients_choices = [('None', 'Do not notify'),
-                          ('owner','Notify only project owner'),
-                          ('coowners', 'Notify all project coowners')]
-    recipients_group = RadioField(lazy_gettext('Choose recipients'),
-                                  choices=recipients_choices)
-    percentage = IntegerField(lazy_gettext('Notify once the following percentage of tasks are completed (0 - 100)'),
-                           [validators.NumberRange(min=0, max=100)])
+    remaining = IntegerField(lazy_gettext('Notify when number of incomplete tasks drops to'))
 
 
 class TaskSchedulerForm(Form):

--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -22,7 +22,7 @@ from flask import request
 from flask_wtf import FlaskForm as Form
 from flask_wtf.file import FileField, FileRequired, FileAllowed
 from werkzeug.utils import secure_filename
-from wtforms import IntegerField, DecimalField, TextField, BooleanField, RadioField, \
+from wtforms import IntegerField, DecimalField, TextField, BooleanField, \
     SelectField, validators, TextAreaField, PasswordField, FieldList, SelectMultipleField
 from wtforms import SelectMultipleField
 from wtforms.fields.html5 import EmailField, URLField

--- a/pybossa/forms/projects_view_forms.py
+++ b/pybossa/forms/projects_view_forms.py
@@ -29,6 +29,7 @@ from forms import (
     TaskPriorityForm,
     TaskTimeoutForm,
     TaskSchedulerForm,
+    ProgressReminderForm,
     BlogpostForm,
     PasswordForm,
     GenericBulkTaskImportForm,

--- a/pybossa/forms/projects_view_forms.py
+++ b/pybossa/forms/projects_view_forms.py
@@ -29,7 +29,7 @@ from forms import (
     TaskPriorityForm,
     TaskTimeoutForm,
     TaskSchedulerForm,
-    ProgressReminderForm,
+    TaskNotificationForm,
     BlogpostForm,
     PasswordForm,
     GenericBulkTaskImportForm,

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -976,6 +976,23 @@ def notify_blog_users(blog_id, project_id, queue='high'):
     return msg
 
 
+# def notify_project_progress(project_id, email_addr, queue='high'):
+#     """ send email about the progress of task completion """
+#     # TODO:
+#     subject = ""
+#     mail_dict = dict(recipients=[row.email_addr],
+#                         subject=subject,
+#                         body=body,
+#                         html=html)
+
+#     job = dict(name=send_mail,
+#                 args=[mail_dict],
+#                 kwargs={},
+#                 timeout=timeout,
+#                 queue=queue)
+#     enqueue_job(job)
+
+
 def get_weekly_stats_update_projects():
     """Return email jobs with weekly stats update for project owner."""
     from sqlalchemy.sql import text

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -697,7 +697,6 @@ def delete_bulk_tasks(data):
 
     mail_dict = dict(recipients=recipients, subject=subject, body=body)
     send_mail(mail_dict)
-    # TODO: send email
     check_and_send_project_progress(project_id)
 
 
@@ -997,10 +996,6 @@ def notify_project_progress(info, email_addr, queue='high'):
                 timeout=timeout,
                 queue=queue)
     enqueue_job(job)
-    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
-    current_app.logger.info('Enqueue Job')
-    current_app.logger.info(mail_dict)
-    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
 
 
 def get_weekly_stats_update_projects():
@@ -1333,9 +1328,6 @@ def check_and_send_project_progress(project_id, conn=None):
     project = project_repo.get(project_id)
     if not project:
         return
-    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
-    current_app.logger.info('check_and_send_project_progress')
-    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
 
     reminder = project.info.get('progress_reminder', {})
     target_remaining = reminder.get("target_remaining")
@@ -1344,35 +1336,17 @@ def check_and_send_project_progress(project_id, conn=None):
         return
 
     n_available_tasks = n_available_tasks(project.id)
-
-    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
-    current_app.logger.info('n_available_tasks: {}'.format(n_available_tasks))
-    current_app.logger.info('target_remaining: {}'.format(target_remaining))
-    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
-
-
     if n_available_tasks > target_remaining:
         reminder['sent'] = False
-        current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
-        current_app.logger.info('check_and_send_project_progress - set to False')
-        current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
 
     elif not email_already_sent:
         # progress reached threshold and email not sent yet, send email
-        current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
-        current_app.logger.info('check_and_send_project_progress - set to True')
-        current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
-
         email_addr = [cached_users.get_user_email(user_id)
                         for user_id in project.owners_ids]
         info = dict(project_name=project.name,
                     n_available_tasks=n_available_tasks)
         notify_project_progress(info, email_addr)
         reminder['sent'] = True
-
-    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
-    current_app.logger.info('email sent, save to project')
-    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
 
     project.info['progress_reminder'] = reminder
     if conn is not None:
@@ -1382,11 +1356,6 @@ def check_and_send_project_progress(project_id, conn=None):
     else:
         current_app.logger.info('save with repo')
         project_repo.save(project)
-
-    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
-    current_app.logger.info('project saved')
-    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
-
 
 def export_all_users(fmt, email_addr):
     exportable_attributes = ('id', 'name', 'fullname', 'email_addr', 'locale',

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -1322,6 +1322,7 @@ def get_management_dashboard_stats(user_email):
 
 
 def check_and_send_task_notifications(project_id, conn=None):
+    from pybossa.core import project_repo
 
     project = project_repo.get(project_id)
     if not project:

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -1350,11 +1350,9 @@ def check_and_send_project_progress(project_id, conn=None):
 
     project.info['progress_reminder'] = reminder
     if conn is not None:
-        current_app.logger.info('save with conn')
         sql = text(''' UPDATE project SET info=:info WHERE id=:id''')
         conn.execute(sql, dict(info=json.dumps(project.info), id=project_id))
     else:
-        current_app.logger.info('save with repo')
         project_repo.save(project)
 
 def export_all_users(fmt, email_addr):

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -980,11 +980,10 @@ def notify_blog_users(blog_id, project_id, queue='high'):
 
 def notify_project_progress(info, email_addr, queue='high'):
     """ send email about the progress of task completion """
+
     subject = "Project progress reminder for {}".format(info['project_name'])
-    msg = """You have completed {} out of {} tasks in your project: {},
-            project progress reached {}%.
-          """.format(info['n_completed_tasks'], info['n_tasks'],
-                     info['project_name'], info['progress'])
+    msg = """There are only {} tasks left incompleted in your project {}.
+          """.format(info['n_available_tasks'], info['project_name'])
     body = (u'Hello,\n\n{}\nThe {} team.'
             .format(msg, current_app.config.get('BRAND')))
     mail_dict = dict(recipients=email_addr,
@@ -998,6 +997,10 @@ def notify_project_progress(info, email_addr, queue='high'):
                 timeout=timeout,
                 queue=queue)
     enqueue_job(job)
+    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+    current_app.logger.info('Enqueue Job')
+    current_app.logger.info(mail_dict)
+    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
 
 
 def get_weekly_stats_update_projects():
@@ -1321,33 +1324,68 @@ def get_management_dashboard_stats(user_email):
     send_mail(mail_dict)
 
 
-def check_and_send_project_progress(project_id):
-    from pybossa.core import project_repo
+def check_and_send_project_progress(project_id, conn=None):
+    from pybossa.cache.helpers import n_available_tasks
     import pybossa.cache.users as cached_users
+    from pybossa.core import project_repo
+    from sqlalchemy.sql import text
 
     project = project_repo.get(project_id)
     if not project:
         return
+    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+    current_app.logger.info('check_and_send_project_progress')
+    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
 
     reminder = project.info.get('progress_reminder', {})
     target_remaining = reminder.get("target_remaining")
     email_already_sent = reminder.get("sent") or False
-    if n_tasks == 0 or target_remaining is None:
+    if target_remaining is None:
         return
 
-    current_incomplete_tasks = ...
-    if current_incomplete_tasks < target_remaining:
+    n_available_tasks = n_available_tasks(project.id)
+
+    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+    current_app.logger.info('n_available_tasks: {}'.format(n_available_tasks))
+    current_app.logger.info('target_remaining: {}'.format(target_remaining))
+    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+
+
+    if n_available_tasks > target_remaining:
         reminder['sent'] = False
+        current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+        current_app.logger.info('check_and_send_project_progress - set to False')
+        current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+
     elif not email_already_sent:
         # progress reached threshold and email not sent yet, send email
+        current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+        current_app.logger.info('check_and_send_project_progress - set to True')
+        current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+
         email_addr = [cached_users.get_user_email(user_id)
-                        for user_id in project.info.owners_ids]
+                        for user_id in project.owners_ids]
         info = dict(project_name=project.name,
-                    current_incomplete_tasks=current_incomplete_tasks)
+                    n_available_tasks=n_available_tasks)
         notify_project_progress(info, email_addr)
         reminder['sent'] = True
+
+    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+    current_app.logger.info('email sent, save to project')
+    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+
     project.info['progress_reminder'] = reminder
-    project_repo.save(project)
+    if conn is not None:
+        current_app.logger.info('save with conn')
+        sql = text(''' UPDATE project SET info=:info WHERE id=:id''')
+        conn.execute(sql, dict(info=json.dumps(project.info), id=project_id))
+    else:
+        current_app.logger.info('save with repo')
+        project_repo.save(project)
+
+    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+    current_app.logger.info('project saved')
+    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
 
 
 def export_all_users(fmt, email_addr):

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -976,21 +976,26 @@ def notify_blog_users(blog_id, project_id, queue='high'):
     return msg
 
 
-# def notify_project_progress(project_id, email_addr, queue='high'):
-#     """ send email about the progress of task completion """
-#     # TODO:
-#     subject = ""
-#     mail_dict = dict(recipients=[row.email_addr],
-#                         subject=subject,
-#                         body=body,
-#                         html=html)
+def notify_project_progress(info, email_addr, queue='high'):
+    """ send email about the progress of task completion """
+    subject = "Project progress reminder for {}".format(info['project_name'])
+    msg = """You have completed {} out of {} tasks in your project: {},
+            project progress reached {}%.
+          """.format(info['n_completed_tasks'], info['n_tasks'],
+                     info['project_name'], info['progress'])
+    body = (u'Hello,\n\n{}\nThe {} team.'
+            .format(msg, current_app.config.get('BRAND')))
+    mail_dict = dict(recipients=email_addr,
+                        subject=subject,
+                        body=body)
 
-#     job = dict(name=send_mail,
-#                 args=[mail_dict],
-#                 kwargs={},
-#                 timeout=timeout,
-#                 queue=queue)
-#     enqueue_job(job)
+    timeout = current_app.config.get('TIMEOUT')
+    job = dict(name=send_mail,
+                args=[mail_dict],
+                kwargs={},
+                timeout=timeout,
+                queue=queue)
+    enqueue_job(job)
 
 
 def get_weekly_stats_update_projects():

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -1338,7 +1338,6 @@ def check_and_send_project_progress(project_id, conn=None):
     n_available_tasks = n_available_tasks(project.id)
     if n_available_tasks > target_remaining:
         reminder['sent'] = False
-
     elif not email_already_sent:
         # progress reached threshold and email not sent yet, send email
         email_addr = [cached_users.get_user_email(user_id)

--- a/pybossa/model/event_listeners.py
+++ b/pybossa/model/event_listeners.py
@@ -140,13 +140,13 @@ def add_task_event(mapper, conn, target):
     update_feed(obj)
 
 
-# @event.listens_for(Task, 'after_update')
-# @event.listens_for(Task, 'after_delete')
-# def calculate_and_send_progress_after_update_task(mapper, conn, target):
-#     current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
-#     current_app.logger.info('after update/delete')
-#     current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
-#     check_and_send_project_progress(target.project_id)
+@event.listens_for(Task, 'after_update')
+@event.listens_for(Task, 'after_delete')
+def calculate_and_send_progress_after_update_task(mapper, conn, target):
+    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+    current_app.logger.info('after update/delete')
+    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+    check_and_send_project_progress(target.project_id, conn)
 
 
 @event.listens_for(User, 'after_insert')
@@ -285,8 +285,8 @@ def on_taskrun_submit(mapper, conn, target):
 
     is_completed = is_task_completed(conn, target.task_id, target.project_id)
     if is_completed:
-        check_and_send_project_progress(target.project_id)
         update_task_state(conn, target.task_id)
+        check_and_send_project_progress(target.project_id, conn)
 
     if is_completed and _published:
         update_feed(project_public)

--- a/pybossa/model/event_listeners.py
+++ b/pybossa/model/event_listeners.py
@@ -35,7 +35,7 @@ from pybossa.model.user import User
 from pybossa.model.result import Result
 from pybossa.model.counter import Counter
 from pybossa.core import result_repo, db, task_repo
-from pybossa.jobs import webhook, notify_blog_users, check_and_send_project_progress
+from pybossa.jobs import webhook, notify_blog_users, check_and_send_task_notifications
 from pybossa.jobs import push_notification
 from pybossa.cache import projects as cached_projects
 from pybossa.cache import users as cached_users
@@ -143,7 +143,7 @@ def add_task_event(mapper, conn, target):
 @event.listens_for(Task, 'after_update')
 @event.listens_for(Task, 'after_delete')
 def calculate_and_send_progress_after_update_task(mapper, conn, target):
-    check_and_send_project_progress(target.project_id, conn)
+    check_and_send_task_notifications(target.project_id, conn)
 
 
 @event.listens_for(User, 'after_insert')
@@ -283,7 +283,7 @@ def on_taskrun_submit(mapper, conn, target):
     is_completed = is_task_completed(conn, target.task_id, target.project_id)
     if is_completed:
         update_task_state(conn, target.task_id)
-        check_and_send_project_progress(target.project_id, conn)
+        check_and_send_task_notifications(target.project_id, conn)
 
     if is_completed and _published:
         update_feed(project_public)

--- a/pybossa/model/event_listeners.py
+++ b/pybossa/model/event_listeners.py
@@ -276,6 +276,10 @@ def on_taskrun_submit(mapper, conn, target):
     is_completed = is_task_completed(conn, target.task_id, target.project_id)
     if is_completed:
         update_task_state(conn, target.task_id)
+        # # TODO: send email notification
+        # if need_notification:
+        #     email_addr = ...
+
     if is_completed and _published:
         update_feed(project_public)
         result_id = create_result(conn, target.project_id, target.task_id)

--- a/pybossa/model/event_listeners.py
+++ b/pybossa/model/event_listeners.py
@@ -34,7 +34,7 @@ from pybossa.model.webhook import Webhook
 from pybossa.model.user import User
 from pybossa.model.result import Result
 from pybossa.model.counter import Counter
-from pybossa.core import project_repo, result_repo, db, task_repo
+from pybossa.core import result_repo, db, task_repo
 from pybossa.jobs import webhook, notify_blog_users, check_and_send_project_progress
 from pybossa.jobs import push_notification
 from pybossa.cache import projects as cached_projects
@@ -143,9 +143,6 @@ def add_task_event(mapper, conn, target):
 @event.listens_for(Task, 'after_update')
 @event.listens_for(Task, 'after_delete')
 def calculate_and_send_progress_after_update_task(mapper, conn, target):
-    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
-    current_app.logger.info('after update/delete')
-    current_app.logger.info('^^^^^^^^^^^^^^^^^^^^^^^^^^^')
     check_and_send_project_progress(target.project_id, conn)
 
 

--- a/pybossa/repositories/task_repository.py
+++ b/pybossa/repositories/task_repository.py
@@ -203,6 +203,8 @@ class TaskRepository(Repository):
         self._delete_zip_files_from_store(project)
 
     def delete_task_by_id(self, project_id, task_id):
+        from pybossa.jobs import check_and_send_project_progress
+
         args = dict(project_id=project_id, task_id=task_id)
         self.db.session.execute(text('''
                    DELETE FROM result WHERE project_id=:project_id
@@ -215,6 +217,7 @@ class TaskRepository(Repository):
                                     AND id=:task_id;'''), args)
         self.db.session.commit()
         cached_projects.clean_project(project_id)
+        check_and_send_project_progress(project_id)
 
     def delete_valid_from_project(self, project, force_reset=False, filters=None):
         if not force_reset:

--- a/pybossa/repositories/task_repository.py
+++ b/pybossa/repositories/task_repository.py
@@ -284,6 +284,7 @@ class TaskRepository(Repository):
         tasks with curr redundancy < new redundancy, with state as completed
         and were marked as exported = True
         """
+        from pybossa.jobs import check_and_send_project_progress
 
         if n_answers < self.MIN_REDUNDANCY or n_answers > self.MAX_REDUNDANCY:
             raise ValueError("Invalid redundancy value: {}".format(n_answers))
@@ -334,6 +335,8 @@ class TaskRepository(Repository):
         self.update_task_state(project.id)
         self.db.session.commit()
         cached_projects.clean_project(project.id)
+        # TODO: send email
+        check_and_send_project_progress(project.id)
         return tasks_not_updated
 
     def update_task_state(self, project_id):

--- a/pybossa/repositories/task_repository.py
+++ b/pybossa/repositories/task_repository.py
@@ -338,7 +338,6 @@ class TaskRepository(Repository):
         self.update_task_state(project.id)
         self.db.session.commit()
         cached_projects.clean_project(project.id)
-        # TODO: send email
         check_and_send_project_progress(project.id)
         return tasks_not_updated
 

--- a/pybossa/repositories/task_repository.py
+++ b/pybossa/repositories/task_repository.py
@@ -203,7 +203,7 @@ class TaskRepository(Repository):
         self._delete_zip_files_from_store(project)
 
     def delete_task_by_id(self, project_id, task_id):
-        from pybossa.jobs import check_and_send_project_progress
+        from pybossa.jobs import check_and_send_task_notifications
 
         args = dict(project_id=project_id, task_id=task_id)
         self.db.session.execute(text('''
@@ -217,7 +217,7 @@ class TaskRepository(Repository):
                                     AND id=:task_id;'''), args)
         self.db.session.commit()
         cached_projects.clean_project(project_id)
-        check_and_send_project_progress(project_id)
+        check_and_send_task_notifications(project_id)
 
     def delete_valid_from_project(self, project, force_reset=False, filters=None):
         if not force_reset:
@@ -287,7 +287,7 @@ class TaskRepository(Repository):
         tasks with curr redundancy < new redundancy, with state as completed
         and were marked as exported = True
         """
-        from pybossa.jobs import check_and_send_project_progress
+        from pybossa.jobs import check_and_send_task_notifications
 
         if n_answers < self.MIN_REDUNDANCY or n_answers > self.MAX_REDUNDANCY:
             raise ValueError("Invalid redundancy value: {}".format(n_answers))
@@ -338,7 +338,7 @@ class TaskRepository(Repository):
         self.update_task_state(project.id)
         self.db.session.commit()
         cached_projects.clean_project(project.id)
-        check_and_send_project_progress(project.id)
+        check_and_send_task_notifications(project.id)
         return tasks_not_updated
 
     def update_task_state(self, project_id):

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -2381,6 +2381,7 @@ def task_progress_reminder(short_name):
     project = project_repo.get_by_shortname(short_name=project.short_name)
     reminder_info = project.info.get('progress_reminder') or {}
     reminder_info['target_remaining'] = remaining
+    reminder_info['sent'] = False
     project.info['progress_reminder'] = reminder_info
     project_repo.save(project)
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -2378,9 +2378,13 @@ def task_notification(short_name):
                                 pro_features=pro))
 
     project = project_repo.get_by_shortname(short_name=project.short_name)
+
     reminder_info = project.info.get('progress_reminder') or {}
     reminder_info['target_remaining'] = remaining
     reminder_info['sent'] = False
+
+    auditlogger.log_event(project, current_user, 'update', 'task_notification',
+                        project.info.get('progress_reminder'), reminder_info)
     project.info['progress_reminder'] = reminder_info
     project_repo.save(project)
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1001,7 +1001,6 @@ def import_task(short_name):
                 flash(gettext(msg), 'error')
                 current_app.logger.exception(u'project: {} {}'.format(project.short_name, e))
         template_args['template'] = '/projects/importers/%s.html' % importer_type
-        # TODO: send email
         check_and_send_project_progress(project.id)
         return handle_content_type(template_args)
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -68,7 +68,7 @@ from pybossa.jobs import (webhook, send_mail,
                           import_tasks, IMPORT_TASKS_TIMEOUT,
                           delete_bulk_tasks, TASK_DELETE_TIMEOUT,
                           export_tasks, EXPORT_TASKS_TIMEOUT,
-                          mail_project_report)
+                          mail_project_report, check_and_send_project_progress)
 from pybossa.forms.dynamic_forms import dynamic_project_form, dynamic_clone_project_form
 from pybossa.forms.projects_view_forms import *
 from pybossa.forms.admin_view_forms import SearchForm
@@ -1001,6 +1001,8 @@ def import_task(short_name):
                 flash(gettext(msg), 'error')
                 current_app.logger.exception(u'project: {} {}'.format(project.short_name, e))
         template_args['template'] = '/projects/importers/%s.html' % importer_type
+        # TODO: send email
+        check_and_send_project_progress(project.id)
         return handle_content_type(template_args)
 
     if request.method == 'GET':

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -2342,6 +2342,64 @@ def task_timeout(short_name):
                                pro_features=pro))
 
 
+
+@blueprint.route('/<short_name>/tasks/progress-reminder', methods=['GET', 'POST'])
+@login_required
+def task_progress_reminder(short_name):
+    project, owner, ps = project_by_shortname(short_name)
+    project_sanitized, owner_sanitized = sanitize_project_owner(project,
+                                                                    owner,
+                                                                    current_user,
+                                                                    ps)
+    title = project_title(project, gettext('Progress Reminder'))
+    form = ProgressReminderForm(request.body) if request.data else ProgressReminderForm()
+
+    ensure_authorized_to('read', project)
+    ensure_authorized_to('update', project)
+    pro = pro_features()
+    if request.method == 'GET':
+        reminder_info = project.info.get('progress_reminder', {})
+        recipients_group = reminder_info.get('recipients')
+        progress_precentage = reminder_info.get('percentage') or 0
+        # options = [('Do not notify', 'None'),
+        #            ('Notify only project owner', 'owner'),
+        #            ('Notify all project coowners', 'coowners')]
+        recipients_group = recipients_group if recipients_group else 'None'
+        print(recipients_group)
+
+        return handle_content_type(dict(template='/projects/progress_reminder.html',
+                               title=title,
+                               form=form,
+                               recipients_group=recipients_group,
+                               progress_precentage=progress_precentage,
+                               project=project_sanitized,
+                               pro_features=pro))
+"""
+    if form.validate() and form.in_range():
+        project = project_repo.get_by_shortname(short_name=project.short_name)
+        reminder_info = project.info.get('progress_reminder') or {}
+        reminder_info['recipients'] = form.recipients if form.recipients is not None else None
+        reminder_info['percentage'] = form.percentage or 0
+        project.info['progress_reminder'] = reminder_info
+        msg = gettext("Project Task Progress Reminder updated!")
+        flash(msg, 'success')
+
+        return redirect_content_type(url_for('.tasks', short_name=project.short_name))
+    else:
+        # if not form.in_range():
+        #     flash(gettext('Timeout should be between {} seconds and {} minuntes')
+        #                   .format(form.min_seconds, form.max_minutes), 'error')
+        # else:
+        #     flash(gettext('Please correct the errors'), 'error')
+        return handle_content_type(dict(template='/projects/progress_reminder.html',
+                               title=title,
+                               form=form,
+                               project=project_sanitized,
+                               owner=owner_sanitized,
+                               pro_features=pro))
+
+"""
+
 @blueprint.route('/<short_name>/blog')
 def show_blogposts(short_name):
     project, owner, ps = project_by_shortname(short_name)

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -2370,8 +2370,6 @@ def task_progress_reminder(short_name):
 
     remaining = form.remaining.data
     n_tasks = cached_projects.n_tasks(project.id)
-    print("remaining......")
-    print(remaining)
     if remaining is not None and (remaining < 0 or remaining > n_tasks):
         flash(gettext('Target number should be between 0 and {}'.format(n_tasks)), 'error')
         return handle_content_type(dict(template='/projects/progress_reminder.html',
@@ -2383,7 +2381,6 @@ def task_progress_reminder(short_name):
     project = project_repo.get_by_shortname(short_name=project.short_name)
     reminder_info = project.info.get('progress_reminder') or {}
     reminder_info['target_remaining'] = remaining
-    reminder_info['sent'] = reminder_info.get('sent') or False
     project.info['progress_reminder'] = reminder_info
     project_repo.save(project)
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -2360,27 +2360,21 @@ def task_progress_reminder(short_name):
     if request.method == 'GET':
         reminder_info = project.info.get('progress_reminder', {})
         recipients_group = reminder_info.get('recipients')
-        progress_precentage = reminder_info.get('percentage') or 0
-        # options = [('Do not notify', 'None'),
-        #            ('Notify only project owner', 'owner'),
-        #            ('Notify all project coowners', 'coowners')]
-        recipients_group = recipients_group if recipients_group else 'None'
-        print(recipients_group)
-
+        form.percentage.data = reminder_info.get('percentage') or 0
+        form.recipients_group.data = recipients_group if recipients_group else 'None'
         return handle_content_type(dict(template='/projects/progress_reminder.html',
                                title=title,
                                form=form,
-                               recipients_group=recipients_group,
-                               progress_precentage=progress_precentage,
                                project=project_sanitized,
                                pro_features=pro))
-"""
-    if form.validate() and form.in_range():
+
+    if form.validate():
         project = project_repo.get_by_shortname(short_name=project.short_name)
         reminder_info = project.info.get('progress_reminder') or {}
-        reminder_info['recipients'] = form.recipients if form.recipients is not None else None
-        reminder_info['percentage'] = form.percentage or 0
+        reminder_info['recipients'] = 'None' if form.recipients_group.data is 'None' else form.recipients_group.data
+        reminder_info['percentage'] = form.percentage.data or 0
         project.info['progress_reminder'] = reminder_info
+        project_repo.save(project)
         msg = gettext("Project Task Progress Reminder updated!")
         flash(msg, 'success')
 
@@ -2395,10 +2389,9 @@ def task_progress_reminder(short_name):
                                title=title,
                                form=form,
                                project=project_sanitized,
-                               owner=owner_sanitized,
                                pro_features=pro))
 
-"""
+
 
 @blueprint.route('/<short_name>/blog')
 def show_blogposts(short_name):

--- a/test/test_jobs/test_progress_reminder.py
+++ b/test/test_jobs/test_progress_reminder.py
@@ -88,7 +88,6 @@ class TestSendTaskNorification(Test):
         assert project.info['progress_reminder']['sent']
 
 
-
     @with_context
     @patch('pybossa.jobs.n_available_tasks')
     @patch('pybossa.jobs.notify_task_progress')
@@ -107,6 +106,24 @@ class TestSendTaskNorification(Test):
         assert not notify.called
         assert not project.info['progress_reminder']['sent']
 
+
+    @with_context
+    @patch('pybossa.jobs.n_available_tasks')
+    @patch('pybossa.jobs.notify_task_progress')
+    def test_remaining_tasks_do_not_drop_below_configuration_2(self, notify, n_tasks):
+        """Do not send email if #remaining tasks is greater than configuration"""
+        n_tasks.return_value = 1
+        reminder = dict(target_remaining=0, sent=True)
+        project_id = '1'
+        project = ProjectFactory.create(id=project_id,
+                                        owners_ids=[],
+                                        published=True,
+                                        featured=True,
+                                        info={'progress_reminder':reminder})
+
+        check_and_send_task_notifications(project_id)
+        assert not notify.called
+        assert not project.info['progress_reminder']['sent']
 
     @with_context
     @patch('pybossa.jobs.enqueue_job')

--- a/test/test_jobs/test_progress_reminder.py
+++ b/test/test_jobs/test_progress_reminder.py
@@ -27,7 +27,7 @@ from pybossa.jobs import check_and_send_task_notifications, notify_task_progress
 queue = MagicMock()
 queue.enqueue.return_value = True
 
-class TestSendTaskNorification(Test):
+class TestSendTaskNotification(Test):
 
     @with_context
     @patch('pybossa.jobs.n_available_tasks')

--- a/test/test_jobs/test_progress_reminder.py
+++ b/test/test_jobs/test_progress_reminder.py
@@ -33,7 +33,7 @@ class TestSendProgressReminder(Test):
     @patch('pybossa.cache.helpers.n_available_tasks')
     @patch('pybossa.jobs.notify_project_progress')
     def test_remaining_tasks_drop_below_configuration_0(self, notify, n_tasks):
-        """Send email if remaining tasks drops below, test with conn"""
+        """Send email if remaining tasks drops below, test with connection"""
         n_tasks.return_value = 0
         reminder = dict(target_remaining=0, sent=False)
         conn = MagicMock()
@@ -45,7 +45,7 @@ class TestSendProgressReminder(Test):
                                         featured=True,
                                         info={'progress_reminder':reminder})
 
-        check_and_send_project_progress(project_id)
+        check_and_send_project_progress(project_id, conn)
         assert notify.called
         assert project.info['progress_reminder']['sent']
 

--- a/test/test_jobs/test_progress_reminder.py
+++ b/test/test_jobs/test_progress_reminder.py
@@ -1,0 +1,89 @@
+# -*- coding: utf8 -*-
+# This file is part of PYBOSSA.
+#
+# Copyright (C) 2015 Scifabric LTD.
+#
+# PYBOSSA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PYBOSSA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
+
+from pybossa.jobs import check_and_send_project_progress
+from default import Test, with_context, flask_app
+from factories import BlogpostFactory
+from factories import TaskRunFactory
+from factories import ProjectFactory
+from factories import UserFactory
+from mock import patch, MagicMock
+
+queue = MagicMock()
+queue.enqueue.return_value = True
+
+class TestSendProgressReminder(Test):
+
+    @with_context
+    @patch('pybossa.cache.helpers.n_available_tasks')
+    @patch('pybossa.jobs.notify_project_progress')
+    def test_remaining_tasks_drop_below_configuration_1(self, notify, n_tasks):
+        """Send email if remaining tasks drops below"""
+        n_tasks.return_value = 0
+        reminder = dict(target_remaining=0, sent=False)
+        project_id = '1'
+        project = ProjectFactory.create(id=project_id,
+                                        owners_ids=[],
+                                        published=True,
+                                        featured=True,
+                                        info={'progress_reminder':reminder})
+
+        check_and_send_project_progress(project_id)
+        assert notify.called
+        assert project.info['progress_reminder']['sent']
+
+
+    @with_context
+    @patch('pybossa.cache.helpers.n_available_tasks')
+    @patch('pybossa.jobs.notify_project_progress')
+    def test_remaining_tasks_drop_below_configuration_2(self, notify, n_tasks):
+        """Do not sent multiple email"""
+        n_tasks.return_value = 0
+        reminder = dict(target_remaining=0, sent=True)
+        project_id = '1'
+        project = ProjectFactory.create(id=project_id,
+                                        owners_ids=[],
+                                        published=True,
+                                        featured=True,
+                                        info={'progress_reminder':reminder})
+
+        check_and_send_project_progress(project_id)
+        assert not notify.called
+        assert project.info['progress_reminder']['sent']
+
+
+
+    @with_context
+    @patch('pybossa.cache.helpers.n_available_tasks')
+    @patch('pybossa.jobs.notify_project_progress')
+    def test_remaining_tasks_do_not_drop_below_configuration(self, notify, n_tasks):
+        """Do not send email if #remaining tasks is greater than configuration"""
+        n_tasks.return_value = 1
+        reminder = dict(target_remaining=0, sent=False)
+        project_id = '1'
+        project = ProjectFactory.create(id=project_id,
+                                        owners_ids=[],
+                                        published=True,
+                                        featured=True,
+                                        info={'progress_reminder':reminder})
+
+        check_and_send_project_progress(project_id)
+        assert not notify.called
+        assert not project.info['progress_reminder']['sent']
+
+

--- a/test/test_jobs/test_progress_reminder.py
+++ b/test/test_jobs/test_progress_reminder.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 
-from pybossa.jobs import check_and_send_project_progress, notify_project_progress
+from pybossa.jobs import check_and_send_task_notifications, notify_task_progress
 from default import Test, with_context, flask_app
 from factories import BlogpostFactory
 from factories import TaskRunFactory
@@ -31,7 +31,7 @@ class TestSendProgressReminder(Test):
 
     @with_context
     @patch('pybossa.cache.helpers.n_available_tasks')
-    @patch('pybossa.jobs.notify_project_progress')
+    @patch('pybossa.jobs.notify_task_progress')
     def test_remaining_tasks_drop_below_configuration_0(self, notify, n_tasks):
         """Send email if remaining tasks drops below, test with connection"""
         n_tasks.return_value = 0
@@ -45,14 +45,14 @@ class TestSendProgressReminder(Test):
                                         featured=True,
                                         info={'progress_reminder':reminder})
 
-        check_and_send_project_progress(project_id, conn)
+        check_and_send_task_notifications(project_id, conn)
         assert notify.called
         assert project.info['progress_reminder']['sent']
 
 
     @with_context
     @patch('pybossa.cache.helpers.n_available_tasks')
-    @patch('pybossa.jobs.notify_project_progress')
+    @patch('pybossa.jobs.notify_task_progress')
     def test_remaining_tasks_drop_below_configuration_1(self, notify, n_tasks):
         """Send email if remaining tasks drops below"""
         n_tasks.return_value = 0
@@ -64,14 +64,14 @@ class TestSendProgressReminder(Test):
                                         featured=True,
                                         info={'progress_reminder':reminder})
 
-        check_and_send_project_progress(project_id)
+        check_and_send_task_notifications(project_id)
         assert notify.called
         assert project.info['progress_reminder']['sent']
 
 
     @with_context
     @patch('pybossa.cache.helpers.n_available_tasks')
-    @patch('pybossa.jobs.notify_project_progress')
+    @patch('pybossa.jobs.notify_task_progress')
     def test_remaining_tasks_drop_below_configuration_2(self, notify, n_tasks):
         """Do not sent multiple email"""
         n_tasks.return_value = 0
@@ -83,7 +83,7 @@ class TestSendProgressReminder(Test):
                                         featured=True,
                                         info={'progress_reminder':reminder})
 
-        check_and_send_project_progress(project_id)
+        check_and_send_task_notifications(project_id)
         assert not notify.called
         assert project.info['progress_reminder']['sent']
 
@@ -91,7 +91,7 @@ class TestSendProgressReminder(Test):
 
     @with_context
     @patch('pybossa.cache.helpers.n_available_tasks')
-    @patch('pybossa.jobs.notify_project_progress')
+    @patch('pybossa.jobs.notify_task_progress')
     def test_remaining_tasks_do_not_drop_below_configuration(self, notify, n_tasks):
         """Do not send email if #remaining tasks is greater than configuration"""
         n_tasks.return_value = 1
@@ -103,15 +103,15 @@ class TestSendProgressReminder(Test):
                                         featured=True,
                                         info={'progress_reminder':reminder})
 
-        check_and_send_project_progress(project_id)
+        check_and_send_task_notifications(project_id)
         assert not notify.called
         assert not project.info['progress_reminder']['sent']
 
 
     @with_context
     @patch('pybossa.jobs.enqueue_job')
-    def test_notify_project_progress(self, mock):
+    def test_notify_task_progress(self, mock):
         info = dict(project_name="test project", n_available_tasks=10)
         email_addr = ['user@user.com']
-        notify_project_progress(info, email_addr)
+        notify_task_progress(info, email_addr)
         assert mock.called

--- a/test/test_jobs/test_progress_reminder.py
+++ b/test/test_jobs/test_progress_reminder.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 
-from pybossa.jobs import check_and_send_project_progress
+from pybossa.jobs import check_and_send_project_progress, notify_project_progress
 from default import Test, with_context, flask_app
 from factories import BlogpostFactory
 from factories import TaskRunFactory
@@ -87,3 +87,10 @@ class TestSendProgressReminder(Test):
         assert not project.info['progress_reminder']['sent']
 
 
+    @with_context
+    @patch('pybossa.jobs.enqueue_job')
+    def test_notify_project_progress(self, mock):
+        info = dict(project_name="test project", n_available_tasks=10)
+        email_addr = ['user@user.com']
+        notify_project_progress(info, email_addr)
+        assert mock.called

--- a/test/test_jobs/test_progress_reminder.py
+++ b/test/test_jobs/test_progress_reminder.py
@@ -16,21 +16,21 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 
-from pybossa.jobs import check_and_send_task_notifications, notify_task_progress
-from default import Test, with_context, flask_app
+from default import Test, db, with_context, flask_app
 from factories import BlogpostFactory
 from factories import TaskRunFactory
 from factories import ProjectFactory
 from factories import UserFactory
 from mock import patch, MagicMock
+from pybossa.jobs import check_and_send_task_notifications, notify_task_progress
 
 queue = MagicMock()
 queue.enqueue.return_value = True
 
-class TestSendProgressReminder(Test):
+class TestSendTaskNorification(Test):
 
     @with_context
-    @patch('pybossa.cache.helpers.n_available_tasks')
+    @patch('pybossa.jobs.n_available_tasks')
     @patch('pybossa.jobs.notify_task_progress')
     def test_remaining_tasks_drop_below_configuration_0(self, notify, n_tasks):
         """Send email if remaining tasks drops below, test with connection"""
@@ -51,7 +51,7 @@ class TestSendProgressReminder(Test):
 
 
     @with_context
-    @patch('pybossa.cache.helpers.n_available_tasks')
+    @patch('pybossa.jobs.n_available_tasks')
     @patch('pybossa.jobs.notify_task_progress')
     def test_remaining_tasks_drop_below_configuration_1(self, notify, n_tasks):
         """Send email if remaining tasks drops below"""
@@ -70,7 +70,7 @@ class TestSendProgressReminder(Test):
 
 
     @with_context
-    @patch('pybossa.cache.helpers.n_available_tasks')
+    @patch('pybossa.jobs.n_available_tasks')
     @patch('pybossa.jobs.notify_task_progress')
     def test_remaining_tasks_drop_below_configuration_2(self, notify, n_tasks):
         """Do not sent multiple email"""
@@ -90,7 +90,7 @@ class TestSendProgressReminder(Test):
 
 
     @with_context
-    @patch('pybossa.cache.helpers.n_available_tasks')
+    @patch('pybossa.jobs.n_available_tasks')
     @patch('pybossa.jobs.notify_task_progress')
     def test_remaining_tasks_do_not_drop_below_configuration(self, notify, n_tasks):
         """Do not send email if #remaining tasks is greater than configuration"""

--- a/test/test_jobs/test_progress_reminder.py
+++ b/test/test_jobs/test_progress_reminder.py
@@ -32,6 +32,27 @@ class TestSendProgressReminder(Test):
     @with_context
     @patch('pybossa.cache.helpers.n_available_tasks')
     @patch('pybossa.jobs.notify_project_progress')
+    def test_remaining_tasks_drop_below_configuration_0(self, notify, n_tasks):
+        """Send email if remaining tasks drops below, test with conn"""
+        n_tasks.return_value = 0
+        reminder = dict(target_remaining=0, sent=False)
+        conn = MagicMock()
+        conn.execute.return_value = None
+        project_id = '1'
+        project = ProjectFactory.create(id=project_id,
+                                        owners_ids=[],
+                                        published=True,
+                                        featured=True,
+                                        info={'progress_reminder':reminder})
+
+        check_and_send_project_progress(project_id)
+        assert notify.called
+        assert project.info['progress_reminder']['sent']
+
+
+    @with_context
+    @patch('pybossa.cache.helpers.n_available_tasks')
+    @patch('pybossa.jobs.notify_project_progress')
     def test_remaining_tasks_drop_below_configuration_1(self, notify, n_tasks):
         """Send email if remaining tasks drops below"""
         n_tasks.return_value = 0

--- a/test/test_view/test_project_progress_reminder.py
+++ b/test/test_view/test_project_progress_reminder.py
@@ -12,13 +12,13 @@ project_repo = ProjectRepository(db)
 user_repo = UserRepository(db)
 
 
-class TestProgressReminderConfig(web.Helper):
+class TestTaskNotificationConfig(web.Helper):
 
     @with_context
     def test_get_configuration(self):
         ''' get correct configuration from project.info'''
         project = ProjectFactory.create(published=True, info={'progress_reminder': {'target_remaining': 5}})
-        url = '/project/%s/tasks/progress-reminder?api_key=%s' % (project.short_name, project.owner.api_key)
+        url = '/project/%s/tasks/task_notification?api_key=%s' % (project.short_name, project.owner.api_key)
         res = self.app.get(url)
         assert res.status_code == 200, res.data
         dom = BeautifulSoup(res.data)
@@ -29,7 +29,7 @@ class TestProgressReminderConfig(web.Helper):
         ''' post correct configuration'''
         project = ProjectFactory.create(published=True)
         task = TaskFactory.create(id=1, project=project)
-        url = '/project/%s/tasks/progress-reminder?api_key=%s' % (project.short_name, project.owner.api_key)
+        url = '/project/%s/tasks/task_notification?api_key=%s' % (project.short_name, project.owner.api_key)
         data = {'remaining': 0}
         res = self.app.post(url, data=data)
         assert project.info['progress_reminder']['target_remaining'] == 0
@@ -40,17 +40,17 @@ class TestProgressReminderConfig(web.Helper):
         ''' should not post to project.info if check fails'''
         project = ProjectFactory.create(published=True)
         task = TaskFactory.create(id=1, project=project)
-        url = '/project/%s/tasks/progress-reminder?api_key=%s' % (project.short_name, project.owner.api_key)
+        url = '/project/%s/tasks/task_notification?api_key=%s' % (project.short_name, project.owner.api_key)
         data = {'remaining': 10}
         res = self.app.post(url, data=data)
         assert not project.info.get('progress_reminder'), project.info
 
     @with_context
     def test_disable_reminder(self):
-        ''' if post emoty value, should disable reminder'''
+        ''' if post empty value, should disable reminder'''
         project = ProjectFactory.create(published=True)
         task = TaskFactory.create(id=1, project=project)
-        url = '/project/%s/tasks/progress-reminder?api_key=%s' % (project.short_name, project.owner.api_key)
+        url = '/project/%s/tasks/task_notification?api_key=%s' % (project.short_name, project.owner.api_key)
         data = {'remaining': None}
         res = self.app.post(url, data=data)
         assert project.info['progress_reminder']['target_remaining'] is None, project.info

--- a/test/test_view/test_project_progress_reminder.py
+++ b/test/test_view/test_project_progress_reminder.py
@@ -1,0 +1,56 @@
+# -*- coding: utf8 -*-
+from bs4 import BeautifulSoup
+import json
+from mock import patch
+
+from default import db, with_context
+from factories import ProjectFactory, TaskFactory
+from helper import web
+from pybossa.repositories import ProjectRepository, UserRepository
+
+project_repo = ProjectRepository(db)
+user_repo = UserRepository(db)
+
+
+class TestProgressReminderConfig(web.Helper):
+
+    @with_context
+    def test_get_configuration(self):
+        ''' get correct configuration from project.info'''
+        project = ProjectFactory.create(published=True, info={'progress_reminder': {'target_remaining': 5}})
+        url = '/project/%s/tasks/progress-reminder?api_key=%s' % (project.short_name, project.owner.api_key)
+        res = self.app.get(url)
+        assert res.status_code == 200, res.data
+        dom = BeautifulSoup(res.data)
+        assert dom.find(id='remaining')['value'] == '5', dom
+
+    @with_context
+    def test_post_reminder(self):
+        ''' post correct configuration'''
+        project = ProjectFactory.create(published=True)
+        task = TaskFactory.create(id=1, project=project)
+        url = '/project/%s/tasks/progress-reminder?api_key=%s' % (project.short_name, project.owner.api_key)
+        data = {'remaining': 0}
+        res = self.app.post(url, data=data)
+        assert project.info['progress_reminder']['target_remaining'] == 0
+        assert not project.info['progress_reminder']['sent'], project.info
+
+    @with_context
+    def test_post_invalid_reminder(self):
+        ''' should not post to project.info if check fails'''
+        project = ProjectFactory.create(published=True)
+        task = TaskFactory.create(id=1, project=project)
+        url = '/project/%s/tasks/progress-reminder?api_key=%s' % (project.short_name, project.owner.api_key)
+        data = {'remaining': 10}
+        res = self.app.post(url, data=data)
+        assert not project.info.get('progress_reminder'), project.info
+
+    @with_context
+    def test_disable_reminder(self):
+        ''' if post emoty value, should disable reminder'''
+        project = ProjectFactory.create(published=True)
+        task = TaskFactory.create(id=1, project=project)
+        url = '/project/%s/tasks/progress-reminder?api_key=%s' % (project.short_name, project.owner.api_key)
+        data = {'remaining': None}
+        res = self.app.post(url, data=data)
+        assert project.info['progress_reminder']['target_remaining'] is None, project.info


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<2835>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-2835

**Describe your changes**
The number remaining tasks will changed by following events: 
- add new tasks
- worker submits tasks
- decrease/increase task redundancy
- delete incomplete tasks

Email should be sent upon there're less than N tasks left incomplete (N is configured by project owner)

Calling `check_and_send_project_progress` in each of events above, `check_and_send_project_progress ` does:
- check if reminder is enabled;
- calculate # remaining tasks;
- send email and mark flag `sent = True` if there're <= N remaining tasks 
- mark `sent = False` if there're more than N remaining tasks

