### PR TITLE
RDISCROWD-3045 Fix Management board statistics error 

### DIFF
--- a/pybossa/cache/site_stats.py
+++ b/pybossa/cache/site_stats.py
@@ -347,12 +347,14 @@ def task_chart():
         AS created_monthly
         FROM task
         GROUP BY created_monthly
-        ORDER BY created_monthly ASC
+        ORDER BY created_monthly DESC
         LIMIT 24;
         ''')
     rows = session.execute(sql).fetchall()
     labels = [date.strftime('%b %Y') for _, date in rows]
     series = [count for count, _ in rows]
+    labels.reverse()
+    series.reverse()
     return dict(labels=labels, series=[series])
 
 
@@ -367,12 +369,14 @@ def submission_chart():
         AS task_run_monthly
         FROM task_run
         GROUP BY task_run_monthly
-        ORDER BY task_run_monthly ASC
+        ORDER BY task_run_monthly DESC
         LIMIT 24;
         ''')
     rows = session.execute(sql).fetchall()
     labels = [date.strftime('%b %Y') for _, date in rows]
     series = [count for count, _ in rows]
+    labels.reverse()
+    series.reverse()
     return dict(labels=labels, series=[series])
 
 

--- a/pybossa/view/admin.py
+++ b/pybossa/view/admin.py
@@ -564,12 +564,14 @@ def management_dashboard():
         DASHBOARD_QUEUE.enqueue(get_management_dashboard_stats, current_user.email_addr)
         return redirect_content_type(url_for('admin.index'))
 
+    # charts
     project_chart = site_stats.project_chart()
     category_chart = site_stats.category_chart()
     task_chart = site_stats.task_chart()
     submission_chart = site_stats.submission_chart()
     current_app.logger.info(task_chart)
 
+    # General platform usage
     timed_stats_funcs = [
         site_stats.number_of_active_jobs,
         site_stats.number_of_created_jobs,
@@ -580,6 +582,7 @@ def management_dashboard():
         site_stats.categories_with_new_projects
     ]
 
+    # Work on platform
     current_stats_funcs = [
         site_stats.avg_task_per_job,
         site_stats.tasks_per_category


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<3045>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-3045

The problem is that monthly data was sorted in ascending order by date, and it selects the first 24 records (2 years), this brings us the *oldest* 24 datapoints.
It should be sorted in descending order by date so we got the latest 24 datapoints instead of oldest 24 datapoints