### PR TITLE
RDISCROWD-3077 Import CSV require integers for data_owner, data_source_id

### DIFF
--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -1079,15 +1079,24 @@ def get_user_pref_db_clause(user_pref, user_email=None):
     return user_pref_sql + email_sql if user_email else user_pref_sql
 
 
+def is_int(s):
+    try:
+        return float(str(s)).is_integer()
+    except:
+        return False
+
+
 def validate_required_fields(data):
     invalid_fields = []
     required_fields = current_app.config.get("TASK_REQUIRED_FIELDS", {})
     for field_name, field_info in required_fields.iteritems():
-        field_val = field_info['val']
-        check_val = field_info['check_val']
+        field_val = field_info.get('val')
+        check_val = field_info.get('check_val')
+        int_val = field_info.get('require_int')
         import_data = data.get(field_name)
         if not import_data or \
-            (check_val and import_data not in field_val):
+            (check_val and import_data not in field_val) or \
+            (int_val and ('.' in import_data or not is_int(import_data))):
             invalid_fields.append(field_name)
     return invalid_fields
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -563,40 +563,10 @@ class TestPybossaUtil(Test):
                     assert item in fake_csv[0], err_msg
 
     @with_context
-    def test_csv_validate_required_fields_accept_string(self):
+    def csv_validate_required_fields(self, config, callback):
         """Test validate_required_fields against csv data
-        with data_access, data_source_id (string), data_owner (string).
-        Ignore numeric validation."""
-        patch_dict = {'TASK_REQUIRED_FIELDS': {
-            'data_owner': {'val': None, 'check_val': False},
-            'data_source_id': {'val': None, 'check_val': False}}}
-        with patch.dict(self.flask_app.config, patch_dict):
-            fake_csv = 'line,data_access,data_source_id,data_owner\ntest,"[""L4""]",123,abc'
-            csvreader = csv.reader(fake_csv.splitlines())
-            csviterator = iter(csvreader)
-
-            index = 0
-            for row in csviterator:
-                if index == 0:
-                    # Read csv header.
-                    headers = row
-                else:
-                    # Read csv data and check required fields.
-                    fvals = {headers[idx]: cell for idx, cell in enumerate(row)}
-                    invalid_fields = util.validate_required_fields(fvals)
-                    assert len(invalid_fields) == 0
-                index = index + 1
-
-    @with_context
-    def test_csv_validate_required_fields_accept_numeric(self):
-        """Test validate_required_fields against csv data
-        with data_access, data_source_id (integer), data_owner (integer).
-        Include numeric validation."""
-        patch_dict = {'TASK_REQUIRED_FIELDS': {
-            'data_access': {'val': None, 'check_val': False},
-            'data_owner': {'val': None, 'check_val': False, 'require_int': True},
-            'data_source_id': {'val': None, 'check_val': False, 'require_int': True}}}
-        with patch.dict(self.flask_app.config, patch_dict):
+        with data_access, data_source_id, data_owner."""
+        with patch.dict(self.flask_app.config, config):
             fake_csv = ('line,data_access,data_source_id,data_owner\n'
                 'test,"[""L4""]",123.0,456\n'
                 'test,"[""L4""]",123.6,456\n'
@@ -620,22 +590,64 @@ class TestPybossaUtil(Test):
                     # Read csv data and check required fields.
                     fvals = {headers[idx]: cell for idx, cell in enumerate(row)}
                     invalid_fields = util.validate_required_fields(fvals)
-                    if index < 5:
-                        # data_source_id must be an integer.
-                        assert len(invalid_fields) == 1
-                        assert 'data_source_id' in invalid_fields
-                    elif index < 9:
-                        # data_owner must be an integer.
-                        assert len(invalid_fields) == 1
-                        assert 'data_owner' in invalid_fields
-                    elif index == 9:
-                        # data_access must have a value.
-                        assert len(invalid_fields) == 1
-                        assert 'data_access' in invalid_fields
-                    else:
-                        # data_source_id, data_owner, data_access are valid.
-                        assert len(invalid_fields) == 0
-                index = index + 1
+
+                    # Allow client to assert on result.
+                    callback(index, invalid_fields)
+    @with_context
+    def test_csv_validate_required_fields_accept_string(self):
+        """Test validate_required_fields ignore integer validation."""
+        config = {'TASK_REQUIRED_FIELDS': {
+            'data_access': {'val': None, 'check_val': False},
+            'data_owner': {'val': None, 'check_val': False},
+            'data_source_id': {'val': None, 'check_val': False}}}
+
+        def validate(index, invalid_fields):
+            if index == 4:
+                # data_source_id must have a value.
+                assert len(invalid_fields) == 1
+                assert 'data_source_id' in invalid_fields
+            elif index == 8:
+                # data_owner must have a value.
+                assert len(invalid_fields) == 1
+                assert 'data_owner' in invalid_fields
+            elif index == 9:
+                # data_access must have a value.
+                assert len(invalid_fields) == 1
+                assert 'data_access' in invalid_fields
+            else:
+                # data_source_id, data_owner, data_access are valid.
+                assert len(invalid_fields) == 0
+
+        # Validate csv data.
+        self.csv_validate_required_fields(config, validate)
+
+    @with_context
+    def test_csv_validate_required_fields_accept_integer(self):
+        """Test validate_required_fields include integer validation."""
+        config = {'TASK_REQUIRED_FIELDS': {
+            'data_access': {'val': None, 'check_val': False},
+            'data_owner': {'val': None, 'check_val': False, 'require_int': True},
+            'data_source_id': {'val': None, 'check_val': False, 'require_int': True}}}
+
+        def validate(index, invalid_fields):
+            if index < 5:
+                # data_source_id must be an integer.
+                assert len(invalid_fields) == 1
+                assert 'data_source_id' in invalid_fields
+            elif index < 9:
+                # data_owner must be an integer.
+                assert len(invalid_fields) == 1
+                assert 'data_owner' in invalid_fields
+            elif index == 9:
+                # data_access must have a value.
+                assert len(invalid_fields) == 1
+                assert 'data_access' in invalid_fields
+            else:
+                # data_source_id, data_owner, data_access are valid.
+                assert len(invalid_fields) == 0
+
+        # Validate csv data.
+        self.csv_validate_required_fields(config, validate)
 
     def test_publish_channel_private(self):
         """Test publish_channel private method works."""

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -589,10 +589,9 @@ class TestPybossaUtil(Test):
                 else:
                     # Read csv data and check required fields.
                     fvals = {headers[idx]: cell for idx, cell in enumerate(row)}
-                    invalid_fields = util.validate_required_fields(fvals)
 
                     # Allow client to assert on result.
-                    callback(index, invalid_fields)
+                    callback(index, fvals)
     @with_context
     def test_csv_validate_required_fields_accept_string(self):
         """Test validate_required_fields ignore integer validation."""
@@ -601,7 +600,8 @@ class TestPybossaUtil(Test):
             'data_owner': {'val': None, 'check_val': False},
             'data_source_id': {'val': None, 'check_val': False}}}
 
-        def validate(index, invalid_fields):
+        def validate(index, fvals):
+            invalid_fields = util.validate_required_fields(fvals)
             if index == 4:
                 # data_source_id must have a value.
                 assert len(invalid_fields) == 1
@@ -629,7 +629,8 @@ class TestPybossaUtil(Test):
             'data_owner': {'val': None, 'check_val': False, 'require_int': True},
             'data_source_id': {'val': None, 'check_val': False, 'require_int': True}}}
 
-        def validate(index, invalid_fields):
+        def validate(index, fvals):
+            invalid_fields = util.validate_required_fields(fvals)
             if index < 5:
                 # data_source_id must be an integer.
                 assert len(invalid_fields) == 1

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -581,17 +581,18 @@ class TestPybossaUtil(Test):
             csvreader = csv.reader(fake_csv.splitlines())
             csviterator = iter(csvreader)
 
-            index = 0
-            for row in csviterator:
+            for index, row in enumerate(csviterator):
                 if index == 0:
                     # Read csv header.
                     headers = row
                 else:
                     # Read csv data and check required fields.
                     fvals = {headers[idx]: cell for idx, cell in enumerate(row)}
+                    invalid_fields = util.validate_required_fields(fvals)
 
                     # Allow client to assert on result.
-                    callback(index, fvals)
+                    callback(index, invalid_fields)
+
     @with_context
     def test_csv_validate_required_fields_accept_string(self):
         """Test validate_required_fields ignore integer validation."""
@@ -600,8 +601,7 @@ class TestPybossaUtil(Test):
             'data_owner': {'val': None, 'check_val': False},
             'data_source_id': {'val': None, 'check_val': False}}}
 
-        def validate(index, fvals):
-            invalid_fields = util.validate_required_fields(fvals)
+        def validate(index, invalid_fields):
             if index == 4:
                 # data_source_id must have a value.
                 assert len(invalid_fields) == 1
@@ -629,8 +629,7 @@ class TestPybossaUtil(Test):
             'data_owner': {'val': None, 'check_val': False, 'require_int': True},
             'data_source_id': {'val': None, 'check_val': False, 'require_int': True}}}
 
-        def validate(index, fvals):
-            invalid_fields = util.validate_required_fields(fvals)
+        def validate(index, invalid_fields):
             if index < 5:
                 # data_source_id must be an integer.
                 assert len(invalid_fields) == 1

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -649,6 +649,18 @@ class TestPybossaUtil(Test):
         # Validate csv data.
         self.csv_validate_required_fields(config, validate)
 
+    def test_is_int(self):
+        """Test is_int method."""
+        assert util.is_int(1) is True
+        assert util.is_int('1') is True
+        assert util.is_int(1.0) is True
+        assert util.is_int('1.0') is True
+        assert util.is_int(1.1) is False
+        assert util.is_int('1.1') is False
+        assert util.is_int('a') is False
+        assert util.is_int(None) is False
+        assert util.is_int(True) is False
+
     def test_publish_channel_private(self):
         """Test publish_channel private method works."""
         sentinel = MagicMock()


### PR DESCRIPTION
- Added validation of integers for required fields when importing via CSV, as configured in settings_local.py (`data_owner` and `data_source_id`).
- Prevents values in CSV imports of `123.0`, `abc`, `456.78` when enabled.
- New option `require_int: True` (if omitted, values will not be enforced to be integers).
- Added unit tests.

## Example Configuration Including Integer Validation

```python
TASK_REQUIRED_FIELDS = {
    'data_owner': {'val': None, 'check_val': False, 'require_int': True},
    'data_source_id': {'val': None, 'check_val': False, 'require_int': True}
}
```