### PR TITLE
RDISCROWD-3221: Bug fix - data access field type

### DIFF
--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -86,7 +86,7 @@ def handle_bloomberg_response():
                 user_data['fullname']   = attributes['firstName'][0] + " " + attributes['lastName'][0]
                 user_data['email_addr'] = attributes['emailAddress'][0]
                 user_data['name']       = attributes['username'][0]
-                user_data['data_access']= "L2"
+                user_data['data_access']= ["L2"]
                 user_data['password']   = generate_password()
                 create_account(user_data, auto_create=True)
                 flash('A new account has been created for you using BSSO.')

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -86,7 +86,7 @@ def handle_bloomberg_response():
                 user_data['fullname']   = attributes['firstName'][0] + " " + attributes['lastName'][0]
                 user_data['email_addr'] = attributes['emailAddress'][0]
                 user_data['name']       = attributes['username'][0]
-                user_data['data_access']= "L4"
+                user_data['data_access']= "L2"
                 user_data['password']   = generate_password()
                 create_account(user_data, auto_create=True)
                 flash('A new account has been created for you using BSSO.')

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -86,7 +86,7 @@ def handle_bloomberg_response():
                 user_data['fullname']   = attributes['firstName'][0] + " " + attributes['lastName'][0]
                 user_data['email_addr'] = attributes['emailAddress'][0]
                 user_data['name']       = attributes['username'][0]
-                user_data['data_access']= ["L2"]
+                user_data['data_access']= ["L4"]
                 user_data['password']   = generate_password()
                 create_account(user_data, auto_create=True)
                 flash('A new account has been created for you using BSSO.')


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-3221

**Describe your changes**
Changing data type of data access field to list to address the following datatype error (single field being parsed because it's not a list):

flask.app:ERROR:[2020-06-25 13:11:00,845] Auto-account creation error: Invalid access levels L, 4, for user attributes: {'username': ['acianciara'], 'uuid': ['5641377'], 'firstName': ['Anna'], 'lastName': ['Cianciara'], 'firmId': ['9001'], 'emailAddress': ['acianciara@bloomberg.net']} [in /opt/bb/libexec/python-gigwork-env/pybossa/pybossa/view/bloomberg.py:97]

**Testing performed**
Local tests are passing.
