### PR TITLE
RDISCROWD-4906 Optimize stats_dates method used in project_by_shortname

### DIFF
--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -805,22 +805,6 @@ def generate_manage_user_email(user, operation):
     return msg
 
 
-class AttrDict(OrderedDict):
-    def __getattr__(self, name):
-        if not name.startswith('_'):
-            return self[name]
-        return super(AttrDict, self).__getattr__(name)
-
-    def __setattr__(self, name, value):
-        if not name.startswith('_'):
-            self[name] = value
-        else:
-            super(AttrDict, self).__setattr__(name, value)
-
-    def dictize(self):
-        return self
-
-
 def check_password_strength(
         password, min_len=8, max_len=15,
         uppercase=True, lowercase=True,

--- a/test/test_cache/test_cache_project_stats.py
+++ b/test/test_cache/test_cache_project_stats.py
@@ -77,18 +77,23 @@ class TestProjectsStatsCache(Test):
     @with_context
     def test_stats_dates(self):
         """Test CACHE PROJECT STATS date works."""
-        pr = ProjectFactory.create()
-        task = TaskFactory.create(project=pr, n_answers=1)
+        pr = ProjectFactory.create()  # project_id = 1
+        task = TaskFactory.create(project=pr, n_answers=1)  # task.id = 1, task.project_id = 1
         today = datetime.now(pytz.utc)
-        TaskFactory.create()
-        TaskRunFactory.create(project=pr, task=task)
-        AnonymousTaskRunFactory.create(project=pr)
+        task2 = TaskFactory.create(project=pr)  # task2.id = 2, task2.project_id = 1
+        task3 = TaskFactory.create(project=pr, n_answers=2)  # task3.id = 3, task.project_id = 1
+
+        task_run1 = TaskRunFactory.create(project=pr, task=task)
+        task_run2 = AnonymousTaskRunFactory.create(project=pr, task=task2)
+        task_run3 = AnonymousTaskRunFactory.create(project=pr, task=task3)
         dates, dates_anon, dates_auth = stats_dates(pr.id)
         assert len(dates) == 15, len(dates)
         assert len(dates_anon) == 15, len(dates_anon)
         assert len(dates_auth) == 15, len(dates_auth)
-        assert dates[today.strftime('%Y-%m-%d')] == 1
-        assert dates_anon[today.strftime('%Y-%m-%d')] == 1
+
+        # This is debatable whether it has to be 2 or 3. The original logic returns 3
+        assert dates[today.strftime('%Y-%m-%d')] == 3
+        assert dates_anon[today.strftime('%Y-%m-%d')] == 2
         assert dates_auth[today.strftime('%Y-%m-%d')] == 1
 
     @with_context

--- a/test/test_cache/test_cache_project_stats.py
+++ b/test/test_cache/test_cache_project_stats.py
@@ -85,7 +85,7 @@ class TestProjectsStatsCache(Test):
 
         task_run1 = TaskRunFactory.create(project=pr, task=task)
         task_run2 = AnonymousTaskRunFactory.create(project=pr, task=task2)
-        task_run3 = AnonymousTaskRunFactory.create(project=pr, task=task3)
+        task_run3 = AnonymousTaskRunFactory.create(project=pr, task=task3)  # task3 is "ongoing" as n_answers = 2
         dates, dates_anon, dates_auth = stats_dates(pr.id)
         assert len(dates) == 15, len(dates)
         assert len(dates_anon) == 15, len(dates_anon)


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-4906*

**Describe your changes**
The original complicated multiple JOIN SQL is really to select all tasks with at least 1 task run and its last finish time. So we can simply get this info from task_run table.

The runtime upon Prod size data(10 million records in task_run) is ~1.3s. The main reason it is still quite slow is because the type of "finish_time" column is text, not timestamp. Thus applying the a function to a column makes index not working, not mentioning there is no index for column "finish_time". Adding an index and changing the column type will be future work. We leave it for now to keep 1.3s query time and utilize cache to compensate the slow query.

**Testing performed**
Local and public QA

**Performance**
Before: 31.3 seconds
After: 1.3 seconds