### PR TITLE
Fix bug with project api data access field being checked before creation

### DIFF
--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -68,8 +68,7 @@ class ProjectAPI(APIBase):
             data["description"] = description_from_long_description(desc, long_desc)
         # set default data_access
         if not data.get('info', {}).get("data_access"):
-            if not data.get("info"):
-                data["info"] = {}
+            data["info"] = data.get("info", {})
             # set to least restrictive, will overwrite when saved
             data["info"]["data_access"] = ["L4"]
 

--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -66,6 +66,12 @@ class ProjectAPI(APIBase):
             data["long_description"] = desc
         if not desc:
             data["description"] = description_from_long_description(desc, long_desc)
+        # set default data_access
+        if not data.get('info', {}).get("data_access"):
+            if not data.get("info"):
+                data["info"] = {}
+            # set to least restrictive, will overwrite when saved
+            data["info"]["data_access"] = ["L4"]
 
     def _create_instance_from_request(self, data):
         if 'password' not in data.keys():
@@ -73,9 +79,6 @@ class ProjectAPI(APIBase):
         password = data.pop("password")
         inst = super(ProjectAPI, self)._create_instance_from_request(data)
         inst.set_password(password)
-        if not inst.info.get("data_access"):
-            # set to least restrictive, will overwrite when saved
-            inst.info["data_access"] = ["L4"]
         category_ids = [c.id for c in get_categories()]
         default_category = get_categories()[0]
         inst.category_id = default_category.id

--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -74,8 +74,8 @@ class ProjectAPI(APIBase):
         inst = super(ProjectAPI, self)._create_instance_from_request(data)
         inst.set_password(password)
         if not inst.info.get("data_access"):
-            # set to most restrictive, will overwrite when saved
-            inst.info["data_access"] = ["L1"]
+            # set to least restrictive, will overwrite when saved
+            inst.info["data_access"] = ["L4"]
         category_ids = [c.id for c in get_categories()]
         default_category = get_categories()[0]
         inst.category_id = default_category.id

--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -32,7 +32,7 @@ from pybossa.cache.categories import get_all as get_categories
 from pybossa.util import is_reserved_name, description_from_long_description
 from pybossa.core import auditlog_repo, result_repo, http_signer
 from pybossa.auditlogger import AuditLogger
-from pybossa.data_access import ensure_user_assignment_to_project, set_default_amp_store
+from pybossa.data_access import set_default_amp_store
 
 auditlogger = AuditLogger(auditlog_repo, caller='api')
 
@@ -100,7 +100,6 @@ class ProjectAPI(APIBase):
         if project.short_name and is_reserved_name('project', project.short_name):
             msg = "Project short_name is not valid, as it's used by the system."
             raise ValueError(msg)
-        ensure_user_assignment_to_project(project)
 
     def _log_changes(self, old_project, new_project):
         auditlogger.add_log_entry(old_project, new_project, current_user)

--- a/pybossa/repositories/project_repository.py
+++ b/pybossa/repositories/project_repository.py
@@ -26,7 +26,6 @@ from pybossa.model.category import Category
 from pybossa.exc import WrongObjectError, DBIntegrityError
 from pybossa.cache import projects as cached_projects
 from pybossa.core import uploader
-from pybossa.data_access import ensure_user_assignment_to_project
 from werkzeug.exceptions import BadRequest
 import pandas.io.sql as sqlio
 import pandas as pd
@@ -61,7 +60,6 @@ class ProjectRepository(Repository):
         self._creator_is_owner(project)
         self._verify_has_password(project)
         self._verify_data_classification(project)
-        ensure_user_assignment_to_project(project)
         self._verify_required_fields(project)
         self._verify_product_subproduct(project)
         try:

--- a/pybossa/repositories/project_repository.py
+++ b/pybossa/repositories/project_repository.py
@@ -26,6 +26,7 @@ from pybossa.model.category import Category
 from pybossa.exc import WrongObjectError, DBIntegrityError
 from pybossa.cache import projects as cached_projects
 from pybossa.core import uploader
+from pybossa.data_access import ensure_user_assignment_to_project
 from werkzeug.exceptions import BadRequest
 import pandas.io.sql as sqlio
 import pandas as pd
@@ -60,6 +61,7 @@ class ProjectRepository(Repository):
         self._creator_is_owner(project)
         self._verify_has_password(project)
         self._verify_data_classification(project)
+        ensure_user_assignment_to_project(project)
         self._verify_required_fields(project)
         self._verify_product_subproduct(project)
         try:

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -1808,7 +1808,6 @@ class TestProjectAPI(TestAPI):
         res = self.app.post('/api/project', headers=headers,
                             data=json.dumps(data))
         err = json.loads(res.data)
-        print(err)
         err_msg = "KPI must be value between 0.1 and 120"
         assert err['action'] == 'POST', err_msg
         assert err['status'] == 'failed', err_msg

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -1771,7 +1771,7 @@ class TestProjectAPI(TestAPI):
             long_description="<HTMLTAG>" + ("a" * 300),
             password="exists",
             info=dict(
-                data_classification=dict(input_data="L4 - public", output_data="L4 - public"),
+                data_classification=dict(input_data="L3 - community", output_data="L4 - public"),
                 kpi=1,
                 product="abc",
                 subproduct="def"
@@ -1788,7 +1788,7 @@ class TestProjectAPI(TestAPI):
         assert res_data["description"][-3:] == "..."
         assert res_data["description"].startswith("a")
         # check that data access was set appropriately
-        assert res_data["info"]["data_access"] == ["L4"]
+        assert res_data["info"]["data_access"] == ["L3"]
 
     @with_context
     def test_project_post_kpi_out_of_range(self):

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -1787,7 +1787,13 @@ class TestProjectAPI(TestAPI):
         assert len(res_data["description"]) == 255
         assert res_data["description"][-3:] == "..."
         assert res_data["description"].startswith("a")
+        # check that data access was set appropriately
+        assert res_data["info"]["data_access"] == ["L4"]
 
+    @with_context
+    def test_project_post_kpi_out_of_range(self):
+        user = UserFactory.create()
+        CategoryFactory.create()
         # test create kpi out of range
         headers = [('Authorization', user.api_key)]
         data = dict(
@@ -1802,6 +1808,7 @@ class TestProjectAPI(TestAPI):
         res = self.app.post('/api/project', headers=headers,
                             data=json.dumps(data))
         err = json.loads(res.data)
+        print(err)
         err_msg = "KPI must be value between 0.1 and 120"
         assert err['action'] == 'POST', err_msg
         assert err['status'] == 'failed', err_msg


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-3296*

**Describe your changes**
info.data_access field is created upon saving a project model, but the project api currently tries to check for it before that. This sets a default that lets the api do its check and the correct data_access to be set upon saving.

**Testing performed**
- updated and ran unit tests
- added test to ensure data access is updated correctly

