### PR TITLE
RDISCROWD-4424 Increase task timeout from 120 to 210.

### DIFF
--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -258,7 +258,7 @@ class TaskPriorityForm(Form):
 
 class TaskTimeoutForm(Form):
     min_seconds = 30
-    max_minutes = 120
+    max_minutes = 210
     minutes = IntegerField(lazy_gettext('Minutes (default 60)'),
                            [validators.NumberRange(
                                 min=0,

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -2360,7 +2360,7 @@ def task_timeout(short_name):
         return redirect_content_type(url_for('.tasks', short_name=project.short_name))
     else:
         if not form.in_range():
-            flash(gettext('Timeout should be between {} seconds and {} minuntes')
+            flash(gettext('Timeout should be between {} seconds and {} minutes')
                           .format(form.min_seconds, form.max_minutes), 'error')
         else:
             flash(gettext('Please correct the errors'), 'error')

--- a/test/test_view/test_project_timeout.py
+++ b/test/test_view/test_project_timeout.py
@@ -72,7 +72,7 @@ class TestProjectTimeout(Helper):
     @with_context
     def test_set_timeout_too_high_seconds(self):
         project = ProjectFactory.create()
-        data = {'minutes': 0, 'seconds': 200 * 60}
+        data = {'minutes': 0, 'seconds': 211 * 60}
         url = '/project/%s/tasks/timeout?api_key=%s' % (project.short_name, project.owner.api_key)
         res = self.app.post(url, data=data)
         assert 'Timeout should be between 30 seconds and 210 minutes' in res.data
@@ -80,7 +80,7 @@ class TestProjectTimeout(Helper):
     @with_context
     def test_set_timeout_too_high_minutes(self):
         project = ProjectFactory.create()
-        data = {'minutes': 200, 'seconds': 0}
+        data = {'minutes': 211, 'seconds': 0}
         url = '/project/%s/tasks/timeout?api_key=%s' % (project.short_name, project.owner.api_key)
         res = self.app.post(url, data=data)
         assert 'Timeout should be between 30 seconds and 210 minutes' in res.data

--- a/test/test_view/test_project_timeout.py
+++ b/test/test_view/test_project_timeout.py
@@ -67,7 +67,7 @@ class TestProjectTimeout(Helper):
         data = {'minutes': 0, 'seconds': 20}
         url = '/project/%s/tasks/timeout?api_key=%s' % (project.short_name, project.owner.api_key)
         res = self.app.post(url, data=data)
-        assert 'Timeout should be between 30 seconds and 120 minuntes' in res.data
+        assert 'Timeout should be between 30 seconds and 210 minutes' in res.data
 
     @with_context
     def test_set_timeout_too_high_seconds(self):
@@ -75,7 +75,7 @@ class TestProjectTimeout(Helper):
         data = {'minutes': 0, 'seconds': 200 * 60}
         url = '/project/%s/tasks/timeout?api_key=%s' % (project.short_name, project.owner.api_key)
         res = self.app.post(url, data=data)
-        assert 'Timeout should be between 30 seconds and 120 minuntes' in res.data
+        assert 'Timeout should be between 30 seconds and 210 minutes' in res.data
 
     @with_context
     def test_set_timeout_too_high_minutes(self):
@@ -83,7 +83,7 @@ class TestProjectTimeout(Helper):
         data = {'minutes': 200, 'seconds': 0}
         url = '/project/%s/tasks/timeout?api_key=%s' % (project.short_name, project.owner.api_key)
         res = self.app.post(url, data=data)
-        assert 'Timeout should be between 30 seconds and 120 minuntes' in res.data
+        assert 'Timeout should be between 30 seconds and 210 minutes' in res.data
 
     @with_context
     def test_set_timeout_invalid(self):


### PR DESCRIPTION
- Increase task timeout from 120 to 210.
- Fixed typo *minuntes* to *minutes*.

## Screenshots

#### Valid range

![timeout-210-1](https://user-images.githubusercontent.com/50708624/124020927-ea1e5b80-d9b8-11eb-9e7d-9af4dcd2488e.png)

#### Invalid range

![timeout-210-2](https://user-images.githubusercontent.com/50708624/124020929-eab6f200-d9b8-11eb-8bdf-2b3cbac084e6.png)

#### Valid range task timeout setting

![timeout-210-4](https://user-images.githubusercontent.com/50708624/124024941-dcb7a000-d9bd-11eb-928f-1fbaf2b289c6.png)

#### Invalid range task timeout setting

![timeout-210-3](https://user-images.githubusercontent.com/50708624/124024984-e6d99e80-d9bd-11eb-9877-9d3fb83aa5fd.png)

## Unit Tests

```text
test_view.test_project_timeout.TestProjectTimeout.test_set_timeout_too_high_minutes ... passed
test_view.test_project_timeout.TestProjectTimeout.test_set_timeout_too_high_seconds ... passed
test_view.test_project_timeout.TestProjectTimeout.test_set_timeout_too_low ... passed
test_view.test_project_timeout.TestProjectTimeout.test_set_timeout_value ... passed

---------- coverage: platform linux2, python 2.7.15-final-0 ----------
Coverage HTML written to dir htmlcov
-----------------------------------------------------------------------------
7 tests run in 147.707 seconds (7 tests passed)
```