### PR TITLE
Rdiscrowd 3774 Admin Stats Dashboard Not Matching User Report

### DIFF
--- a/pybossa/cache/users.py
+++ b/pybossa/cache/users.py
@@ -383,7 +383,7 @@ def get_users_for_report():
             u.info->'metadata'->'timezone' AS timezone,
             u.info->'metadata'->'user_type' AS type_of_user,
             u.info->'metadata'->'review' AS additional_comments,
-            count(t.id) AS completed_tasks,
+            count(t.id) AS completed_task_runs,
             min(finish_time) AS first_submission_date,
             max(finish_time) AS last_submission_date,
             coalesce(
@@ -402,9 +402,9 @@ def get_users_for_report():
                     additional_comments=row.additional_comments,
                     type_of_user=row.type_of_user, first_submission_date=row.first_submission_date,
                     last_submission_date=row.last_submission_date,
-                    completed_tasks=row.completed_tasks, avg_time_per_task=str(round(row.avg_time_per_task.total_seconds() / 60, 2)),
+                    completed_tasks=row.completed_task_runs, avg_time_per_task=str(round(row.avg_time_per_task.total_seconds() / 60, 2)),
                     total_projects_contributed=n_projects_contributed(row.u_id),
-                    percentage_tasks_completed=round(float(row.completed_tasks) * 100 / n_total_tasks(), 2) if n_total_tasks() else 0,
+                    percentage_tasks_completed=round(float(row.completed_task_runs) * 100 / n_total_tasks(), 2) if n_total_tasks() else 0,
                     consent=row.consent, restrict=row.restrict)
                     for row in results]
     return users_report

--- a/pybossa/cache/users.py
+++ b/pybossa/cache/users.py
@@ -402,7 +402,7 @@ def get_users_for_report():
                     additional_comments=row.additional_comments,
                     type_of_user=row.type_of_user, first_submission_date=row.first_submission_date,
                     last_submission_date=row.last_submission_date,
-                    completed_tasks=row.completed_task_runs, avg_time_per_task=str(round(row.avg_time_per_task.total_seconds() / 60, 2)),
+                    completed_task_runs=row.completed_task_runs, avg_time_per_task=str(round(row.avg_time_per_task.total_seconds() / 60, 2)),
                     total_projects_contributed=n_projects_contributed(row.u_id),
                     percentage_tasks_completed=round(float(row.completed_task_runs) * 100 / n_total_tasks(), 2) if n_total_tasks() else 0,
                     consent=row.consent, restrict=row.restrict)

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -1442,7 +1442,7 @@ def export_all_users(fmt, email_addr):
                              'created', 'admin', 'subadmin', 'enabled', 'languages',
                              'locations', 'work_hours_from', 'work_hours_to',
                              'timezone', 'type_of_user', 'additional_comments',
-                             'total_projects_contributed', 'completed_tasks',
+                             'total_projects_contributed', 'completed_task_runs',
                              'percentage_tasks_completed', 'first_submission_date',
                              'last_submission_date', 'avg_time_per_task', 'consent',
                              'restrict')


### PR DESCRIPTION
Rdiscrowd 3774 Admin Stats Dashboard Not Matching User Report

**Describe your changes**
Changed the column name in the user report from completed_tasks to completed_task_runs

**Testing performed**
ran local gigwork and confirmed that the change was made properly by exporting a user report

**Additional context**
this was a bug fix for an instance where the completed_tasks col on the user report was actually displaying completed_task_runs