### PR TITLE
RDISCROWD-3112 Number of locked tasks for tasks in progress

### DIFF
--- a/pybossa/cache/helpers.py
+++ b/pybossa/cache/helpers.py
@@ -229,3 +229,11 @@ def n_unexpired_gold_tasks(project_id):
     ''')
     result = session.execute(query, dict(project_id=project_id))
     return result.scalar()
+
+
+def n_locked_tasks(project_id):
+    """Return the number of locked tasks in the project."""
+    from pybossa.core import sentinel
+    from pybossa.redis_lock import get_active_user_count
+
+    return get_active_user_count(project_id, sentinel.master)

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -84,7 +84,7 @@ from pybossa.contributions_guard import ContributionsGuard
 from pybossa.default_settings import TIMEOUT
 from pybossa.forms.admin_view_forms import *
 from pybossa.cache.helpers import n_gold_tasks, n_available_tasks, oldest_available_task, n_completed_tasks_by_user
-from pybossa.cache.helpers import n_available_tasks_for_user, latest_submission_task_date
+from pybossa.cache.helpers import n_available_tasks_for_user, latest_submission_task_date, n_locked_tasks
 from pybossa.util import crossdomain
 from pybossa.error import ErrorStatus
 from pybossa.sched import select_task_for_gold_mode
@@ -870,6 +870,7 @@ def details(short_name):
     num_remaining_task_runs = cached_projects.n_remaining_task_runs(project.id)
     num_expected_task_runs = cached_projects.n_expected_task_runs(project.id)
     num_gold_tasks = n_gold_tasks(project.id)
+    num_locked_tasks = n_locked_tasks(project.id)
 
     # all projects require password check
     redirect_to_password = _check_if_redirect_to_password(project)
@@ -896,6 +897,7 @@ def details(short_name):
                      "num_expected_task_runs": num_expected_task_runs,
                      "num_remaining_task_runs": num_remaining_task_runs,
                      "num_gold_tasks": num_gold_tasks,
+                     "num_locked_tasks": num_locked_tasks,
                      "n_volunteers": ps.n_volunteers,
                      "pro_features": pro,
                      "n_available_tasks": num_available_tasks,


### PR DESCRIPTION
- Added number of tasks in progress to the project summary page.

## Screenshots

### Number of tasks in progress

![number-tasks-in-progress](https://user-images.githubusercontent.com/50708624/82672658-a03c4100-9c0e-11ea-8747-99b85122916e.png)

### Animated screenshot

![locked-tasks](https://user-images.githubusercontent.com/50708624/82574737-8b4fa700-9b55-11ea-8ec7-584ef93be639.gif)

Re: https://github.com/bloomberg/pybossa-default-theme/pull/273
