### PR TITLE
RDISCROWD-4654 Fix for User Type when Importing Users CSV

### DIFF
--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -482,14 +482,11 @@ def create_account(user_data, project_slugs=None, ldap_disabled=True, auto_creat
     if user_data.get('user_pref'):
         new_user.user_pref = user_data['user_pref']
 
-    if user_data.get('metadata'):
-        new_user.info = dict(metadata=user_data['metadata'])
-        new_user.info['metadata'].update({"user_type": user_data.get('user_type', None),
-       "admin":user_data.get('admin', None)})
-    else:
-        new_user.info = dict(metadata={})
-        new_user.info['metadata'].update({"user_type": user_data.get('user_type', None),
-        "admin":user_data.get('admin', None)})
+    user_metadata = user_data.get('metadata', {})
+    new_user.info = dict(metadata=user_metadata)
+
+    new_user.info['metadata'].update({"user_type": user_metadata.get('user_type', None),
+        "admin": user_data.get('admin', None)})
 
     if ldap_disabled:
         new_user.set_password(user_data['password'])

--- a/test/test_view/test_user_import.py
+++ b/test/test_view/test_user_import.py
@@ -88,7 +88,7 @@ class TestUserImport(web.Helper):
         new_user = user_repo.get_by_name('newuser')
         assert new_user.fullname == 'New User'
         assert new_user.email_addr == 'new@user.com'
-        assert new_user.info['metadata']['user_type'] == None
+        assert new_user.info['metadata']['user_type'] == 'type_a'
 
     @with_context
     @patch('pybossa.forms.forms.app_settings.upref_mdata.get_upref_mdata_choices')

--- a/test/test_view/test_user_import.py
+++ b/test/test_view/test_user_import.py
@@ -23,6 +23,7 @@ from factories import UserFactory
 from helper import web
 from mock import patch
 from pybossa.repositories import UserRepository
+from pybossa.view import account
 
 
 user_repo = UserRepository(db)
@@ -140,3 +141,14 @@ class TestUserImport(web.Helper):
         res = self.app.post(url, follow_redirects=True, content_type='multipart/form-data',
             data={'file': (StringIO(users), 'users.csv')})
         assert 'Missing user_type in metadata' in res.data, res.data
+
+    @with_context
+    def test_get_user_pref_and_metadata_no_form(self):
+        class MockForm():
+            data = {}
+
+        form = MockForm()
+        user_pref, metadata = account.get_user_pref_and_metadata(None, form)
+
+        assert user_pref == {}
+        assert metadata == {}


### PR DESCRIPTION
- Fixed bug on **User Type** when importing users from csv.
  *Changed `user_type` to be read from `user_data.metadata`*

## Example CSV

```csv
name,fullname,email_addr,project_slugs,metadata
Alice.Doe,Alice Doe,alice.doe@null.com,,"{""user_type"": ""Generic Vendor""}"
```