### PR TITLE
Fix for redis.exceptions.ResponseError: invalid expire time in setex

### DIFF
--- a/pybossa/cache/__init__.py
+++ b/pybossa/cache/__init__.py
@@ -44,6 +44,8 @@ except ImportError:  # pragma: no cover
     REDIS_KEYPREFIX = settings.REDIS_KEYPREFIX
     os.environ['PYBOSSA_REDIS_CACHE_DISABLED'] = '1'
 
+DEFAULT_TIMEOUT = 300
+MIN_TIMEOUT = 1
 ONE_DAY = 24 * 60 * 60
 ONE_HOUR = 60 * 60
 HALF_HOUR = 30 * 60
@@ -114,7 +116,9 @@ def cache(key_prefix, timeout=300, cache_group_keys=None):
 
     """
     if timeout is None:
-        timeout = 300
+        timeout = DEFAULT_TIMEOUT
+    elif timeout < MIN_TIMEOUT:
+        timeout = MIN_TIMEOUT
     def decorator(f):
         @wraps(f)
         def wrapper(*args, **kwargs):
@@ -143,7 +147,9 @@ def memoize(timeout=300, cache_group_keys=None):
 
     """
     if timeout is None:
-        timeout = 300
+        timeout = DEFAULT_TIMEOUT
+    elif timeout < MIN_TIMEOUT:
+        timeout = MIN_TIMEOUT
     def decorator(f):
         @wraps(f)
         def wrapper(*args, **kwargs):
@@ -176,7 +182,9 @@ def memoize_essentials(timeout=300, essentials=None, cache_group_keys=None):
 
     """
     if timeout is None:
-        timeout = 300
+        timeout = DEFAULT_TIMEOUT
+    elif timeout < MIN_TIMEOUT:
+        timeout = MIN_TIMEOUT
     if essentials is None:
         essentials = []
     def decorator(f):

--- a/test/test_cache/__init__.py
+++ b/test/test_cache/__init__.py
@@ -460,7 +460,7 @@ class TestCacheMemoizeFunctions(object):
     def test_cache_min_timeout(self):
         """Test CACHE cache for min timeout value."""
 
-        @cache(key_prefix='my_cached_func', tiemout=0)
+        @cache(key_prefix='my_cached_func', timeout=0)
         def my_func(*args, **kwargs):
             return [args, kwargs]
 

--- a/test/test_cache/__init__.py
+++ b/test/test_cache/__init__.py
@@ -436,3 +436,32 @@ class TestCacheMemoizeFunctions(object):
             return None
         my_func('a')
         assert len(test_sentinel.master.keys()) == 1
+
+    def test_memoized_min_timeout(self):
+        """Test CACHE memoize for min timeout value."""
+
+        @memoize(timeout=0)
+        def my_func(*args, **kwargs):
+            return [args, kwargs]
+        my_func('a')
+        assert len(test_sentinel.master.keys()) == 1
+
+    def test_memoized_essentials_min_timeout(self):
+        """Test CACHE memoize_essentials for min timeout value."""
+
+        @memoize_essentials(timeout=0, essentials=[0])
+        def my_func(*args, **kwargs):
+            return [args, kwargs]
+
+        my_func('a', kwarg='kwarg')
+        assert len(test_sentinel.master.keys()) == 1
+
+    def test_cache_min_timeout(self):
+        """Test CACHE cache for min timeout value."""
+
+        @memoize_essentials(timeout=0, essentials=[0])
+        def my_func(*args, **kwargs):
+            return [args, kwargs]
+
+        my_func('a', kwarg='kwarg')
+        assert len(test_sentinel.master.keys()) == 1

--- a/test/test_cache/__init__.py
+++ b/test/test_cache/__init__.py
@@ -443,6 +443,7 @@ class TestCacheMemoizeFunctions(object):
         @memoize(timeout=0)
         def my_func(*args, **kwargs):
             return [args, kwargs]
+
         my_func('a')
         assert len(test_sentinel.master.keys()) == 1
 
@@ -453,15 +454,15 @@ class TestCacheMemoizeFunctions(object):
         def my_func(*args, **kwargs):
             return [args, kwargs]
 
-        my_func('a', kwarg='kwarg')
+        my_func('a')
         assert len(test_sentinel.master.keys()) == 1
 
     def test_cache_min_timeout(self):
         """Test CACHE cache for min timeout value."""
 
-        @memoize_essentials(timeout=0, essentials=[0])
+        @cache(key_prefix='my_cached_func')
         def my_func(*args, **kwargs):
             return [args, kwargs]
 
-        my_func('a', kwarg='kwarg')
+        my_func('a')
         assert len(test_sentinel.master.keys()) == 1

--- a/test/test_cache/__init__.py
+++ b/test/test_cache/__init__.py
@@ -460,7 +460,7 @@ class TestCacheMemoizeFunctions(object):
     def test_cache_min_timeout(self):
         """Test CACHE cache for min timeout value."""
 
-        @cache(key_prefix='my_cached_func')
+        @cache(key_prefix='my_cached_func', tiemout=0)
         def my_func(*args, **kwargs):
             return [args, kwargs]
 


### PR DESCRIPTION
- Set minimum redis timeout to 1 second.
- Fix for `redis.exceptions.ResponseError` when setting a value of `0` for a cache timeout value.

## To reproduce error

1. Edit default_settings.py and change line 82:
```python
USER_TIMEOUT = 0 #15 * 60
```

### ResponseError: invalid expire time in setex

See also [here](https://serverfault.com/questions/682801/redis-and-invalid-expire-time-in-setex).