### PR TITLE
RDISCROWD-3134: Hide Password in Project Settings Password Field

### DIFF
--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -96,7 +96,7 @@ class ProjectCommonForm(Form):
                                     "Short Name is already taken.")),
                             pb_validator.ReservedName('project', current_app)])
 
-    password = TextField(
+    password = PasswordField(
                     lazy_gettext('Password'),
                     [validators.Required(),
                         pb_validator.CheckPasswordStrength(
@@ -139,7 +139,7 @@ class ProjectUpdateForm(ProjectForm):
     category_id = SelectField(lazy_gettext('Category'), coerce=int)
     hidden = BooleanField(lazy_gettext('Hide?'))
     email_notif = BooleanField(lazy_gettext('Email Notifications'))
-    password = TextField(
+    password = PasswordField(
                     lazy_gettext('Password'),
                     [validators.Optional(),
                         pb_validator.CheckPasswordStrength(

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -118,7 +118,7 @@ def signin():
         user = user_repo.search_by_email(email_addr=email_addr)
         if user and user.check_password(password):
             # Check if the user can bypass two-factor authentication.
-            if otp.is_enabled(user.email_addr, current_app.config):
+            '''if otp.is_enabled(user.email_addr, current_app.config):
                 # Enforce two-factor authentication.
                 if not user.enabled:
                     return disable_redirect()
@@ -129,11 +129,11 @@ def signin():
                 return redirect_content_type(url_for('account.otpvalidation',
                                              token=url_token,
                                              next=next_url))
-            else:
-                # Bypass two-factor authentication.
-                msg_1 = gettext('Welcome back') + ' ' + user.fullname
-                flash(msg_1, 'success')
-                return _sign_in_user(user)
+            else:'''
+            # Bypass two-factor authentication.
+            msg_1 = gettext('Welcome back') + ' ' + user.fullname
+            flash(msg_1, 'success')
+            return _sign_in_user(user)
         elif user:
             msg, method = get_user_signup_method(user)
             if method == 'local':

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -118,7 +118,7 @@ def signin():
         user = user_repo.search_by_email(email_addr=email_addr)
         if user and user.check_password(password):
             # Check if the user can bypass two-factor authentication.
-            '''if otp.is_enabled(user.email_addr, current_app.config):
+            if otp.is_enabled(user.email_addr, current_app.config):
                 # Enforce two-factor authentication.
                 if not user.enabled:
                     return disable_redirect()
@@ -129,7 +129,7 @@ def signin():
                 return redirect_content_type(url_for('account.otpvalidation',
                                              token=url_token,
                                              next=next_url))
-            else:'''
+            else:
             # Bypass two-factor authentication.
             msg_1 = gettext('Welcome back') + ' ' + user.fullname
             flash(msg_1, 'success')

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -130,10 +130,10 @@ def signin():
                                              token=url_token,
                                              next=next_url))
             else:
-            # Bypass two-factor authentication.
-            msg_1 = gettext('Welcome back') + ' ' + user.fullname
-            flash(msg_1, 'success')
-            return _sign_in_user(user)
+                # Bypass two-factor authentication.
+                msg_1 = gettext('Welcome back') + ' ' + user.fullname
+                flash(msg_1, 'success')
+                return _sign_in_user(user)
         elif user:
             msg, method = get_user_signup_method(user)
             if method == 'local':


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-3134

**Describe your changes**
The ProjectCommonForm and ProjectUpdateForm passwords were both TextFields instead of Password fields. I changed this and also added type="password" to the render_field in the html for projects/new.html and projects/update.html. 

**Testing performed**
I checked to see that these fields were rendering correctly locally.

***Screenshot***
<img width="926" alt="Screenshot 2020-06-19 at 08 14 30" src="https://user-images.githubusercontent.com/4377042/85131550-0499f280-b205-11ea-822c-56bff4e7cf03.png">

