### PR TITLE
RDISCROWD-4878 Task browse bulk edit state not updating

### DIFF
--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1814,6 +1814,10 @@ def bulk_update_assign_worker(short_name):
             if task_id is not None:
                 t = task_repo.get_task_by(project_id=project.id,
                                         id=int(task_id))
+                is_gold_task = bool(t.gold_answers)
+                # continue to allow users to be assigned to gold tasks if selected individually 
+                if is_gold_task and len(task_ids) > 1:
+                    continue
                 # add new users 
                 user_pref = t.user_pref or {}
                 assign_user = user_pref.get("assign_user", [])


### PR DESCRIPTION
Deliverables:

The bulk edit options edit priority, edit redundancy, and task assignment should be applied to all tasks in the current filter - this includes the scenario when the modal for single task edit is open and closed without updating, followed by a bulk edit update.
Bulk assign should skip gold tasks.
allow co-owners to be able to assign tickets even if they are not sub admin
