### PR TITLE
RDISCROWD-2186: removing extra period from timeout warning

### DIFF
--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -299,7 +299,7 @@ def setup_logging(run_as_server=True):
 def setup_login_manager(app):
     """Setup login manager."""
     login_manager.login_view = 'account.signin'
-    login_manager.login_message = u"This feature requires being logged in. If you were previously logged in, your session may have timed out.."
+    login_manager.login_message = u"This feature requires being logged in. If you were previously logged in, your session may have timed out."
 
     @login_manager.user_loader
     def _load_user(username):


### PR DESCRIPTION
Issue number of the reported bug or feature request:  RDISCROWD-2186

**Describe your changes**
- Removed extra period from timeout warning message

**Testing performed**
None, didn't want to wait for a timeout :)

