### PR TITLE
add default data access level

### DIFF
--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -86,6 +86,7 @@ def handle_bloomberg_response():
                 user_data['fullname']   = attributes['firstName'][0] + " " + attributes['lastName'][0]
                 user_data['email_addr'] = attributes['emailAddress'][0]
                 user_data['name']       = attributes['username'][0]
+                user_data['data_access']= "L4"
                 user_data['password']   = generate_password()
                 create_account(user_data, auto_create=True)
                 flash('A new account has been created for you using BSSO.')


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-3216?filter=-1

**Describe your changes**
Bug fix for merged branch RDISCROWD-3216. We needed to pass the data access level at the time of account creation which is required for prod. This is why it was working in dev but failing in prod.

**Testing performed**
Tests pass and I was able to create an account without issue locally.