### PR TITLE
RDISCROWD-3031 - default optout L1 projects

### DIFF
--- a/pybossa/data_access.py
+++ b/pybossa/data_access.py
@@ -247,5 +247,7 @@ def valid_user_type_based_data_access(user_type, access_levels):
 @when_data_access()
 def set_default_amp_store(project):
     annotation_config = project['info'].get('annotation_config', {})
-    annotation_config['amp_store'] = True
+    input_data = project['info'].get('input_data') or ''
+    output_data = project['info'].get('output_data') or ''
+    annotation_config['amp_store'] = ('L1' in str(input_data) + str(output_data) == False)
     project['info']['annotation_config'] = annotation_config

--- a/pybossa/data_access.py
+++ b/pybossa/data_access.py
@@ -249,6 +249,7 @@ def set_default_amp_store(project):
     annotation_config = project['info'].get('annotation_config', {})
     input_data = project['info'].get('data_classification', {}).get('input_data') or ''
     output_data = project['info'].get('data_classification', {}).get('output_data') or ''
+    # Set amp_store default to False if 'L1' is in input or output data classifications.
     if 'L1' in (str(input_data) + str(output_data)):
         annotation_config['amp_store'] = False
     else:

--- a/pybossa/data_access.py
+++ b/pybossa/data_access.py
@@ -247,7 +247,10 @@ def valid_user_type_based_data_access(user_type, access_levels):
 @when_data_access()
 def set_default_amp_store(project):
     annotation_config = project['info'].get('annotation_config', {})
-    input_data = project['info'].get('input_data') or ''
-    output_data = project['info'].get('output_data') or ''
-    annotation_config['amp_store'] = ('L1' in str(input_data) + str(output_data) == False)
+    input_data = project['info'].get('data_classification', {}).get('input_data') or ''
+    output_data = project['info'].get('data_classification', {}).get('output_data') or ''
+    if 'L1' in (str(input_data) + str(output_data)):
+        annotation_config['amp_store'] = False
+    else:
+        annotation_config['amp_store'] = True
     project['info']['annotation_config'] = annotation_config

--- a/pybossa/data_access.py
+++ b/pybossa/data_access.py
@@ -250,8 +250,5 @@ def set_default_amp_store(project):
     input_data = project['info'].get('data_classification', {}).get('input_data') or ''
     output_data = project['info'].get('data_classification', {}).get('output_data') or ''
     # Set amp_store default to False if 'L1' is in input or output data classifications.
-    if 'L1' in (str(input_data) + str(output_data)):
-        annotation_config['amp_store'] = False
-    else:
-        annotation_config['amp_store'] = True
+     annotation_config['amp_store'] = False if 'L1' in (str(input_data) + str(output_data)) else True
     project['info']['annotation_config'] = annotation_config

--- a/pybossa/data_access.py
+++ b/pybossa/data_access.py
@@ -250,5 +250,5 @@ def set_default_amp_store(project):
     input_data = project['info'].get('data_classification', {}).get('input_data') or ''
     output_data = project['info'].get('data_classification', {}).get('output_data') or ''
     # Set amp_store default to False if 'L1' is in input or output data classifications.
-     annotation_config['amp_store'] = False if 'L1' in (str(input_data) + str(output_data)) else True
+    annotation_config['amp_store'] = False if 'L1' in (str(input_data) + str(output_data)) else True
     project['info']['annotation_config'] = annotation_config

--- a/pybossa/forms/dynamic_forms.py
+++ b/pybossa/forms/dynamic_forms.py
@@ -32,8 +32,7 @@ def dynamic_project_form(class_type, form_data, data_access_levels, products=Non
 
     if data_access_levels:
         ProjectFormExtraInputs.amp_store = BooleanField(
-            lazy_gettext('Opt in to store annotations on Annotation Management Platform'),
-            render_kw={'checked': True})
+            lazy_gettext('Opt in to store annotations on Annotation Management Platform'))
         ProjectFormExtraInputs.amp_pvf = TextField(
             lazy_gettext('Annotation Store PVF'),
             [validators.Regexp('^([A-Z]{3,4}\s\d+)?$')]) #[validators.Regexp('^$|[A-Z]\s\d')])

--- a/pybossa/forms/dynamic_forms.py
+++ b/pybossa/forms/dynamic_forms.py
@@ -31,12 +31,9 @@ def dynamic_project_form(class_type, form_data, data_access_levels, products=Non
         pass
 
     if data_access_levels:
-        kw={'checked': not obj or obj.amp_store}
-        print(kw)
         ProjectFormExtraInputs.amp_store = BooleanField(
             lazy_gettext('Opt in to store annotations on Annotation Management Platform'),
             render_kw = {'checked': not obj or obj.amp_store})
-            # render_kw={'checked': False if obj and obj.amp_store is False else True})
         ProjectFormExtraInputs.amp_pvf = TextField(
             lazy_gettext('Annotation Store PVF'),
             [validators.Regexp('^([A-Z]{3,4}\s\d+)?$')]) #[validators.Regexp('^$|[A-Z]\s\d')])

--- a/pybossa/forms/dynamic_forms.py
+++ b/pybossa/forms/dynamic_forms.py
@@ -33,7 +33,7 @@ def dynamic_project_form(class_type, form_data, data_access_levels, products=Non
     if data_access_levels:
         ProjectFormExtraInputs.amp_store = BooleanField(
             lazy_gettext('Opt in to store annotations on Annotation Management Platform'),
-            render_kw = {'checked': obj and obj.amp_store})
+            render_kw={'checked': False if obj and obj.amp_store is False else True})
         ProjectFormExtraInputs.amp_pvf = TextField(
             lazy_gettext('Annotation Store PVF'),
             [validators.Regexp('^([A-Z]{3,4}\s\d+)?$')]) #[validators.Regexp('^$|[A-Z]\s\d')])

--- a/pybossa/forms/dynamic_forms.py
+++ b/pybossa/forms/dynamic_forms.py
@@ -32,7 +32,8 @@ def dynamic_project_form(class_type, form_data, data_access_levels, products=Non
 
     if data_access_levels:
         ProjectFormExtraInputs.amp_store = BooleanField(
-            lazy_gettext('Opt in to store annotations on Annotation Management Platform'))
+            lazy_gettext('Opt in to store annotations on Annotation Management Platform'),
+            render_kw = {'checked': obj and obj.amp_store})
         ProjectFormExtraInputs.amp_pvf = TextField(
             lazy_gettext('Annotation Store PVF'),
             [validators.Regexp('^([A-Z]{3,4}\s\d+)?$')]) #[validators.Regexp('^$|[A-Z]\s\d')])

--- a/pybossa/forms/dynamic_forms.py
+++ b/pybossa/forms/dynamic_forms.py
@@ -31,9 +31,12 @@ def dynamic_project_form(class_type, form_data, data_access_levels, products=Non
         pass
 
     if data_access_levels:
+        kw={'checked': not obj or obj.amp_store}
+        print(kw)
         ProjectFormExtraInputs.amp_store = BooleanField(
             lazy_gettext('Opt in to store annotations on Annotation Management Platform'),
-            render_kw={'checked': False if obj and obj.amp_store is False else True})
+            render_kw = {'checked': not obj or obj.amp_store})
+            # render_kw={'checked': False if obj and obj.amp_store is False else True})
         ProjectFormExtraInputs.amp_pvf = TextField(
             lazy_gettext('Annotation Store PVF'),
             [validators.Regexp('^([A-Z]{3,4}\s\d+)?$')]) #[validators.Regexp('^$|[A-Z]\s\d')])

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -486,7 +486,7 @@ class TestProjectAPI(TestAPI):
             info=dict(
                 passwd_hash="hello",
                 task_presenter='taskpresenter',
-                data_classification=dict(input_data="L4 - public", output_data="L4 - public")
+                data_classification=dict(input_data="L1 - internal", output_data="L4 - public")
             ))
         new_project3 = json.dumps(new_project3)
         res = self.app.post('/api/project', headers=headers,


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<3031>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-3031

**Describe your changes**
- add js code to `/update` and `/new` page so that if the user chooses L1 for either input_data_class or ourput_data_class, uncheck opt-in checkbox 
- modify create-project API method so that if the user chooses L1, set opt-in False

Re: https://github.com/bloomberg/pybossa-default-theme/pull/275