### PR TITLE
RDISCROWD-3173: auto-generate new account from BSSO login

### DIFF
--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -24,7 +24,6 @@ from urlparse import urlparse
 from pybossa.util import is_own_url_or_else
 from pybossa.exc.repository import DBIntegrityError
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
-import json
 
 blueprint = Blueprint('bloomberg', __name__)
 
@@ -87,8 +86,9 @@ def handle_bloomberg_response():
             user_data['fullname']   = _u_data['FirstName'][0] + " " + _u_data['LastName'][0]
             user_data['email_addr'] = _u_data['Email'][0]
             user_data['name']       = _u_data['LoginID'][0]
+            user_data['password']   = u"pAssw0rd"
             create_account(user_data)
-            user = user_repo.get_by(email_addr=unicode(_u_data['emailAddress'][0]).lower())
+            user = user_repo.get_by(email_addr=unicode(attributes['emailAddress'][0]).lower())
             return _sign_in_user(user, next_url=request.form.get('RelayState'))
         except DBIntegrityError as dberror:
             print(dberror)

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -88,11 +88,13 @@ def handle_bloomberg_response():
             user_data['name']       = _u_data['LoginID'][0]
             user_data['password']   = u"pAssw0rd"
             create_account(user_data)
-            user = user_repo.get_by(email_addr=unicode(attributes['emailAddress'][0]).lower())
+            user = user_repo.get_by(email_addr=unicode(_u_data['emailAddress'][0]).lower())
             return _sign_in_user(user, next_url=request.form.get('RelayState'))
         except DBIntegrityError as dberror:
             print(dberror)
-            return
+            flash(gettext('There was a problem logging into your account. Please contact a Gigwork administrator'), 'error')
+            return redirect(url_for('home.home'))
         except Exception as ex:
             print(ex)
-            return
+            flash(gettext('We were unable to log you into an account. Please contact a Gigwork administrator.'), 'error')
+            return redirect(url_for('home.home'))

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -21,7 +21,7 @@ from flask_babel import gettext
 from pybossa.core import user_repo, csrf
 from pybossa.view.account import _sign_in_user, create_account
 from urlparse import urlparse
-from pybossa.util import is_own_url_or_else
+from pybossa.util import is_own_url_or_else, generate_password
 from pybossa.exc.repository import DBIntegrityError
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 
@@ -75,10 +75,6 @@ def handle_bloomberg_response():
         attributes = auth.get_attributes()
         user = user_repo.get_by(email_addr=unicode(attributes['emailAddress'][0]).lower())
         return _sign_in_user(user, next_url=request.form.get('RelayState'))
-    elif not auth.is_authenticated:
-        current_app.logger.error('BSSO authentication failed')
-        flash(gettext('Authentication failed.'), 'error')
-        return redirect(url_for('home.home'))
     else:
         attributes = auth.get_attributes()
         user_data = {}
@@ -86,15 +82,11 @@ def handle_bloomberg_response():
             user_data['fullname']   = attributes['FirstName'][0] + " " + attributes['LastName'][0]
             user_data['email_addr'] = attributes['emailAddress'][0]
             user_data['name']       = attributes['LoginID'][0]
-            user_data['password']   = u"pAssw0rd"
+            user_data['password']   = generate_password()
             create_account(user_data)
-            user = user_repo.get_by(email_addr=unicode(attributes['emailAddress'][0]).lower())
+            user = user_repo.get_by(email_addr=unicode(user_data['email_addr'].lower()))
             return _sign_in_user(user, next_url=request.form.get('RelayState'))
-        except DBIntegrityError as dberror:
-            print(dberror)
-            flash(gettext('There was a problem logging into your account. Please contact a Gigwork administrator'), 'error')
-            return redirect(url_for('home.home'))
-        except Exception as ex:
-            print(ex)
+        except Exception as error:
+            current_app.logger.exception('Auto-account creation error: %s', error)
             flash(gettext('We were unable to log you into an account. Please contact a Gigwork administrator.'), 'error')
             return redirect(url_for('home.home'))

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -80,15 +80,15 @@ def handle_bloomberg_response():
         flash(gettext('Authentication failed.'), 'error')
         return redirect(url_for('home.home'))
     else:
-        _u_data = auth.get_attributes()
+        attributes = auth.get_attributes()
         user_data = {}
         try:
-            user_data['fullname']   = _u_data['FirstName'][0] + " " + _u_data['LastName'][0]
-            user_data['email_addr'] = _u_data['Email'][0]
-            user_data['name']       = _u_data['LoginID'][0]
+            user_data['fullname']   = attributes['FirstName'][0] + " " + attributes['LastName'][0]
+            user_data['email_addr'] = attributes['emailAddress'][0]
+            user_data['name']       = attributes['LoginID'][0]
             user_data['password']   = u"pAssw0rd"
             create_account(user_data)
-            user = user_repo.get_by(email_addr=unicode(_u_data['emailAddress'][0]).lower())
+            user = user_repo.get_by(email_addr=unicode(attributes['emailAddress'][0]).lower())
             return _sign_in_user(user, next_url=request.form.get('RelayState'))
         except DBIntegrityError as dberror:
             print(dberror)

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -74,9 +74,7 @@ def handle_bloomberg_response():
         return redirect(url_for('home.home'))
     elif auth.is_authenticated:
         attributes = auth.get_attributes()
-        #WHY IS EMAILADDRESS NOT WORKING?
-        #user = user_repo.get_by(email_addr=unicode(attributes['emailAddress'][0]).lower())
-        user = user_repo.get_by(email_addr=unicode(attributes['Email'][0]).lower())
+        user = user_repo.get_by(email_addr=unicode(attributes['emailAddress'][0]).lower())
         return _sign_in_user(user, next_url=request.form.get('RelayState'))
     elif not auth.is_authenticated:
         current_app.logger.error('BSSO authentication failed')
@@ -90,9 +88,7 @@ def handle_bloomberg_response():
             user_data['email_addr'] = _u_data['Email'][0]
             user_data['name']       = _u_data['LoginID'][0]
             create_account(user_data)
-            #WHY IS EMAILADDRESS NOT WORKING?
-            #user = user_repo.get_by(email_addr=unicode(_u_data['emailAddress'][0]).lower())
-            user = user_repo.get_by(email_addr=u'jdoe1@bloomberg.net')
+            user = user_repo.get_by(email_addr=unicode(_u_data['emailAddress'][0]).lower())
             return _sign_in_user(user, next_url=request.form.get('RelayState'))
         except DBIntegrityError as dberror:
             print(dberror)

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -87,6 +87,6 @@ def handle_bloomberg_response():
             user = user_repo.get_by(email_addr=unicode(user_data['email_addr'].lower()))
             return _sign_in_user(user, next_url=request.form.get('RelayState'))
         except Exception as error:
-            current_app.logger.exception('Auto-account creation error: %s', error)
+            current_app.logger.exception('Auto-account creation error: %s, for user attributes: %s', error, attributes)
             flash(gettext('We were unable to log you into an account. Please contact a Gigwork administrator.'), 'error')
             return redirect(url_for('home.home'))

--- a/test/test_view/test_bloomberg.py
+++ b/test/test_view/test_bloomberg.py
@@ -65,3 +65,13 @@ class TestBloomberg(Test):
         mock_one_login.return_value = mock_auth
         res = self.app.post('/bloomberg/login')
         assert res.status_code == 302, res.status_code
+
+    @with_context
+    @patch('pybossa.view.bloomberg.OneLogin_Saml2_Auth', autospec=True)
+    def test_login_create_account_fail(self, mock_one_login):
+        mock_auth = MagicMock()
+        mock_auth.get_errors.return_value = False
+        mock_auth.is_authenticated.return_value = True
+        mock_one_login.return_value = mock_auth
+        res = self.app.post('/bloomberg/login', content_type='multipart/form-data', data={'UUID': ['1234567'], 'FirstName': ['test'], 'LastName': ['test'], 'PVFLevels': ['PVF_GUTS_3'], 'Email': ['test@bloomberg.net'], 'LoginID': ['test']})
+        assert res.status_code ==302

--- a/test/test_view/test_bloomberg.py
+++ b/test/test_view/test_bloomberg.py
@@ -70,6 +70,22 @@ class TestBloomberg(Test):
     @patch('pybossa.view.account._sign_in_user', autospec=True)
     @patch('pybossa.view.account.create_account', autospec=True)
     @patch('pybossa.view.bloomberg.OneLogin_Saml2_Auth', autospec=True)
+    def test_login_create_account_fail(self, mock_one_login, mock_create_account, mock_sign_in):
+        redirect_url = 'http://localhost'
+        mock_auth = MagicMock()
+        mock_auth.get_errors.return_value = False
+        mock_auth.process_response.return_value = None
+        mock_auth.is_authenticated = False
+        mock_one_login.return_value = mock_auth
+        mock_auth.get_attributes.return_value = {'UUID': [u'1234567'], 'FirstName': [u'test'], 'LastName': [u'test'], 'PVFLevels': [u'PVF_GUTS_3'], 'LoginID': [u'test']}
+        mock_create_account.return_value = None
+        res = self.app.post('/bloomberg/login', method='POST', content_type='multipart/form-data', data={'RelayState': redirect_url})
+        assert res.status_code == 302, res.status_code
+
+    @with_context
+    @patch('pybossa.view.account._sign_in_user', autospec=True)
+    @patch('pybossa.view.account.create_account', autospec=True)
+    @patch('pybossa.view.bloomberg.OneLogin_Saml2_Auth', autospec=True)
     def test_login_create_account_success(self, mock_one_login, mock_create_account, mock_sign_in):
         redirect_url = 'http://localhost'
         mock_auth = MagicMock()


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-3173
https://jira.prod.bloomberg.com/browse/RDISCROWD-3143

**Describe your changes**
I added a conditional to the response handler in bloomberg.py to create a new basic Gigwork account with values return by a successful BSSO if no account exists.

**Testing performed**
I tested for a few different scenarios and confirmed that existing BSSO and login functionality would not be affected.

