### PR TITLE
Manual disable of task from polling

### DIFF
--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -71,7 +71,7 @@ class TaskAPI(APIBase):
             if not gold_task and (n_taskruns >= new.n_answers):
                 new.state = 'completed'
         new.calibration = int(gold_task)
-        new.exported = new.disabled or gold_task
+        new.exported = new.disabled if 'disabled' in new or gold_task
 
     def _preprocess_post_data(self, data):
         project_id = data["project_id"]

--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -71,7 +71,7 @@ class TaskAPI(APIBase):
             if not gold_task and (n_taskruns >= new.n_answers):
                 new.state = 'completed'
         new.calibration = int(gold_task)
-        new.exported = new.disabled if 'disabled' in new or gold_task
+        new.exported = new.disabled if 'disabled' in new else gold_task
 
     def _preprocess_post_data(self, data):
         project_id = data["project_id"]

--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -71,7 +71,7 @@ class TaskAPI(APIBase):
             if not gold_task and (n_taskruns >= new.n_answers):
                 new.state = 'completed'
         new.calibration = int(gold_task)
-        new.exported = gold_task
+        new.exported = new.disabled or gold_task
 
     def _preprocess_post_data(self, data):
         project_id = data["project_id"]


### PR DESCRIPTION
- Use `{"disabled": true}` to disable a task from being polled.
- When updating a task with this attribute, the following value will also be automatically set `"exported": true`

This is a shortcut field to allow manually disabling a task without having to set two fields `{ "gold_answers": 1, "exported": true }`