### PR TITLE
RDISCROWD-4793 Fix announcements permission to clear cache

### DIFF
--- a/pybossa/api/api_base.py
+++ b/pybossa/api/api_base.py
@@ -107,10 +107,10 @@ class APIBase(MethodView):
     def refresh_cache(self, cls_name, oid):
         """Refresh the cache."""
         if caching.get(cls_name):
-           if cls_name != 'Category' and cls_name != 'Announcement':
-              caching.get(cls_name)['refresh'](oid)
-           else:
-              caching.get(cls_name)['refresh']()
+            if cls_name not in ['Category', 'Announcement']:
+                caching.get(cls_name)['refresh'](oid)
+            else:
+                caching.get(cls_name)['refresh']()
 
     def valid_args(self):
         """Check if the domain object args are valid."""

--- a/pybossa/api/api_base.py
+++ b/pybossa/api/api_base.py
@@ -46,7 +46,8 @@ from pybossa.model import DomainObject, announcement
 from pybossa.model.task import Task
 from pybossa.cache.projects import clean_project
 from pybossa.cache.users import delete_user_summary_id
-from pybossa.cache.categories import reset
+from pybossa.cache.categories import reset as reset_categories
+from pybossa.cache.announcements import reset as reset_announcements
 
 repos = {'Task': {'repo': task_repo, 'filter': 'filter_tasks_by',
                   'get': 'get_task', 'save': 'save', 'update': 'update',
@@ -83,7 +84,8 @@ repos = {'Task': {'repo': task_repo, 'filter': 'filter_tasks_by',
 
 caching = {'Project': {'refresh': clean_project},
            'User': {'refresh': delete_user_summary_id},
-           'Category': {'refresh': reset}}
+           'Category': {'refresh': reset_categories},
+           'Announcement': {'refresh': reset_announcements}}
 
 cors_headers = ['Content-Type', 'Authorization']
 
@@ -105,10 +107,10 @@ class APIBase(MethodView):
     def refresh_cache(self, cls_name, oid):
         """Refresh the cache."""
         if caching.get(cls_name):
-           if cls_name != 'Category':
+           if cls_name != 'Category' and cls_name != 'Announcement':
               caching.get(cls_name)['refresh'](oid)
            else:
-              caching.get(cls_name)['refresh']
+              caching.get(cls_name)['refresh']()
 
     def valid_args(self):
         """Check if the domain object args are valid."""

--- a/pybossa/cache/announcements.py
+++ b/pybossa/cache/announcements.py
@@ -1,7 +1,7 @@
 # -*- coding: utf8 -*-
 # This file is part of PYBOSSA.
 #
-# Copyright (C) 2015 Scifabric LTD.
+# Copyright (C) 2021 Scifabric LTD.
 #
 # PYBOSSA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/pybossa/cache/announcements.py
+++ b/pybossa/cache/announcements.py
@@ -1,0 +1,24 @@
+# -*- coding: utf8 -*-
+# This file is part of PYBOSSA.
+#
+# Copyright (C) 2015 Scifabric LTD.
+#
+# PYBOSSA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PYBOSSA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
+
+from pybossa.cache import delete_memoized
+from pybossa.cache.users import get_announcements_by_level_cached
+
+def reset():
+    """Clean the cache"""
+    delete_memoized(get_announcements_by_level_cached)


### PR DESCRIPTION
- Clear announcements cache when updating an announcement.
- Fixes bug with user-level workers seeing admin-level announcements during cache period of announcement between saves.