### PR TITLE
RDISCROWD-3470: AMP PVF to be set as per projects data access levels

### DIFF
--- a/pybossa/forms/dynamic_forms.py
+++ b/pybossa/forms/dynamic_forms.py
@@ -2,6 +2,7 @@ from flask_babel import lazy_gettext
 from flask_wtf import FlaskForm as Form
 from wtforms import SelectField, validators, TextField, BooleanField
 from pybossa.forms.fields.select_two import Select2Field
+from validator import AmpPvfValidator
 
 import wtforms
 
@@ -35,7 +36,7 @@ def dynamic_project_form(class_type, form_data, data_access_levels, products=Non
             lazy_gettext('Opt in to store annotations on Annotation Management Platform'))
         ProjectFormExtraInputs.amp_pvf = TextField(
             lazy_gettext('Annotation Store PVF'),
-            [validators.Regexp('^([A-Z]{3,4}\s\d+)?$')]) #[validators.Regexp('^$|[A-Z]\s\d')])
+            [AmpPvfValidator()])
 
     generate_form = ProjectFormExtraInputs(form_data, obj=obj)
     if data_access_levels and not form_data:

--- a/pybossa/forms/validator.py
+++ b/pybossa/forms/validator.py
@@ -236,3 +236,16 @@ class NotInFutureValidator(object):
     def __call__(self, form, field):
         if field.data > date.today():
             raise ValidationError(self.message)
+
+class AmpPvfValidator(object):
+    """Apply correct pvf as per data access level."""
+    def __init__(self, message=None):
+        if not message:
+            message = lazy_gettext("Invalid PVF.")
+        self.message = message
+        self.pvf_format = re.compile('^([A-Z]{3,4}\s\d+)?$')
+
+    def __call__(self, form, field):
+        amp_pvf = form.amp_pvf.data
+        if amp_pvf and not self.pvf_format.match(amp_pvf):
+            raise ValidationError("Invalid PVF format. Must contain <PVF name> <PVF val>.")

--- a/settings_test.py.tmpl
+++ b/settings_test.py.tmpl
@@ -212,7 +212,9 @@ WIZARD_STEPS = OrderedDict([
 ])
 DATA_CLASSIFICATION = [
     ('L1 - internal', False),
+    ('L1 - internal valid', True),
     ('L2 - propriertary', False),
+    ('L2 - propriertary valid', True),
     ('L3 - community', True),
     ('L4 - public', True)
 ]


### PR DESCRIPTION
With opt-in for annotations to be stored on AMP, Project PVF to be required for projects with data access levels as L1/L2.
For L3, L4 annotations, generic pvf to be configured.