### PR TITLE
RDISCROWD-4850 Change to use psycopg2 2.8.6 version

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -23,9 +23,6 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
-      - run: |
-          echo "::remove-matcher owner=python::"
-
       - name: Checkout repository and submodules recursively
         uses: actions/checkout@v2
         with:
@@ -68,6 +65,7 @@ jobs:
 
       - name: Run unit test
         run: |
+          echo "::remove-matcher owner=python::"
           ./run_tests
 
       - name: Run code coverage

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -23,6 +23,9 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
+      - run: |
+          echo "::remove-matcher owner=python::"
+
       - name: Checkout repository and submodules recursively
         uses: actions/checkout@v2
         with:
@@ -36,7 +39,7 @@ jobs:
       - name: Pre installation
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y libxml2-dev libxmlsec1-dev libsasl2-dev libldap2-dev libssl-dev libkrb5-dev redis-server redis-tools postgresql-client
+          sudo apt-get install -y libxml2-dev libxmlsec1-dev libsasl2-dev libldap2-dev libssl-dev libkrb5-dev libpq-dev redis-server redis-tools postgresql-client
           redis-server --version
           redis-server contrib/redis/sentinel.conf --sentinel
           cd pybossa && ln -s themes/default/translations && cd ..

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ requirements = [
     "Pillow==8.3.2",
     "prettytable==2.2.1",
     "protobuf==3.18.0",
-    "psycopg2-binary==2.9.1",
+    "psycopg2==2.8.6",
     "pyasn1==0.4.8",
     "pyasn1-modules==0.2.8",
     "pybossa-onesignal==1.1",


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-4850*

**Describe your changes**
- change psycopg2-binary to psycopg2 per [recommendation](https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary). Also downgrade the version to make consistent.
- Github Actions to change to disable annotations alert.

**Testing performed**
Tested locally
