### PR TITLE
task-notification fix

### DIFF
--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -799,7 +799,10 @@ def import_tasks(project_id, current_user_fullname, from_auto=False, **form_data
         form_data['last_import_meta'] = report.metadata
         project.set_autoimporter(form_data)
         project_repo.save(project)
-    msg = report.message + u' to your project {0} by {1}'.format(project.name, current_user_fullname)
+    msg = report.message + u' to your project {0} by {1}. \
+        If you are expecting task notification, \
+        you may need to re-configure task notification in task setting.'
+        .format(project.name, current_user_fullname)
 
     subject = 'Tasks Import to your project %s' % project.name
     body = 'Hello,\n\n' + msg + '\n\nAll the best,\nThe %s team.'\

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -800,10 +800,10 @@ def import_tasks(project_id, current_user_fullname, from_auto=False, **form_data
         project.set_autoimporter(form_data)
         project_repo.save(project)
     msg = report.message + u' to your project {0} by {1}.'.format(project.name, current_user_fullname)
-    msg += 'If you are expecting task notification, \
+    msg_r = 'If you are expecting task notification, \
             you may need to re-configure task notification in task setting.'
     subject = 'Tasks Import to your project %s' % project.name
-    body = 'Hello,\n\n' + msg + '\n\nAll the best,\nThe %s team.'\
+    body = 'Hello,\n\n' + msg + '\n' + msg_r + '\n\nAll the best,\nThe %s team.'\
         % current_app.config.get('BRAND')
     mail_dict = dict(recipients=recipients, subject=subject, body=body)
     send_mail(mail_dict)

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -799,11 +799,9 @@ def import_tasks(project_id, current_user_fullname, from_auto=False, **form_data
         form_data['last_import_meta'] = report.metadata
         project.set_autoimporter(form_data)
         project_repo.save(project)
-    msg = report.message + u' to your project {0} by {1}. \
-        If you are expecting task notification, \
-        you may need to re-configure task notification in task setting.'
-        .format(project.name, current_user_fullname)
-
+    msg = report.message + u' to your project {0} by {1}.'.format(project.name, current_user_fullname)
+    msg += 'If you are expecting task notification, \
+            you may need to re-configure task notification in task setting.'
     subject = 'Tasks Import to your project %s' % project.name
     body = 'Hello,\n\n' + msg + '\n\nAll the best,\nThe %s team.'\
         % current_app.config.get('BRAND')

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -795,15 +795,14 @@ def import_tasks(project_id, current_user_fullname, from_auto=False, **form_data
         raise
 
     cached_projects.delete_browse_tasks(project_id)
+    check_and_send_task_notifications(project_id)
     if from_auto:
         form_data['last_import_meta'] = report.metadata
         project.set_autoimporter(form_data)
         project_repo.save(project)
     msg = report.message + u' to your project {0} by {1}.'.format(project.name, current_user_fullname)
-    msg_r = 'If you are expecting task notification, \
-            you may need to re-configure task notification in task setting.'
     subject = 'Tasks Import to your project %s' % project.name
-    body = 'Hello,\n\n' + msg + '\n' + msg_r + '\n\nAll the best,\nThe %s team.'\
+    body = 'Hello,\n\n' + msg + '\n\nAll the best,\nThe %s team.'\
         % current_app.config.get('BRAND')
     mail_dict = dict(recipients=recipients, subject=subject, body=body)
     send_mail(mail_dict)

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1032,13 +1032,13 @@ def _import_tasks(project, **form_data):
         flash(report.message)
         if report.total > 0:
             cached_projects.delete_browse_tasks(project.id)
+            check_and_send_task_notifications(project.id)
     else:
         importer_queue.enqueue(import_tasks, project.id, current_user.fullname, **form_data)
         flash(gettext("You're trying to import a large amount of tasks, so please be patient.\
             You will receive an email when the tasks are ready."))
 
     if not report or report.total > 0: #success
-        check_and_send_task_notifications(project.id)
         return redirect_content_type(url_for('.tasks', short_name=project.short_name))
     else:
         return redirect_content_type(url_for('.import_task',

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1001,7 +1001,6 @@ def import_task(short_name):
                 flash(gettext(msg), 'error')
                 current_app.logger.exception(u'project: {} {}'.format(project.short_name, e))
         template_args['template'] = '/projects/importers/%s.html' % importer_type
-        check_and_send_task_notifications(project.id)
         return handle_content_type(template_args)
 
     if request.method == 'GET':
@@ -1039,6 +1038,7 @@ def _import_tasks(project, **form_data):
             You will receive an email when the tasks are ready."))
 
     if not report or report.total > 0: #success
+        check_and_send_task_notifications(project.id)
         return redirect_content_type(url_for('.tasks', short_name=project.short_name))
     else:
         return redirect_content_type(url_for('.import_task',

--- a/test/test_jobs/test_import_tasks.py
+++ b/test/test_jobs/test_import_tasks.py
@@ -46,7 +46,8 @@ class TestImportTasksJob(Test):
         project = ProjectFactory.create()
         form_data = {'type': 'csv', 'csv_url': 'http://google.es'}
         subject = 'Tasks Import to your project %s' % project.name
-        body = 'Hello,\n\n1 new task was imported successfully to your project %s by %s\n\nAll the best,\nThe PYBOSSA team.' % (project.name, uploader_name)
+        body = 'Hello,\n\n1 new task was imported successfully to your project %s by %s.\nIf you are expecting task notification, \
+            you may need to re-configure task notification in task setting.\n\nAll the best,\nThe PYBOSSA team.' % (project.name, uploader_name)
         email_data = dict(recipients=[project.owner.email_addr],
                           subject=subject, body=body)
 

--- a/test/test_jobs/test_import_tasks.py
+++ b/test/test_jobs/test_import_tasks.py
@@ -46,8 +46,7 @@ class TestImportTasksJob(Test):
         project = ProjectFactory.create()
         form_data = {'type': 'csv', 'csv_url': 'http://google.es'}
         subject = 'Tasks Import to your project %s' % project.name
-        body = 'Hello,\n\n1 new task was imported successfully to your project %s by %s.\nIf you are expecting task notification, \
-            you may need to re-configure task notification in task setting.\n\nAll the best,\nThe PYBOSSA team.' % (project.name, uploader_name)
+        body = 'Hello,\n\n1 new task was imported successfully to your project %s by %s.\n\nAll the best,\nThe PYBOSSA team.' % (project.name, uploader_name)
         email_data = dict(recipients=[project.owner.email_addr],
                           subject=subject, body=body)
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<2988>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-2988

**Describe your changes**
Bug issue: 
`import_task` function returns before re-activating task notification.

Additional change: 
For the usecase where task file is too large to import synchronously, importing job is placed in job queue. In this case we are not able to activate task notification synchronously, instead, reactivate after the job is picked up by background worker and executed successfully.