### PR TITLE
RDISCROWD-4287 Task Preferences warning message

### DIFF
--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -798,8 +798,11 @@ class UserPrefMetadataForm(Form):
     review = TextAreaField(
         lazy_gettext('Additional comments'), default="")
     profile = TextAreaField(
-        lazy_gettext('Profiles(json format)'), [is_json(dict)], default="",
-        render_kw={"placeholder": '{"finance": 0.5, "english": 0.8}'})
+        lazy_gettext("<div>Task Preferences</div>"
+                     "<div style='color:red; font-weight:normal; font-size:12px;'>"
+                     "Must not include sensitive nor personally identifiable information.</div>"),
+            [is_json(dict)], default="",
+            render_kw={"placeholder": '{"finance": 0.5, "english": 0.8}'})
 
     def __init__(self, *args, **kwargs):
         Form.__init__(self, *args, **kwargs)

--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -800,7 +800,7 @@ class UserPrefMetadataForm(Form):
     profile = TextAreaField(
         lazy_gettext("<div>Task Preferences</div>"
                      "<div style='color:red; font-weight:normal; font-size:12px;'>"
-                     "Must not include sensitive nor personally identifiable information.</div>"),
+                     "Must not include sensitive or personally identifiable information.</div>"),
             [is_json(dict)], default="",
             render_kw={"placeholder": '{"finance": 0.5, "english": 0.8}'})
 


### PR DESCRIPTION
- Added warning message to Task Preferences form field.
- Renamed label from "Profiles(json format)" to "Task Preferences".

## Screenshot

![task-preference-message-1](https://user-images.githubusercontent.com/50708624/118687801-6d05a100-b7d3-11eb-9685-cc171d5cb442.png)
