### PR TITLE
fix project report and user csv exporting

### DIFF
--- a/pybossa/exporter/csv_export.py
+++ b/pybossa/exporter/csv_export.py
@@ -21,14 +21,13 @@ CSV Exporter module for exporting tasks and tasks results out of PYBOSSA
 """
 
 import tempfile
-from pybossa.exporter import Exporter
-from pybossa.core import uploader, task_repo
-from pybossa.model.task import Task
-from pybossa.model.task_run import TaskRun
-from pybossa.util import UnicodeWriter
+
+import pandas as pd
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
-import pandas as pd
+
+from pybossa.core import uploader
+from pybossa.exporter import Exporter
 
 
 class CsvExporter(Exporter):

--- a/pybossa/exporter/csv_reports_export.py
+++ b/pybossa/exporter/csv_reports_export.py
@@ -16,17 +16,16 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PyBossa.  If not, see <http://www.gnu.org/licenses/>.
 # Cache global variables for timeouts
-import os
 import tempfile
-from pybossa.exporter.csv_export import CsvExporter
-from pybossa.core import project_repo, uploader
-from pybossa.util import UnicodeWriter
+
+import pandas as pd
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
+
 from pybossa.cache.projects import get_project_report_projectdata
 from pybossa.cache.users import get_project_report_userdata
-from pybossa.uploader import local
-from flask import url_for, safe_join, redirect, current_app
+from pybossa.core import project_repo, uploader
+from pybossa.exporter.csv_export import CsvExporter
 
 
 class ProjectReportCsvExporter(CsvExporter):
@@ -41,69 +40,60 @@ class ProjectReportCsvExporter(CsvExporter):
         filename = secure_filename(filename)
         return filename
 
-    def _get_csv(self, out, writer):
-        out.seek(0)
-        yield out.read()
-
-    def _respond_csv(self, ty, id, info_only=False, **kwargs):
-        out = tempfile.TemporaryFile()
-        writer = UnicodeWriter(out)
-        empty_row = []
-        p = project_repo.get(id)
+    def _respond_csv(self, ty, project_id, info_only=False, **kwargs):
+        p = project_repo.get(project_id)
         if p is not None:
-            project_section = ['Project Statistics']
+            project_section = 'Project Statistics'
             project_header = ['Id', 'Name', 'Short Name', 'Total Tasks',
                               'First Task Submission', 'Last Task Submission',
                               'Average Time Spend Per Task', 'Task Redundancy']
-            writer.writerow(project_section)
-            writer.writerow(project_header)
-
 
             # get project data for report
             start_date = kwargs.get("start_date")
             end_date = kwargs.get("end_date")
-            project_data = get_project_report_projectdata(id, start_date, end_date)
-            writer.writerow(project_data)
+            project_data = get_project_report_projectdata(project_id, start_date, end_date)
 
-            writer.writerow(empty_row)
-            user_section = ['User Statistics']
+            project_csv = pd.DataFrame([project_data],
+                                       columns=project_header).to_csv(index=False)
+
+            user_section = 'User Statistics'
             user_header = ['Id', 'Name', 'Fullname', 'Email', 'Admin', 'Subadmin', 'Enabled', 'Languages',
                            'Locations', 'Start Time', 'End Time', 'Timezone', 'Type of User',
                            'Additional Comments', 'Total Tasks Completed', 'Percent Tasks Completed',
                            'First Task Submission', 'Last Task Submission', 'Average Time Per Task']
-            writer.writerow(user_section)
 
             # get user data for report
-            users_project_data = get_project_report_userdata(id, start_date, end_date)
-            if users_project_data:
-                writer.writerow(user_header)
-                for user_data in users_project_data:
-                    writer.writerow(user_data)
+            users_project_data = get_project_report_userdata(project_id, start_date, end_date)
+            if users_project_data and users_project_data[0]:
+                users_csv = pd.DataFrame(users_project_data, columns=user_header).to_csv(index=False)
             else:
-                writer.writerow(['No user data'])
+                users_csv = pd.DataFrame(columns=user_header).to_csv(index=False)
 
-            return self._get_csv(out, writer)
+            csv_txt = f'{project_section}\n{project_csv}\n{user_section}\n{users_csv}'
+
+            return csv_txt
 
     def _make_zip(self, project, ty, **kwargs):
         name = self._project_name_latin_encoded(project)
-        csv_task_generator = self._respond_csv(ty, project.id, **kwargs)
+        csv_task_generator = self._respond_csv(ty, project.id)
         if csv_task_generator is not None:
-            with tempfile.NamedTemporaryFile() as datafile, \
-                 tempfile.NamedTemporaryFile(delete=False) as zipped_datafile:
+            datafile = tempfile.NamedTemporaryFile()
+            try:
+                datafile.write(str(csv_task_generator).encode('utf-8'))
+                datafile.flush()
+                zipped_datafile = tempfile.NamedTemporaryFile()
                 try:
-                    for line in csv_task_generator:
-                        datafile.write(str(line).encode())  # write() accepts bytes only
-                    datafile.flush()
-                    csv_task_generator.close()  # delete temp csv file
                     _zip = self._zip_factory(zipped_datafile.name)
                     _zip.write(
                         datafile.name,
                         secure_filename('%s_%s.csv' % (name, ty)))
                     _zip.close()
-                    return dict(filepath=zipped_datafile.name,
-                                filename=self.download_name(project, ty),
-                                delete=True)
-                except Exception:
-                    if os.path.exists(zipped_datafile.name):
-                        os.remove(zipped_datafile.name)
-                    raise
+                    container = "user_%d" % project.owner_id
+                    _file = FileStorage(
+                        filename=self.download_name(project, ty),
+                        stream=zipped_datafile)
+                    uploader.upload_file(_file, container=container)
+                finally:
+                    zipped_datafile.close()
+            finally:
+                datafile.close()

--- a/pybossa/exporter/project_csv_export.py
+++ b/pybossa/exporter/project_csv_export.py
@@ -21,13 +21,11 @@ CSV Exporter module for exporting tasks and tasks results out of PyBossa
 """
 
 import tempfile
-from pybossa.exporter.csv_export import CsvExporter
-from pybossa.core import project_repo, user_repo
-from werkzeug.datastructures import FileStorage
+
 from werkzeug.utils import secure_filename
-from pybossa.cache.helpers import n_available_tasks
-import pandas as pd
-from collections import OrderedDict
+
+from pybossa.core import project_repo
+from pybossa.exporter.csv_export import CsvExporter
 
 
 class ProjectCsvExporter(CsvExporter):

--- a/pybossa/exporter/task_csv_export.py
+++ b/pybossa/exporter/task_csv_export.py
@@ -17,15 +17,18 @@
 # along with PyBossa.  If not, see <http://www.gnu.org/licenses/>.
 # Cache global variables for timeouts
 
-import tempfile
 import json
-from flask import url_for, send_file, redirect
-from pybossa.uploader import local
+import tempfile
+
+from flask import send_file
+from werkzeug.utils import safe_join
+
+from pybossa.core import uploader
 from pybossa.exporter.csv_export import CsvExporter
-from pybossa.core import uploader, task_repo
+from pybossa.uploader import local
 from pybossa.util import UnicodeWriter
 from .export_helpers import browse_tasks_export
-from werkzeug.utils import safe_join
+
 
 class TaskCsvExporter(CsvExporter):
     """CSV Exporter for exporting ``Task``s and ``TaskRun``s

--- a/pybossa/exporter/task_json_export.py
+++ b/pybossa/exporter/task_json_export.py
@@ -18,10 +18,13 @@
 # Cache global variables for timeouts
 
 import json
-from flask import url_for, safe_join, send_file, redirect
+
+from flask import send_file
+from werkzeug.utils import safe_join
+
 from pybossa.core import uploader, task_repo
-from pybossa.uploader import local
 from pybossa.exporter.json_export import JsonExporter
+from pybossa.uploader import local
 from .export_helpers import browse_tasks_export, browse_tasks_export_count
 
 TASK_GOLD_FIELDS = [
@@ -165,7 +168,7 @@ class TaskJsonExporter(JsonExporter):
         self._make_zip(project, ty, expanded)
         if isinstance(uploader, local.LocalUploader):
             filepath = self._download_path(project)
-            res = send_file(filename_or_fp=safe_join(filepath, filename),
+            res = send_file(path_or_file=safe_join(filepath, filename),
                             mimetype='application/octet-stream',
                             as_attachment=True,
                             attachment_filename=filename)

--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -34,7 +34,7 @@ from pybossa import util
 from pybossa.core import project_repo, user_repo, task_repo
 from pybossa.core import uploader
 from pybossa.uploader import local
-from flask import safe_join
+from werkzeug.utils import safe_join
 from flask_login import current_user
 import os
 import json

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -16,44 +16,43 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 """Module with PyBossa utils."""
-from collections import OrderedDict
-from datetime import timedelta, datetime, date
-from yacryptopan import CryptoPAn
-from functools import update_wrapper
-from tempfile import NamedTemporaryFile
-from flask_wtf import FlaskForm as Form
-import csv
-import codecs
-import io
-import dateutil.tz
-from flask import abort, request, make_response, current_app, url_for
-from flask import redirect, render_template, jsonify, get_flashed_messages
-from flask_wtf.csrf import generate_csrf
-import dateutil.parser
-from functools import wraps
-from flask_login import current_user
-from sqlalchemy import text
-from sqlalchemy.exc import ProgrammingError
-from math import ceil
-import json
 import base64
+import codecs
+import csv
 import hashlib
 import hmac
-import random
-import simplejson
-import time
-from flask_babel import lazy_gettext
-import re
+import io
+import json
 import os
-from werkzeug.utils import secure_filename
-from flask import safe_join
-from pybossa.cloud_store_api.s3 import s3_upload_file_storage
-from pybossa.cloud_store_api.connection import create_connection
-from pybossa.uploader import local
-from pybossa.cloud_store_api.s3 import get_file_from_s3, delete_file_from_s3
+import random
+import re
+import time
+from collections import OrderedDict
+from datetime import timedelta, datetime, date
+from functools import update_wrapper
+from functools import wraps
+from math import ceil
+from tempfile import NamedTemporaryFile
 
+import dateutil.parser
+import dateutil.tz
+import simplejson
+from flask import abort, request, make_response, current_app, url_for
+from flask import redirect, render_template, jsonify, get_flashed_messages
+from flask_babel import lazy_gettext
+from flask_login import current_user
 # Markdown support
 from flask_misaka import Misaka
+from flask_wtf import FlaskForm as Form
+from flask_wtf.csrf import generate_csrf
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+from yacryptopan import CryptoPAn
+
+from pybossa.cloud_store_api.connection import create_connection
+from pybossa.cloud_store_api.s3 import get_file_from_s3, delete_file_from_s3
+from pybossa.cloud_store_api.s3 import s3_upload_file_storage
+
 misaka = Misaka()
 
 def last_flashed_message():
@@ -88,7 +87,6 @@ def hash_last_flash_message():
 
 def handle_content_type(data):
     """Return HTML or JSON based on request type."""
-    from pybossa.model.project import Project
     if (request.headers.get('Content-Type') == 'application/json' or
         request.args.get('response_format') == 'json'):
         message_and_status = last_flashed_message()
@@ -1191,7 +1189,6 @@ def description_from_long_description(desc, long_desc):
 
 
 def generate_bsso_account_notification(user):
-    from pybossa.core import user_repo
     warning = False if user.get('metadata', {}).get('user_type') else True
     template_type = 'adminbssowarning' if warning else 'adminbssonotification'
     admins_email_list = current_app.config.get('ALERT_LIST',[])

--- a/test/test_project_report.py
+++ b/test/test_project_report.py
@@ -64,20 +64,15 @@ class TestProjectReport(web.Helper):
         assert res.status_code == 200, res.data
 
     @with_context
-    @patch.object(exporter.os, 'remove')
-    def test_project_report_cleanup_on_error(self, mock_os_remove):
-        def _new_get_csv(*args, **kwargs):
-            yield ''
-            raise Exception('test')
+    def test_project_report_cleanup_on_error(self):
         self.register()
         self.signin()
         user = user_repo.get(1)
         project = ProjectFactory.create(owner=user)
         prce = ProjectReportCsvExporter()
-        with patch.object(prce, '_get_csv', _new_get_csv):
+        with patch.object(prce, '_respond_csv', side_effect=Exception('a')):
             with assert_raises(Exception):
                 prce._make_zip(project, None)
-        assert mock_os_remove.called
 
     @with_context
     def test_project_report_date_range_data(self):


### PR DESCRIPTION
I used pandas to do CSV export instead of using "UnicodeWriter" in the util.py. The "UnicodeWriter" is difficult to maintain and work right in Python3. Also using Pandas, the code is conciser. Now, the only place still using "UnicodeWriter" is the tasks exporting. There is some work to get rid of "UnicodeWriter" for task exporting, so I just leave there. But I have tested and made changes to make sure the export works (verify the file in temp path).
