### PR TITLE
RDISCROWD-4747 Allow toggle between browse tasks and task list views.

### DIFF
--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1491,6 +1491,7 @@ def tasks_browse(short_name, page=1, records_per_page=None):
             args["sql_params"] = dict(assign_user=json.dumps({'assign_user': [user_email]}))
             args["display_columns"] = ['task_id', 'priority', 'created']
             args["display_info_columns"] = project.info.get('tasklist_columns', [])
+            args["view"] = view_type
             columns = args["display_info_columns"]
             # default page size for worker view is 100
             per_page = records_per_page if records_per_page in allowed_records_per_page else 100

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1474,7 +1474,8 @@ def tasks_browse(short_name, page=1, records_per_page=None):
 
     try:
         args = parse_tasks_browse_args(request.args)
-        if current_user.subadmin or current_user.admin or current_user.id in project.owners_ids:
+        view_type = request.args.get('view')
+        if view_type != 'tasklist' and (current_user.subadmin or current_user.admin or current_user.id in project.owners_ids):
             # owners and (sub)admin have full access, default size page for owner view is 10
             per_page = records_per_page if records_per_page in allowed_records_per_page else 10
         elif scheduler == Schedulers.task_queue:


### PR DESCRIPTION
- Allow toggle between browse tasks and task list views.

## Screenshot

![tasklist-browse-2](https://user-images.githubusercontent.com/50708624/140814111-4d8b8e3e-bea6-4cdb-9d17-f89e8a0fd3e2.gif)

Re: https://github.com/bloomberg/pybossa-default-theme/pull/329