### PR TITLE
RDISCROWD-4427 enable API to mark gold task exported=false

### DIFF
--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -71,7 +71,6 @@ class TaskAPI(APIBase):
             if not gold_task and (n_taskruns >= new.n_answers):
                 new.state = 'completed'
         new.calibration = int(gold_task)
-        new.exported = gold_task or new.exported
         current_app.logger.info("Updating task %d, old state: %s, new state: %s, "
                                 "old exported: %s, new exported: %s",
                                 new.id, old.state, new.state,

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -515,6 +515,14 @@ class TestAdmin(web.Helper):
         assert "Current Users with Admin privileges" not in res.data
         err_msg = "User.id=2 should be listed as an admin"
         assert "Juan Jose" not in res.data, err_msg
+
+         # Add user.id=2 disabled user to admin group
+        user = user_repo.get_by(name='juan')
+        user.enabled = False
+        user_repo.update(user)
+        res = self.app.get("/admin/users/add/2", follow_redirects=True)
+        assert "<strong>User account </strong> Juan Jose <strong> is disabled</strong>" in res.data
+
         # Delete a non existant user should return an error
         res = self.app.get("/admin/users/del/5000", follow_redirects=True)
         err = json.loads(res.data)


### PR DESCRIPTION
https://jira.prod.bloomberg.com/browse/RDISCROWD-4427
This is to replay exporting tasks in order to support a valid use case described under 4427 wherein tasks were originally a regular task(but incomplete, hence not added to user buckets) when converted to gold, export task data to user bucket.