### PR TITLE
RDISCROWD-3395: Project sync to prod fails due to password error

### DIFF
--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -74,7 +74,10 @@ class ProjectAPI(APIBase):
 
     def _create_instance_from_request(self, data):
         # password required if not syncing
-        sync = "sync" in data["info"]
+        sync_json = data["info"].get("sync", {})
+        # keys added when syncing
+        sync_keys = ("latest_sync", "source_url", "syncer")
+        sync = all(sync_key in sync_json for sync_key in sync_keys)
         password = data.pop("password", "")
         if not (sync or password) or (sync and "passwd_hash" not in data["info"]):
             raise BadRequest("password required")

--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -75,9 +75,9 @@ class ProjectAPI(APIBase):
     def _create_instance_from_request(self, data):
         # password required if not syncing
         sync = "sync" in data["info"]
-        if 'password' not in data.keys() and not sync:
-            raise BadRequest("password required")
         password = data.pop("password", "")
+        if not (sync or password) or (sync and "passwd_hash" not in data["info"]):
+            raise BadRequest("password required")
         inst = super(ProjectAPI, self)._create_instance_from_request(data)
         if not sync:
             # set password if not syncing

--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -73,11 +73,15 @@ class ProjectAPI(APIBase):
             data["info"]["data_access"] = ["L4"]
 
     def _create_instance_from_request(self, data):
-        if 'password' not in data.keys():
+        # password required if not syncing
+        sync = "sync" in data["info"]
+        if 'password' not in data.keys() and not sync:
             raise BadRequest("password required")
-        password = data.pop("password")
+        password = data.pop("password", "")
         inst = super(ProjectAPI, self)._create_instance_from_request(data)
-        inst.set_password(password)
+        if not sync:
+            # set password if not syncing
+            inst.set_password(password)
         category_ids = [c.id for c in get_categories()]
         default_category = get_categories()[0]
         inst.category_id = default_category.id

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -1821,7 +1821,7 @@ class TestProjectAPI(TestAPI):
         # test create kpi out of range
         headers = [('Authorization', user.api_key)]
         data = dict(
-            name=name,
+            name='my-project',
             short_name='my-project',
             description='my-project-description',
             info=dict(

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -1813,3 +1813,29 @@ class TestProjectAPI(TestAPI):
         assert err['status'] == 'failed', err_msg
         assert err['exception_cls'] == "BadRequest", err_msg
         assert res.status_code == 400, err_msg
+
+    @with_context
+    def test_project_post_from_sync(self):
+        user = UserFactory.create()
+        CategoryFactory.create()
+        # test create kpi out of range
+        headers = [('Authorization', user.api_key)]
+        data = dict(
+            name=name,
+            short_name='my-project',
+            description='my-project-description',
+            info=dict(
+                data_classification=dict(input_data="L4 - public", output_data="L4 - public"),
+                kpi=50,
+                sync=dict(latest_sync="latest_sync",
+                      source_url="test.com",
+                      syncer="test@test.com",
+                      enabled=True),
+                passwd_hash = "hashpwd",
+                product="abc",
+                subproduct="def",
+        ))
+        res = self.app.post('/api/project', headers=headers,
+                            data=json.dumps(data))
+        res_data = json.loads(res.data)
+        assert res.status_code == 200

--- a/test/test_syncer/__init__.py
+++ b/test/test_syncer/__init__.py
@@ -18,7 +18,6 @@
 
 import json
 from mock import patch, Mock
-from pybossa.syncer import Syncer
 from default import Test, with_context
 from factories import ProjectFactory
 from nose.tools import assert_raises
@@ -32,6 +31,7 @@ class TestSyncer(Test):
     target_id = 'some_target_id'
 
     def setUp(self):
+        from pybossa.syncer import Syncer
         super(TestSyncer, self).setUp()
         self.syncer = Syncer(self.target_url, self.target_key)
 


### PR DESCRIPTION
Issue number of the reported bug or feature request: #RDISCROWD-3395

**Describe your changes**
- Updated api for projects so password is not required for sync requests. This method was chosen instead of changing the syncer to prevent having to use multiple API queries to sync a new project, since the current API requires one call to create with password and another to replace the passwd_hash. 


**Testing performed**
- Updated and ran unit tests
- Added integration tests between syncer and api
- Couldn't get tests to work on locally running pybossa instance

**Additional Notes**

Test setup change due to issue related to https://github.com/bloomberg/pybossa/pull/505

`http_signer`, similar to `misaka`, isn't made a global variable until the app is setup. This is done as part of the setUp function in a test class. Solution is to move the import until after the app had been initialized.