### PR TITLE
RDISCROWD-3216: BSSO account creation alert

### DIFF
--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -809,6 +809,26 @@ def generate_notification_email_for_admins(user, admins_emails, access_type):
                                   is_qa=is_qa)
     return msg
 
+def generate_bsso_account_notification(user, admins_emails, access_type):
+
+    is_qa = current_app.config.get('IS_QA')
+    server_url = current_app.config.get('SERVER_URL')
+    brand = current_app.config.get('BRAND')
+
+    subject = 'Admin permissions have been granted on {}'.format(brand)
+    msg = dict(subject=subject,
+               recipients=admins_emails)
+    msg['body'] = render_template('/account/email/adminbssonotification.md',
+                                  username=user.fullname,
+                                  access_type=access_type,
+                                  server_url=server_url,
+                                  is_qa=is_qa)
+    msg['html'] = render_template('/account/email/adminbssonotification.html',
+                                  username=user.fullname,
+                                  access_type=access_type,
+                                  server_url=server_url,
+                                  is_qa=is_qa)
+    return msg
 
 def generate_manage_user_email(user, operation):
     assert user

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -810,7 +810,7 @@ def generate_notification_email_for_admins(user, admins_emails, access_type):
     return msg
 
 def generate_bsso_account_notification(user, admins_emails, access_type):
-
+    
     is_qa = current_app.config.get('IS_QA')
     server_url = current_app.config.get('SERVER_URL')
     brand = current_app.config.get('BRAND')

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -815,16 +815,17 @@ def generate_bsso_account_notification(user, admins_emails, access_type):
     server_url = current_app.config.get('SERVER_URL')
     brand = current_app.config.get('BRAND')
 
-    subject = 'Admin permissions have been granted on {}'.format(brand)
+    subject = 'A new account has been created via BSSO for {}'.format(brand)
     msg = dict(subject=subject,
                recipients=admins_emails)
+    fullname = user['fullname']
     msg['body'] = render_template('/account/email/adminbssonotification.md',
-                                  username=user.fullname,
+                                  username=fullname,
                                   access_type=access_type,
                                   server_url=server_url,
                                   is_qa=is_qa)
     msg['html'] = render_template('/account/email/adminbssonotification.html',
-                                  username=user.fullname,
+                                  username=fullname,
                                   access_type=access_type,
                                   server_url=server_url,
                                   is_qa=is_qa)

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -43,6 +43,7 @@ from pybossa.core import signer, uploader, sentinel, newsletter
 from pybossa.util import Pagination, handle_content_type, admin_required
 from pybossa.util import admin_or_subadmin_required
 from pybossa.util import get_user_signup_method, generate_invitation_email_for_new_user
+from pybossa.util import generate_bsso_account_notification
 from pybossa.util import redirect_content_type, is_own_url_or_else
 from pybossa.util import get_avatar_url
 from pybossa.util import can_update_user_info, url_for_app_type
@@ -464,7 +465,7 @@ def confirm_account():
     return redirect(url_for("home.home"))
 
 
-def create_account(user_data, project_slugs=None, ldap_disabled=True):
+def create_account(user_data, project_slugs=None, ldap_disabled=True, autocreate=False):
     new_user = model.user.User(fullname=user_data['fullname'],
                                name=user_data['name'],
                                email_addr=user_data['email_addr'],
@@ -492,6 +493,9 @@ def create_account(user_data, project_slugs=None, ldap_disabled=True):
                      password=user_data['password'])
     msg = generate_invitation_email_for_new_user(user=user_info, project_slugs=project_slugs)
     mail_queue.enqueue(send_mail, msg)
+    if autocreate is True:
+        admin_msg = generate_bsso_account_notification(user=user_info, admins_emails=['tbarrett@bloomberg.net','acianciara@bloomberg.net'], access_type="BSSO")
+        mail_queue.enqueue(send_mail, admin_msg) 
 
 
 def _update_user_with_valid_email(user, email_addr):

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -494,7 +494,7 @@ def create_account(user_data, project_slugs=None, ldap_disabled=True, auto_creat
     msg = generate_invitation_email_for_new_user(user=user_info, project_slugs=project_slugs)
     mail_queue.enqueue(send_mail, msg)
     if auto_create is True:
-        admin_msg = generate_bsso_account_notification(user=user_info, admins_emails=['tbarrett@bloomberg.net','acianciara@bloomberg.net'], access_type="BSSO")
+        admin_msg = generate_bsso_account_notification(user=user_info, admins_emails=['tbarrett@bloomberg.net'], access_type="BSSO")
         mail_queue.enqueue(send_mail, admin_msg) 
 
 

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -465,7 +465,7 @@ def confirm_account():
     return redirect(url_for("home.home"))
 
 
-def create_account(user_data, project_slugs=None, ldap_disabled=True, autocreate=False):
+def create_account(user_data, project_slugs=None, ldap_disabled=True, auto_create=False):
     new_user = model.user.User(fullname=user_data['fullname'],
                                name=user_data['name'],
                                email_addr=user_data['email_addr'],
@@ -493,7 +493,7 @@ def create_account(user_data, project_slugs=None, ldap_disabled=True, autocreate
                      password=user_data['password'])
     msg = generate_invitation_email_for_new_user(user=user_info, project_slugs=project_slugs)
     mail_queue.enqueue(send_mail, msg)
-    if autocreate is True:
+    if auto_create is True:
         admin_msg = generate_bsso_account_notification(user=user_info, admins_emails=['tbarrett@bloomberg.net','acianciara@bloomberg.net'], access_type="BSSO")
         mail_queue.enqueue(send_mail, admin_msg) 
 

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -88,7 +88,7 @@ def handle_bloomberg_response():
                 user_data['email_addr'] = attributes['emailAddress'][0]
                 user_data['name']       = attributes['username'][0]
                 user_data['password']   = generate_password()
-                create_account(user_data)
+                create_account(user_data, autocreate=True)
                 user = user_repo.get_by(email_addr=unicode(user_data['email_addr'].lower()))
                 return _sign_in_user(user, next_url=request.form.get('RelayState'))
             except Exception as error:

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -81,14 +81,13 @@ def handle_bloomberg_response():
             return _sign_in_user(user, next_url=request.form.get('RelayState'))
         else:
             # User is authenticated on BSSO, but does not yet have a GIGwork account, auto create one.
-            attributes = auth.get_attributes()
             user_data = {}
             try:
                 user_data['fullname']   = attributes['firstName'][0] + " " + attributes['lastName'][0]
                 user_data['email_addr'] = attributes['emailAddress'][0]
                 user_data['name']       = attributes['username'][0]
                 user_data['password']   = generate_password()
-                create_account(user_data, autocreate=True)
+                create_account(user_data, auto_create=True)
                 user = user_repo.get_by(email_addr=unicode(user_data['email_addr'].lower()))
                 return _sign_in_user(user, next_url=request.form.get('RelayState'))
             except Exception as error:

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -88,6 +88,7 @@ def handle_bloomberg_response():
                 user_data['name']       = attributes['username'][0]
                 user_data['password']   = generate_password()
                 create_account(user_data, auto_create=True)
+                flash('A new account has been created for you via BSSO.')
                 user = user_repo.get_by(email_addr=unicode(user_data['email_addr'].lower()))
                 return _sign_in_user(user, next_url=request.form.get('RelayState'))
             except Exception as error:

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -88,7 +88,7 @@ def handle_bloomberg_response():
                 user_data['name']       = attributes['username'][0]
                 user_data['password']   = generate_password()
                 create_account(user_data, auto_create=True)
-                flash('A new account has been created for you via BSSO.')
+                flash('A new account has been created for you using BSSO.')
                 user = user_repo.get_by(email_addr=unicode(user_data['email_addr'].lower()))
                 return _sign_in_user(user, next_url=request.form.get('RelayState'))
             except Exception as error:

--- a/test/test_view/test_bloomberg.py
+++ b/test/test_view/test_bloomberg.py
@@ -98,7 +98,7 @@ class TestBloomberg(Test):
         assert res.status_code == 302, res.status_code
         
     @with_context
-    @patch('pybossa.util.generate_bsso_account_notification', autospec=True)
+    @patch('pybossa.view.account.generate_bsso_account_notification', autospec=True)
     @patch('pybossa.view.bloomberg.OneLogin_Saml2_Auth', autospec=True)
     def test_bsso_auto_account_alert(self, mock_one_login, mock_bsso_alert):
         redirect_url = 'http://localhost'
@@ -107,6 +107,7 @@ class TestBloomberg(Test):
         mock_auth.process_response.return_value = None
         mock_auth.is_authenticated = True 
         mock_one_login.return_value = mock_auth
+        mock_bsso_alert.return_value = None
         mock_auth.get_attributes.return_value = {'firstName': [u'test'], 'lastName': [u'test'], 'emailAddress': [u'test@bloomberg.net'], 'username': [u'test']}
         res = self.app.post('/bloomberg/login', method='POST', content_type='multipart/form-data', data={'RelayState': redirect_url})
         assert mock_bsso_alert.called

--- a/test/test_view/test_bloomberg.py
+++ b/test/test_view/test_bloomberg.py
@@ -85,7 +85,7 @@ class TestBloomberg(Test):
     @with_context
     @patch('pybossa.view.bloomberg.create_account', autospec=True)
     @patch('pybossa.view.bloomberg.OneLogin_Saml2_Auth', autospec=True)
-    def test_login_create_account_success(self, mock_one_login, mock_create_accountt ):
+    def test_login_create_account_success(self, mock_one_login, mock_create_account):
         redirect_url = 'http://localhost'
         mock_auth = MagicMock()
         mock_auth.get_errors.return_value = False

--- a/test/test_view/test_bloomberg.py
+++ b/test/test_view/test_bloomberg.py
@@ -112,6 +112,12 @@ class TestBloomberg(Test):
         res = self.app.post('/bloomberg/login', method='POST', content_type='multipart/form-data', data={'RelayState': redirect_url})
         assert mock_bsso_alert.called
         assert res.status_code == 302, res.status_code
+
+    @with_context
+    def test_bsso_msg_generation(self):
+        from pybossa.view.account import generate_bsso_account_notification
+        user = { 'fullname': "test test", "email": "test@test.com"}
+        assert generate_bsso_account_notification(user, "test_admin@test.com", "test") != None
     
     @with_context
     @patch('pybossa.view.bloomberg.create_account', autospec=True)

--- a/test/test_view/test_bloomberg.py
+++ b/test/test_view/test_bloomberg.py
@@ -83,9 +83,10 @@ class TestBloomberg(Test):
         assert res.status_code == 302, res.status_code
 
     @with_context
+    @patch('pybossa.view.account.generate_bsso_account_notification', autospec=True)
     @patch('pybossa.view.bloomberg.create_account', autospec=True)
     @patch('pybossa.view.bloomberg.OneLogin_Saml2_Auth', autospec=True)
-    def test_login_create_account_success(self, mock_one_login, mock_create_account):
+    def test_login_create_account_success(self, mock_one_login, mock_create_account, mock_bsso_alert):
         redirect_url = 'http://localhost'
         mock_auth = MagicMock()
         mock_auth.get_errors.return_value = False
@@ -96,6 +97,7 @@ class TestBloomberg(Test):
         mock_create_account.return_value = None
         res = self.app.post('/bloomberg/login', method='POST', content_type='multipart/form-data', data={'RelayState': redirect_url})
         assert mock_create_account.called
+        assert mock_bsso_alert.called
         assert res.status_code == 302, res.status_code
 
     @with_context

--- a/test/test_view/test_bloomberg.py
+++ b/test/test_view/test_bloomberg.py
@@ -83,10 +83,9 @@ class TestBloomberg(Test):
         assert res.status_code == 302, res.status_code
 
     @with_context
-    @patch('pybossa.view.account.generate_bsso_account_notification', autospec=True)
     @patch('pybossa.view.bloomberg.create_account', autospec=True)
     @patch('pybossa.view.bloomberg.OneLogin_Saml2_Auth', autospec=True)
-    def test_login_create_account_success(self, mock_one_login, mock_create_account, mock_bsso_alert):
+    def test_login_create_account_success(self, mock_one_login, mock_create_accountt ):
         redirect_url = 'http://localhost'
         mock_auth = MagicMock()
         mock_auth.get_errors.return_value = False
@@ -94,11 +93,25 @@ class TestBloomberg(Test):
         mock_auth.is_authenticated = True 
         mock_one_login.return_value = mock_auth
         mock_auth.get_attributes.return_value = {'firstName': [u'test'], 'lastName': [u'test'], 'emailAddress': [u'test@bloomberg.net'], 'username': [u'test']}
-        mock_create_account.return_value = None
         res = self.app.post('/bloomberg/login', method='POST', content_type='multipart/form-data', data={'RelayState': redirect_url})
         assert mock_create_account.called
+        assert res.status_code == 302, res.status_code
+        
+    @with_context
+    @patch('pybossa.view.account.generate_bsso_account_notification', autospec=True)
+    @patch('pybossa.view.bloomberg.OneLogin_Saml2_Auth', autospec=True)
+    def test_bsso_auto_account_alert(self, mock_one_login, mock_bsso_alert):
+        redirect_url = 'http://localhost'
+        mock_auth = MagicMock()
+        mock_auth.get_errors.return_value = False
+        mock_auth.process_response.return_value = None
+        mock_auth.is_authenticated = True 
+        mock_one_login.return_value = mock_auth
+        mock_auth.get_attributes.return_value = {'firstName': [u'test'], 'lastName': [u'test'], 'emailAddress': [u'test@bloomberg.net'], 'username': [u'test']}
+        res = self.app.post('/bloomberg/login', method='POST', content_type='multipart/form-data', data={'RelayState': redirect_url})
         assert mock_bsso_alert.called
         assert res.status_code == 302, res.status_code
+    
 
     @with_context
     @patch('pybossa.view.bloomberg.create_account', autospec=True)

--- a/test/test_view/test_bloomberg.py
+++ b/test/test_view/test_bloomberg.py
@@ -114,8 +114,13 @@ class TestBloomberg(Test):
         assert res.status_code == 302, res.status_code
 
     @with_context
-    def test_bsso_msg_generation(self):
+    @patch('pybossa.view.account.generate_bsso_account_notification', autospec=True)
+    def test_bsso_msg_generation(self, mock_bsso_alert):
         from pybossa.view.account import generate_bsso_account_notification
+        mock_alert = MagicMock() 
+        mock_alert.body = None
+        mock_alert.html = None
+        mock_bsso_alert = mock_alert
         user = { 'fullname': "test test", "email": "test@test.com"}
         assert generate_bsso_account_notification(user, "test_admin@test.com", "test") != None
     

--- a/test/test_view/test_bloomberg.py
+++ b/test/test_view/test_bloomberg.py
@@ -98,7 +98,7 @@ class TestBloomberg(Test):
         assert res.status_code == 302, res.status_code
         
     @with_context
-    @patch('pybossa.view.account.generate_bsso_account_notification', autospec=True)
+    @patch('pybossa.util.generate_bsso_account_notification', autospec=True)
     @patch('pybossa.view.bloomberg.OneLogin_Saml2_Auth', autospec=True)
     def test_bsso_auto_account_alert(self, mock_one_login, mock_bsso_alert):
         redirect_url = 'http://localhost'
@@ -112,7 +112,6 @@ class TestBloomberg(Test):
         assert mock_bsso_alert.called
         assert res.status_code == 302, res.status_code
     
-
     @with_context
     @patch('pybossa.view.bloomberg.create_account', autospec=True)
     @patch('pybossa.view.bloomberg._sign_in_user', autospec=True)    


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-3216

**Describe your changes**
Tim requested that an email be sent to his account when an account is created via the BSSO route, as well as to display a flash message to the user indicating that a new account has been created for them using BSSO. This required adding the conditional to send the message, the message creation function, the message html/md, and the related test.

**Testing performed**
I added a new test and also tested locally.

<img width="866" alt="Screenshot 2020-06-23 at 09 15 46" src="https://user-images.githubusercontent.com/4377042/85445762-bcab0080-b561-11ea-8ad7-7c93d9194937.png">
