### PR TITLE
RDISCROWD-3744: Encrypted task payload

### DIFF
--- a/test/test_view/test_fileproxy.py
+++ b/test/test_view/test_fileproxy.py
@@ -438,3 +438,160 @@ def test_is_file_url():
     assert not is_valid_url('/a/b?offset=1&length=3&task-signature=asdfasdfad')
     assert is_valid_url('/a/b?offset=1&length=2')
     assert is_valid_url('/a/b?offset=1&length=2&task-signature=asdfasdfas')
+
+
+class TestEncryptedPayload(web.Helper):
+
+    app_config = {
+        'VAULT_CONFIG': {
+            'url': 'https://valut.com/{key_id}',
+            'request': {
+                'headers': {'Authorization': 'apikey'}
+            },
+            'response': ['key'],
+            'error': ['error']
+        },
+        'ENCRYPTION_CONFIG_PATH': ['ext_config', 'encryption']
+    }
+
+    @with_context
+    def test_proxy_no_signature(self):
+        project = ProjectFactory.create()
+        owner = project.owner
+
+        task_id = 2020127
+        url = '/fileproxy/encrypted/taskpayload/%s/%s?api_key=%s' \
+             % (project.id, task_id, owner.api_key)
+        res = self.app.get(url, follow_redirects=True)
+        assert res.status_code == 403, res.status_code
+
+    @with_context
+    def test_proxy_no_task(self):
+        project = ProjectFactory.create()
+        owner = project.owner
+
+        task_id = 2020127
+        signature = signer.dumps({'task_id': task_id})
+
+        url = '/fileproxy/encrypted/taskpayload/%s/%s?api_key=%s&task-signature=%s' \
+            % (project.id, task_id, owner.api_key, signature)
+        with patch.dict(self.flask_app.config, self.app_config):
+            res = self.app.get(url, follow_redirects=True)
+            assert res.status_code == 400, res.status_code
+
+    @with_context
+    @patch('pybossa.view.fileproxy.requests.get')
+    def test_proxy_owner(self, http_get):
+        res = MagicMock()
+        res.json.return_value = {'key': 'testkey'}
+        http_get.return_value = res
+
+        project = ProjectFactory.create(info={
+            'ext_config': {
+                'encryption': {'key_id': 123}
+            }
+        })
+
+        encryption_key = 'testkey'
+        aes = AESWithGCM(encryption_key)
+        content = json.dumps(dict(a=1,b="2"))
+        encrypted_content = aes.encrypt(content)
+        task = TaskFactory.create(project=project, info={
+            'private_json__encrypted_payload': encrypted_content
+        })
+        owner = project.owner
+
+        signature = signer.dumps({'task_id': task.id})
+        url = '/fileproxy/encrypted/taskpayload/%s/%s?api_key=%s&task-signature=%s' \
+            % (project.id, task.id, owner.api_key, signature)
+
+        with patch.dict(self.flask_app.config, self.app_config):
+            res = self.app.get(url, follow_redirects=True)
+            assert res.status_code == 200, res.status_code
+            assert res.data == content, res.data
+
+    @with_context
+    @patch('pybossa.view.fileproxy.requests.get')
+    def test_proxy_admin(self, http_get, hdfs_get):
+        res = MagicMock()
+        res.json.return_value = {'key': 'testkey'}
+        http_get.return_value = res
+
+        admin, owner = UserFactory.create_batch(2)
+        project = ProjectFactory.create(owner=owner, info={
+            'ext_config': {
+                'encryption': {'key_id': 123}
+            }
+        })
+
+        encryption_key = 'testkey'
+        aes = AESWithGCM(encryption_key)
+        content = json.dumps(dict(a=1,b="2"))
+        encrypted_content = aes.encrypt(content)
+        task = TaskFactory.create(project=project, info={
+            'private_json__encrypted_payload': encrypted_content
+        })
+
+        signature = signer.dumps({'task_id': task.id})
+        url = '/fileproxy/encrypted/taskpayload/%s/%s?api_key=%s&task-signature=%s' \
+            % (project.id, task.id, admin.api_key, signature)
+
+        with patch.dict(self.flask_app.config, self.app_config):
+            res = self.app.get(url, follow_redirects=True)
+            assert res.status_code == 200, res.status_code
+            assert res.data == content, res.data
+
+    @with_context
+    @patch('pybossa.view.fileproxy.requests.get')
+    def test_empty_response(self, http_get):
+        """Returns empty response with task payload not containing encrypted data."""
+        res = MagicMock()
+        res.json.return_value = {'key': 'testkey'}
+        http_get.return_value = res
+
+        project = ProjectFactory.create(info={
+            'ext_config': {
+                'encryption': {'key_id': 123}
+            }
+        })
+        encryption_key = 'testkey'
+        task = TaskFactory.create(project=project, info={}) # missing private_json__encrypted_payload
+        owner = project.owner
+
+        signature = signer.dumps({'task_id': task.id})
+        url = '/fileproxy/encrypted/taskpayload/%s/%s?api_key=%s&task-signature=%s' \
+            % (project.id, task.id, owner.api_key, signature)
+
+        with patch.dict(self.flask_app.config, self.app_config):
+            res = self.app.get(url, follow_redirects=True)
+            assert res.status_code == 200, res.status_code
+            assert res.data == '', res.data
+
+    @with_context
+    @patch('pybossa.view.fileproxy.requests.get')
+    def test_proxy_key_err(self, http_get):
+        res = MagicMock()
+        res.json.return_value = {'error': 'an error occurred'}
+        http_get.return_value = res
+
+        admin, owner = UserFactory.create_batch(2)
+        project = ProjectFactory.create(owner=owner, info={
+            'ext_config': {
+                'encryption': {'key_id': 123}
+            }
+        })
+        encryption_key = 'testkey'
+        aes = AESWithGCM(encryption_key)
+        content = json.dumps(dict(a=1,b="2"))
+        encrypted_content = aes.encrypt(content)
+        task = TaskFactory.create(project=project, info={
+            'private_json__encrypted_payload': encrypted_content
+        })
+
+        signature = signer.dumps({'task_id': task.id})
+        url = '/fileproxy/encrypted/taskpayload/%s/%s?api_key=%s&task-signature=%s' \
+            % (project.id, task.id, admin.api_key, signature)
+
+        with patch.dict(self.flask_app.config, self.app_config):
+            res = self.app.get(url, follow_redirects=True)
+            assert res.status_code == 500, res.status_code

--- a/test/test_view/test_fileproxy.py
+++ b/test/test_view/test_fileproxy.py
@@ -512,7 +512,7 @@ class TestEncryptedPayload(web.Helper):
 
     @with_context
     @patch('pybossa.view.fileproxy.requests.get')
-    def test_proxy_admin(self, http_get, hdfs_get):
+    def test_proxy_admin(self, http_get):
         res = MagicMock()
         res.json.return_value = {'key': 'testkey'}
         http_get.return_value = res


### PR DESCRIPTION
- task.info can have field named `private_json__encrypted_payload` that contains stringified json payload in encrypted form.
- the encryption key is stored under BPV and BPV id is submitted under project settings.
- when presenting task, client can make call to `/encrypted/taskpayload/<int:project_id>/<int:task_id>`
- encrypted data would be decrypted by this new endpoint taking encryption key from project settings.
- response returned by this new endpoint would contain decrypted stringified json that can be appended to task.info under task presenters onPresentTask