### PR TITLE
RDISCROWD-3216: Update auto-create account fields for new BSSO return

### DIFF
--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -83,9 +83,9 @@ def handle_bloomberg_response():
             attributes = auth.get_attributes()
             user_data = {}
             try:
-                user_data['fullname']   = attributes['FirstName'][0] + " " + attributes['LastName'][0]
+                user_data['fullname']   = attributes['firstName'][0] + " " + attributes['lastName'][0]
                 user_data['email_addr'] = attributes['emailAddress'][0]
-                user_data['name']       = attributes['LoginID'][0]
+                user_data['name']       = attributes['username'][0]
                 user_data['password']   = generate_password()
                 create_account(user_data)
                 user = user_repo.get_by(email_addr=unicode(user_data['email_addr'].lower()))

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -81,7 +81,6 @@ def handle_bloomberg_response():
         else:
             # User is authenticated on BSSO, but does not yet have a GIGwork account, auto create one.
             attributes = auth.get_attributes()
-            print(attributes)
             user_data = {}
             try:
                 user_data['fullname']   = attributes['firstName'][0] + " " + attributes['lastName'][0]

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -81,6 +81,7 @@ def handle_bloomberg_response():
         else:
             # User is authenticated on BSSO, but does not yet have a GIGwork account, auto create one.
             attributes = auth.get_attributes()
+            print(attributes)
             user_data = {}
             try:
                 user_data['fullname']   = attributes['firstName'][0] + " " + attributes['lastName'][0]

--- a/test/test_view/test_bloomberg.py
+++ b/test/test_view/test_bloomberg.py
@@ -77,7 +77,7 @@ class TestBloomberg(Test):
         mock_auth.process_response.return_value = None
         mock_auth.is_authenticated = False
         mock_one_login.return_value = mock_auth
-        mock_auth.get_attributes.return_value = {'UUID': [u'1234567'], 'firstName': [u'test'], 'emailAddress': ['test@test.com'], 'lastName': [u'test'], 'PVFLevels': [u'PVF_GUTS_3'], 'username': [u'test']}
+        mock_auth.get_attributes.return_value = {'firstName': [u'test'], 'emailAddress': ['test@test.com'], 'lastName': [u'test'], 'username': [u'test']}
         res = self.app.post('/bloomberg/login', method='POST', content_type='multipart/form-data', data={'RelayState': redirect_url})
         assert mock_create_account.called == False
         assert res.status_code == 302, res.status_code
@@ -92,7 +92,7 @@ class TestBloomberg(Test):
         mock_auth.process_response.return_value = None
         mock_auth.is_authenticated = True 
         mock_one_login.return_value = mock_auth
-        mock_auth.get_attributes.return_value = {'UUID': [u'1234567'], 'firstName': [u'test'], 'lastName': [u'test'], 'PVFLevels': [u'PVF_GUTS_3'], 'emailAddress': [u'test@bloomberg.net'], 'loginID': [u'test']}
+        mock_auth.get_attributes.return_value = {'firstName': [u'test'], 'lastName': [u'test'], 'emailAddress': [u'test@bloomberg.net'], 'username': [u'test']}
         mock_create_account.return_value = None
         res = self.app.post('/bloomberg/login', method='POST', content_type='multipart/form-data', data={'RelayState': redirect_url})
         assert mock_create_account.called
@@ -110,7 +110,7 @@ class TestBloomberg(Test):
         mock_auth.is_authenticated = True
         mock_one_login.return_value = mock_auth
         mock_sign_in.side_effect = Exception()
-        mock_auth.get_attributes.return_value = {'UUID': [u'1234567'], 'FirstName': [u'test'], 'emailAddress': ['test@test.com'], 'LastName': [u'test'], 'PVFLevels': [u'PVF_GUTS_3'], 'LoginID': [u'test']}
+        mock_auth.get_attributes.return_value = {'firstName': [u'test'], 'emailAddress': ['test@test.com'], 'lastName': [u'test'], 'PVFLevels': [u'PVF_GUTS_3'], 'username': [u'test']}
         res = self.app.post('/bloomberg/login', method='POST', content_type='multipart/form-data', data={'RelayState': redirect_url})
-        assert mock_create_account.called == True
+        assert mock_create_account.called 
         assert res.status_code == 302, res.status_code

--- a/test/test_view/test_bloomberg.py
+++ b/test/test_view/test_bloomberg.py
@@ -77,7 +77,7 @@ class TestBloomberg(Test):
         mock_auth.process_response.return_value = None
         mock_auth.is_authenticated = False
         mock_one_login.return_value = mock_auth
-        mock_auth.get_attributes.return_value = {'UUID': [u'1234567'], 'FirstName': [u'test'], 'emailAddress': ['test@test.com'], 'LastName': [u'test'], 'PVFLevels': [u'PVF_GUTS_3'], 'LoginID': [u'test']}
+        mock_auth.get_attributes.return_value = {'UUID': [u'1234567'], 'firstName': [u'test'], 'emailAddress': ['test@test.com'], 'lastName': [u'test'], 'PVFLevels': [u'PVF_GUTS_3'], 'username': [u'test']}
         res = self.app.post('/bloomberg/login', method='POST', content_type='multipart/form-data', data={'RelayState': redirect_url})
         assert mock_create_account.called == False
         assert res.status_code == 302, res.status_code
@@ -92,7 +92,7 @@ class TestBloomberg(Test):
         mock_auth.process_response.return_value = None
         mock_auth.is_authenticated = True 
         mock_one_login.return_value = mock_auth
-        mock_auth.get_attributes.return_value = {'UUID': [u'1234567'], 'FirstName': [u'test'], 'LastName': [u'test'], 'PVFLevels': [u'PVF_GUTS_3'], 'emailAddress': [u'test@bloomberg.net'], 'LoginID': [u'test']}
+        mock_auth.get_attributes.return_value = {'UUID': [u'1234567'], 'firstName': [u'test'], 'lastName': [u'test'], 'PVFLevels': [u'PVF_GUTS_3'], 'emailAddress': [u'test@bloomberg.net'], 'loginID': [u'test']}
         mock_create_account.return_value = None
         res = self.app.post('/bloomberg/login', method='POST', content_type='multipart/form-data', data={'RelayState': redirect_url})
         assert mock_create_account.called


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-3216?filter=-1

**Describe your changes**
I updated the fields used to create new accounts from BSSO login information so that the syntax would match the new return. See DRQS 160388426 for more details on the BSSO update.

**Testing performed**
I updated the mocks to reflect the syntax of the new return and tested the modules locally.
