### PR TITLE
RDISCROWD-4347 Refresh Cache When Updating User Profile Information on Private and Public Platforms

### DIFF
--- a/pybossa/cache/users.py
+++ b/pybossa/cache/users.py
@@ -357,7 +357,6 @@ def get_user_preferences(user_id):
     return get_user_pref_db_clause(user_pref, user_email)
 
 
-@memoize(timeout=ONE_DAY)
 def get_user_filters(user_id):
     user_profile = get_user_profile_metadata(user_id)
     user_profile = json.loads(user_profile) if user_profile else {}

--- a/pybossa/cache/users.py
+++ b/pybossa/cache/users.py
@@ -345,11 +345,9 @@ def get_user_pref_metadata(name):
 
 def delete_user_pref_metadata(user):
     delete_memoized(get_user_pref_metadata, user.name)
-    delete_memoized(get_user_preferences, user.id)
     delete_memoized(get_user_by_id, user.id)
 
 
-@memoize(timeout=ONE_DAY)
 def get_user_preferences(user_id):
     user = get_user_by_id(user_id)
     user_pref = user.user_pref or {} if user else {}

--- a/test/test_cache/test_cache_users.py
+++ b/test/test_cache/test_cache_users.py
@@ -553,6 +553,9 @@ class TestUsersCache(Test):
 
     @with_context
     def test_draft_projects_cached(self):
+        """Test CACHE USERS draft_projects_cached returns an empty list if the user has no
+                draft projects"""
         user = UserFactory.create()
-        result = cached_users.draft_projects(user.id)
-        assert result
+        ProjectFactory.create(owner=user, published=True)
+        draft_projects = cached_users.draft_projects_cached(user.id)
+        assert len(draft_projects) == 0

--- a/test/test_cache/test_cache_users.py
+++ b/test/test_cache/test_cache_users.py
@@ -550,3 +550,9 @@ class TestUsersCache(Test):
         end = None
         task_runs = cached_users.get_tasks_completed_between(user.id, beginning_time_utc=beg, end_time_utc=end)
         assert len(task_runs) == 0
+
+    @with_context
+    def test_draft_projects_cached(self):
+        user = UserFactory.create()
+        result = cached_users.draft_projects(user.id)
+        assert result


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-4347*

**Describe your changes**
When the system selects tasks, the call chain is: [select_contributable_task](https://github.com/bloomberg/pybossa/blob/3da998fcb56489bb3ba9c9e0f42b4fa2faeb10e5/pybossa/sched.py#L378) -> [locked_task_sql](https://github.com/bloomberg/pybossa/blob/3da998fcb56489bb3ba9c9e0f42b4fa2faeb10e5/pybossa/sched.py#L387) -> [get_user_filter](https://github.com/bloomberg/pybossa/blob/3da998fcb56489bb3ba9c9e0f42b4fa2faeb10e5/pybossa/sched.py#L325). get_user_filter is [cached for one day](https://github.com/bloomberg/pybossa/blob/3da998fcb56489bb3ba9c9e0f42b4fa2faeb10e5/pybossa/cache/users.py#L360). When saving a meta, although it [clears the cache](https://github.com/bloomberg/pybossa/blob/3da998fcb56489bb3ba9c9e0f42b4fa2faeb10e5/pybossa/view/account.py#L1147), the [delete_user_pref_metadata](https://github.com/bloomberg/pybossa/blob/3da998fcb56489bb3ba9c9e0f42b4fa2faeb10e5/pybossa/cache/users.py#L346) doesn't clear the cache for get_user_filter function. We can add a call to clear the get_user_filter function in delete_user_pref_metadata, however, it makes more sense to remove the decorator to cache it. Because get_user_filters calls [get_user_profile_metadata](https://github.com/bloomberg/pybossa/blob/3da998fcb56489bb3ba9c9e0f42b4fa2faeb10e5/pybossa/cache/users.py#L362) and get_user_profile_metadata calls [get_user_by_id](https://github.com/bloomberg/pybossa/blob/3da998fcb56489bb3ba9c9e0f42b4fa2faeb10e5/pybossa/cache/users.py#L368) and get_user_by_id is cached already.

**Testing performed**
Tested locally

