### PR TITLE
RDISCROWD-3584 Add Content-Types to BCOS Upload Python Script

### DIFF
--- a/pybossa/cloud_store_api/s3.py
+++ b/pybossa/cloud_store_api/s3.py
@@ -30,7 +30,9 @@ allowed_mime_types = ['application/pdf',
                       'image/gif',
                       'application/zip',
                       'application/vnd.ms-excel',
-                      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']
+                      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                      'audio/mpeg',
+                      'audio/wav']
 
 
 DEFAULT_CONN = 'S3_DEFAULT'


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-3584*

**Describe your changes**
Added audio/mpeg and audio/wav MIMe type to support uploading mp3 and wav audio in the task presenter

**Testing performed**
Tested locally