### PR TITLE
Fix for required_field_validator on an integer value.

### DIFF
--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -1096,7 +1096,7 @@ def validate_required_fields(data):
         import_data = data.get(field_name)
         if not import_data or \
             (check_val and import_data not in field_val) or \
-            (int_val and ('.' in import_data or not is_int(import_data))):
+            (int_val and ('.' in str(import_data) or not is_int(import_data))):
             invalid_fields.append(field_name)
     return invalid_fields
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -661,6 +661,21 @@ class TestPybossaUtil(Test):
         assert util.is_int(None) is False
         assert util.is_int(True) is False
 
+    @with_context
+    def test_integer_required_cast_string(self):
+        """Test importing an integer (BBDS) with validate_required_fields."""
+        config = {'TASK_REQUIRED_FIELDS': {
+            'data_access': {'val': None, 'check_val': False},
+            'data_owner': {'val': None, 'check_val': False, 'require_int': True},
+            'data_source_id': {'val': None, 'check_val': False, 'require_int': True}}}
+
+        # While csv imports as string values, we explicitly set an integer value.
+        data = {'data_access': "1", 'data_owner': 5, 'data_source_id': '2'}
+
+        with patch.dict(self.flask_app.config, config):
+            invalid_fields = util.validate_required_fields(data)
+            assert len(invalid_fields) == 0
+
     def test_publish_channel_private(self):
         """Test publish_channel private method works."""
         sentinel = MagicMock()


### PR DESCRIPTION
- Added fix for validate_required_fields() when a value is an integer (not a string).
- Added unit test to handle case.

## Resolves the following error

```text
   Traceback (most recent call last):
    /home/____/.local/lib/python2.7/site-packages/nose/case.py line 197 in runTest
      self.test(*self.arg)
    test/default.py line 43 in decorated_function
      return f(*args, **kwargs)
    test/test_util.py line 676 in test_integer_required_cast_string
      invalid_fields = util.validate_required_fields(data)
    pybossa/util.py line 1099 in validate_required_fields
      (int_val and ('.' in import_data or not is_int(import_data))):
   TypeError: argument of type 'int' is not iterable
```

## Successful unit test

```text
Test importing an integer (non-csv) with validate_required_fields. ... passed

---------- coverage: platform linux2, python 2.7.15-final-0 ----------
Coverage HTML written to dir htmlcov
-----------------------------------------------------------------------------
1 test run in 51.934 seconds (1 test passed)
```