### PR TITLE
RDISCROWD-4904 fix gigwork cache miss - step 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.db
 settings_local.py
 settings_test.py
-settings_upref_mdata.py
+pybossa/settings_upref_mdata.py
 *env/
 doc/_build
 *.un~

--- a/pybossa/cache/__init__.py
+++ b/pybossa/cache/__init__.py
@@ -231,6 +231,8 @@ def memoize_with_l2_cache(timeout=DEFAULT_TIMEOUT,
         timeout = DEFAULT_TIMEOUT
     if timeout < MIN_TIMEOUT:
         timeout = MIN_TIMEOUT
+    if timeout_mutex_lock > MUTEX_LOCK_TIMEOUT:
+        timeout_mutex_lock = MUTEX_LOCK_TIMEOUT
 
     def decorator(f):
         def update_cache(key_l1, key_l2, *args, **kwargs):

--- a/pybossa/cache/__init__.py
+++ b/pybossa/cache/__init__.py
@@ -28,6 +28,7 @@ It exports:
 """
 import os
 import hashlib
+import time
 from functools import wraps
 from pybossa.core import sentinel
 
@@ -51,6 +52,9 @@ ONE_HOUR = 60 * 60
 HALF_HOUR = 30 * 60
 FIVE_MINUTES = 5 * 60
 ONE_WEEK = 7 * ONE_DAY
+ONE_MINUTE = 60
+L2_CACHE_TIMEOUT = ONE_DAY
+MUTEX_LOCK_TIMEOUT = ONE_MINUTE
 
 management_dashboard_stats = [
     'project_chart', 'category_chart', 'task_chart',
@@ -212,6 +216,94 @@ def memoize_essentials(timeout=300, essentials=None, cache_group_keys=None):
     return decorator
 
 
+def memoize_with_l2_cache(timeout=DEFAULT_TIMEOUT,
+                          timeout_l2=L2_CACHE_TIMEOUT,
+                          timeout_mutex_lock=MUTEX_LOCK_TIMEOUT,
+                          cache_group_keys=None):
+    """
+    Decorator for caching functions using its arguments as part of the key.
+    Returns the cached value, or the function if the cache is disabled
+    If l1 cache miss, it will try to read l2 cache, which has a longer TTL
+    If l2 cache miss, it will try to obtain a mutex lock, read DB and
+    update l1 and l2 caches.
+    """
+    if timeout is None:
+        timeout = DEFAULT_TIMEOUT
+    if timeout < MIN_TIMEOUT:
+        timeout = MIN_TIMEOUT
+
+    def decorator(f):
+        def update_cache(key_l1, key_l2, *args, **kwargs):
+            """ Execute f and then update l1 and l2 cache """
+            output = f(*args, **kwargs)
+            output_bytes = pickle.dumps(output)
+            sentinel.master.setex(key_l1, timeout, output_bytes)
+            sentinel.master.setex(key_l2, timeout_l2, output_bytes)
+            add_key_to_cache_groups(key_l1, cache_group_keys, *args, **kwargs)
+            add_key_to_cache_groups(key_l2, cache_group_keys, *args, **kwargs)
+            return output
+
+        def update_cache_sync(key_l1, key_l2, *args, **kwargs):
+            """ Update l1 and l2 cache synchronously with a mutex lock.
+            If the other request is updating, return None """
+            lock_name = f"{key_l1}:mutex_lock"
+            mutex_lock = sentinel.master.lock(lock_name, timeout_mutex_lock)
+
+            # acquiring a non blocking lock: default is blocking
+            lock_success = mutex_lock.acquire(blocking=False)
+            if lock_success:
+                output = update_cache(key_l1, key_l2, *args, **kwargs)
+                mutex_lock.release()  # release the lock
+                return output
+            return None
+
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            key = "%s:%s_args:" % (REDIS_KEYPREFIX, f.__name__)
+            key_to_hash = get_key_to_hash(*args, **kwargs)
+            key = get_hash_key(key, key_to_hash)
+            key_l2 = f"{key}:l2"
+
+            if os.environ.get('PYBOSSA_REDIS_CACHE_DISABLED') is None:
+                output_bytes = sentinel.slave.get(key)  # read l1 cache
+                if output_bytes:
+                    return pickle.loads(output_bytes)
+
+                # If l1 cache miss, try to read from l2 cache
+                output_bytes = sentinel.slave.get(key_l2)
+
+                # If l2 cache has the data
+                if output_bytes:
+                    # Try to keep the cache up-to-date
+                    output = update_cache_sync(key, key_l2, *args, **kwargs)
+                    if output:
+                        return output
+
+                    # return l2 cache data if the other request is updating data
+                    return pickle.loads(output_bytes)
+
+                # If l1 and l2 cache miss: get a mutex lock, then update cache
+                output = update_cache_sync(key, key_l2, *args, **kwargs)
+                if output:
+                    return output
+
+                # output is None, meaning the other request is updating data.
+                # Then just keep querying the l2 cache until MUTEX_LOCK_TIMEOUT
+                total_retry_time = 0
+                while total_retry_time < timeout_mutex_lock:
+                    output_bytes = sentinel.slave.get(key_l2)
+                    if output_bytes:
+                        return pickle.loads(output_bytes)
+
+                    sleep_time = 0.1  # seconds
+                    total_retry_time += sleep_time
+                    time.sleep(sleep_time)
+            output = update_cache(key, key_l2, *args, **kwargs)
+            return output
+        return wrapper
+    return decorator
+
+
 def delete_cached(key):
     """
     Delete a cached value from the cache.
@@ -256,6 +348,29 @@ def delete_memoized_essential(function, *args, **kwargs):
         key = "%s:%s_args:" % (REDIS_KEYPREFIX, function.__name__)
         if args or kwargs:
             key += get_key_to_hash(*args, **kwargs)
+        keys_to_delete = list(sentinel.slave.scan_iter(match=key + '*', count=10000))
+        if not keys_to_delete:
+            return False
+        return bool(sentinel.master.delete(*keys_to_delete))
+    return True
+
+
+def delete_memoize_with_l2_cache(function, *args, **kwargs):
+    """
+    Delete a memoize_with_l2_cache value from the cache.
+
+    Returns True if success or no cache is enabled
+
+    """
+    if os.environ.get('PYBOSSA_REDIS_CACHE_DISABLED') is None:
+        key = "%s:%s_args:" % (REDIS_KEYPREFIX, function.__name__)
+        if args or kwargs:
+            key_to_hash = get_key_to_hash(*args, **kwargs)
+            key = get_hash_key(key, key_to_hash)
+            key_l2 = f"{key}:l2"
+            key_deleted = bool(sentinel.master.delete(key))
+            key_l2_deleted = bool(sentinel.master.delete(key_l2))
+            return key_deleted and key_l2_deleted
         keys_to_delete = list(sentinel.slave.scan_iter(match=key + '*', count=10000))
         if not keys_to_delete:
             return False

--- a/test/test_cache/__init__.py
+++ b/test/test_cache/__init__.py
@@ -17,11 +17,14 @@
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 
 import hashlib
+import threading
+import time
 from unittest.mock import patch
 from pybossa.cache import (get_key_to_hash, get_hash_key, cache, memoize,
                            delete_cached, delete_memoized, memoize_essentials,
                            delete_memoized_essential, delete_cache_group,
-                           get_cache_group_key)
+                           get_cache_group_key, memoize_with_l2_cache,
+                           delete_memoize_with_l2_cache)
 from pybossa.sentinel import Sentinel
 import pybossa.settings_test as settings_test
 
@@ -35,7 +38,6 @@ class TestCacheHashFunctions(object):
         err_msg = "Different key_to_hash %s != %s" % (key_to_hash, expected)
         assert key_to_hash == expected, err_msg
 
-
     def test_01_get_key_to_hash_with_kwargs(self):
         """Test CACHE get_key_to_hash with kwargs works."""
         expected = ':1:a'
@@ -43,14 +45,12 @@ class TestCacheHashFunctions(object):
         err_msg = "Different key_to_hash %s != %s" % (key_to_hash, expected)
         assert key_to_hash == expected, err_msg
 
-
     def test_02_get_key_to_hash_with_args_and_kwargs(self):
         """Test CACHE get_key_to_hash with args and kwargs works."""
         expected = ':1:a'
         key_to_hash = get_key_to_hash(1, vowel='a')
         err_msg = "Different key_to_hash %s != %s" % (key_to_hash, expected)
         assert key_to_hash == expected, err_msg
-
 
     def test_03_get_hash_key(self):
         """Test CACHE get_hash_key works."""
@@ -61,7 +61,6 @@ class TestCacheHashFunctions(object):
         key = get_hash_key(prefix, key_to_hash)
         err_msg = "The expected key is different %s != %s" % (expected, key)
         assert expected == key, err_msg
-
 
 
 class FakeApp(object):
@@ -77,7 +76,9 @@ class FakeApp(object):
             self.config = { 'REDIS_SENTINEL': settings_test.REDIS_SENTINEL,
                 'REDIS_PWD': pwd }
 
+
 test_sentinel = Sentinel(app=FakeApp())
+
 
 @patch('pybossa.cache.sentinel', new=test_sentinel)
 class TestCacheMemoizeFunctions(object):
@@ -114,7 +115,6 @@ class TestCacheMemoizeFunctions(object):
         # in redis-py, all responses are returned as bytes in Python 3
         assert list(test_sentinel.master.keys()) == [key.encode()], list(test_sentinel.master.keys())
 
-
     def test_cache_gets_function_from_cache_after_first_call(self):
         """Test CACHE cache retrieves the function value from cache after it has
         been called the first time, and does not call the function but once"""
@@ -129,7 +129,6 @@ class TestCacheMemoizeFunctions(object):
         assert second_call == 1, second_call
         assert second_call == first_call, second_call
 
-
     def test_cached_function_returns_expected_value(self):
         """Test CACHE cache decorator returns the expected function return value
         in every call"""
@@ -143,7 +142,6 @@ class TestCacheMemoizeFunctions(object):
         assert first_call == 'my_func was called', first_call
         assert second_call == 'my_func was called', second_call
 
-
     def test_memoize_stores_function_call_first_time_called(self):
         """Test CACHE memoize decorator stores the result of calling a function
         in the cache the first time it's called"""
@@ -156,6 +154,17 @@ class TestCacheMemoizeFunctions(object):
 
         assert len(test_sentinel.master.keys(key_pattern)) == 1
 
+    def test_memoize_with_l2_cache_stores_function_call_first_time_called(self):
+        """Test CACHE memoize_with_l2_cache decorator stores the result of calling a function
+        in the cache the first time it's called"""
+
+        @memoize_with_l2_cache()
+        def my_func(*args, **kwargs):
+            return [args, kwargs]
+        my_func('arg')
+        key_pattern = "%s:%s_args:*" % (settings_test.REDIS_KEYPREFIX, my_func.__name__)
+
+        assert len(test_sentinel.master.keys(key_pattern)) == 2
 
     def test_memoize_stores_function_call_only_first_time_called(self):
         """Test CACHE memoize decorator stores the result of calling a function
@@ -170,6 +179,18 @@ class TestCacheMemoizeFunctions(object):
 
         assert len(test_sentinel.master.keys(key_pattern)) == 1
 
+    def test_memoize_with_l2_cache_stores_function_call_only_first_time_called(self):
+        """Test CACHE memoize_with_l2_cache decorator stores the result of calling a function
+        in the cache only the first time it's called"""
+
+        @memoize_with_l2_cache()
+        def my_func(*args, **kwargs):
+            return [args, kwargs]
+        my_func('arg')
+        my_func('arg')
+        key_pattern = "%s:%s_args:*" % (settings_test.REDIS_KEYPREFIX, my_func.__name__)
+
+        assert len(test_sentinel.master.keys(key_pattern)) == 2
 
     def test_memoize_stores_function_calls_for_different_arguments(self):
         """Test CACHE memoize decorator stores the result of calling a function
@@ -184,6 +205,18 @@ class TestCacheMemoizeFunctions(object):
         my_func('another_arg')
         assert len(test_sentinel.master.keys(key_pattern)) == 2
 
+    def test_memoize_with_l2_cache_stores_function_calls_for_different_arguments(self):
+        """Test CACHE memoize_with_l2_cache decorator stores the result of calling a function
+        every time it's called with different argument values"""
+
+        @memoize_with_l2_cache()
+        def my_func(*args, **kwargs):
+            return [args, kwargs]
+        key_pattern = "%s:%s_args:*" % (settings_test.REDIS_KEYPREFIX, my_func.__name__)
+        my_func('arg')
+        assert len(test_sentinel.master.keys(key_pattern)) == 2
+        my_func('another_arg')
+        assert len(test_sentinel.master.keys(key_pattern)) == 4
 
     def test_memoize_gets_value_from_cache_after_first_call(self):
         """Test CACHE memoize decorator gets the value from cache for the same
@@ -202,6 +235,22 @@ class TestCacheMemoizeFunctions(object):
         assert second_call == first_call, second_call
         assert third_call_with_other_arg == 2, third_call_with_other_arg
 
+    def test_memoize_with_l2_cache_gets_value_from_cache_after_first_call(self):
+        """Test CACHE memoize_with_l2_cache decorator gets the value from cache for the same
+        function arguments (but not for calls with different args)"""
+
+        @memoize_with_l2_cache()
+        def my_func(arg, call_count=[]):
+            call_count.append(1)
+            return len(call_count)
+
+        first_call = my_func(arg='arg')
+        second_call = my_func(arg='arg')
+        third_call_with_other_arg = my_func(arg='other_arg')
+
+        assert second_call == 1, second_call
+        assert second_call == first_call, second_call
+        assert third_call_with_other_arg == 2, third_call_with_other_arg
 
     def test_memoized_function_returns_expected_values(self):
         """Test CACHE memoized function returns the expected value every time"""
@@ -215,10 +264,25 @@ class TestCacheMemoizeFunctions(object):
         second_call_other_arg = my_func('other', kwarg='other')
 
         assert first_call == [('arg',), {'kwarg': 'kwarg'}], first_call
-        assert second_call == [('arg',), {'kwarg': 'kwarg'}], first_call
-        assert first_call_other_arg == [('other',), {'kwarg': 'other'}], first_call
-        assert second_call_other_arg == [('other',), {'kwarg': 'other'}], first_call
+        assert second_call == [('arg',), {'kwarg': 'kwarg'}], second_call
+        assert first_call_other_arg == [('other',), {'kwarg': 'other'}], first_call_other_arg
+        assert second_call_other_arg == [('other',), {'kwarg': 'other'}], second_call_other_arg
 
+    def test_memoize_with_l2_cache_function_returns_expected_values(self):
+        """Test CACHE memoize_with_l2_cache function returns the expected value every time"""
+
+        @memoize_with_l2_cache()
+        def my_func(*args, **kwargs):
+            return [args, kwargs]
+        first_call = my_func('arg', kwarg='kwarg')
+        second_call = my_func('arg', kwarg='kwarg')
+        first_call_other_arg = my_func('other', kwarg='other')
+        second_call_other_arg = my_func('other', kwarg='other')
+
+        assert first_call == [('arg',), {'kwarg': 'kwarg'}], first_call
+        assert second_call == [('arg',), {'kwarg': 'kwarg'}], second_call
+        assert first_call_other_arg == [('other',), {'kwarg': 'other'}], first_call_other_arg
+        assert second_call_other_arg == [('other',), {'kwarg': 'other'}], second_call_other_arg
 
     def test_delete_cached_returns_true_when_delete_succeeds(self):
         """Test CACHE delete_cached deletes a stored key and returns True if
@@ -235,7 +299,6 @@ class TestCacheMemoizeFunctions(object):
         assert delete_succedeed is True, delete_succedeed
         assert list(test_sentinel.master.keys()) == [], 'Key was not deleted!'
 
-
     def test_delete_cached_returns_false_when_delete_fails(self):
         """Test CACHE delete_cached returns False if deletion is not successful"""
 
@@ -247,7 +310,6 @@ class TestCacheMemoizeFunctions(object):
 
         delete_succedeed = delete_cached('my_cached_func')
         assert delete_succedeed is False, delete_succedeed
-
 
     def test_delete_memoized_returns_true_when_delete_succeeds(self):
         """Test CACHE delete_memoized deletes a stored key and returns True if
@@ -263,6 +325,19 @@ class TestCacheMemoizeFunctions(object):
         assert delete_succedeed is True, delete_succedeed
         assert list(test_sentinel.master.keys()) == [], 'Key was not deleted!'
 
+    def test_delete_memoize_with_l2_cache_returns_true_when_delete_succeeds(self):
+        """Test CACHE delete_memoize_with_l2_cache deletes a stored key and returns True if
+        deletion is successful"""
+
+        @memoize_with_l2_cache()
+        def my_func(*args, **kwargs):
+            return [args, kwargs]
+        my_func('arg', kwarg='kwarg')
+        assert len(list(test_sentinel.master.keys())) == 2
+
+        delete_succedeed = delete_memoize_with_l2_cache(my_func, 'arg', kwarg='kwarg')
+        assert delete_succedeed is True, delete_succedeed
+        assert list(test_sentinel.master.keys()) == [], 'Key was not deleted!'
 
     def test_delete_memoized_returns_false_when_delete_fails(self):
         """Test CACHE delete_memoized returns False if deletion is not successful"""
@@ -277,6 +352,18 @@ class TestCacheMemoizeFunctions(object):
         assert delete_succedeed is False, delete_succedeed
         assert len(list(test_sentinel.master.keys())) == 1, 'Key was unexpectedly deleted'
 
+    def test_delete_memoize_with_l2_cache_returns_false_when_delete_fails(self):
+        """Test CACHE delete_memoize_with_l2_cache returns False if deletion is not successful"""
+
+        @memoize_with_l2_cache()
+        def my_func(*args, **kwargs):
+            return [args, kwargs]
+        my_func('arg', kwarg='kwarg')
+        assert len(list(test_sentinel.master.keys())) == 2
+
+        delete_succedeed = delete_memoized(my_func, 'badarg', kwarg='barkwarg')
+        assert delete_succedeed is False, delete_succedeed
+        assert len(list(test_sentinel.master.keys())) == 2, 'Key was unexpectedly deleted'
 
     def test_delete_memoized_deletes_only_requested(self):
         """Test CACHE delete_memoized deletes only the values it's asked and
@@ -293,6 +380,19 @@ class TestCacheMemoizeFunctions(object):
         assert delete_succedeed is True, delete_succedeed
         assert len(list(test_sentinel.master.keys())) == 1, 'Everything was deleted!'
 
+    def test_delete_memoize_with_l2_cache_deletes_only_requested(self):
+        """Test CACHE delete_memoize_with_l2_cache deletes only the values it's asked and
+        leaves the rest untouched"""
+
+        @memoize_with_l2_cache()
+        def my_func(*args, **kwargs):
+            return [args, kwargs]
+        my_func('arg', kwarg='kwarg')
+        my_func('other', kwarg='other')
+        assert len(list(test_sentinel.master.keys())) == 4
+        delete_succedeed = delete_memoize_with_l2_cache(my_func, 'arg', kwarg='kwarg')
+        assert delete_succedeed is True, delete_succedeed
+        assert len(list(test_sentinel.master.keys())) == 2, 'Everything was deleted!'
 
     def test_delete_memoized_deletes_all_function_calls(self):
         """Test CACHE delete_memoized deletes all the function calls stored if
@@ -313,6 +413,25 @@ class TestCacheMemoizeFunctions(object):
         assert delete_succedeed is True, delete_succedeed
         assert len(list(test_sentinel.master.keys())) == 1
 
+    def test_delete_memoize_with_l2_cache_deletes_all_function_calls(self):
+        """Test CACHE delete_memoize_with_l2_cache deletes all the function calls stored if
+        only function is specified and no arguments of the calls are provided"""
+
+        @memoize_with_l2_cache()
+        def my_func(*args, **kwargs):
+            return [args, kwargs]
+
+        @memoize_with_l2_cache()
+        def my_other_func(*args, **kwargs):
+            return [args, kwargs]
+        my_func('arg', kwarg='kwarg')
+        my_func('other', kwarg='other')
+        my_other_func('arg', kwarg='kwarg')
+        assert len(list(test_sentinel.master.keys())) == 6
+
+        delete_succedeed = delete_memoize_with_l2_cache(my_func)
+        assert delete_succedeed is True, delete_succedeed
+        assert len(list(test_sentinel.master.keys())) == 2
 
     def test_delete_memoized_essentials(self):
         """Test CACHE delete_memoized_essential deletes all the function
@@ -329,7 +448,6 @@ class TestCacheMemoizeFunctions(object):
         delete_succedeed = delete_memoized_essential(my_func, 'other')
         assert delete_succedeed is True, delete_succedeed
         assert len(list(test_sentinel.master.keys())) == 1
-
 
     def test_delete_memoized_essentials_no_key(self):
         """Test CACHE delete_memoized_essential no key to delete"""
@@ -349,17 +467,16 @@ class TestCacheMemoizeFunctions(object):
         assert delete_succedeed is False, delete_succedeed
         assert len(list(test_sentinel.master.keys())) == 2
 
-
     def test_delete_cache_group_no_group(self):
         assert not list(test_sentinel.master.keys())
         delete_cache_group('key')
         assert not list(test_sentinel.master.keys())
 
-
     def test_cache_group_key_one_group(self):
         @memoize(cache_group_keys=([0],))
         def my_func(*args, **kwargs):
             return None
+
         @memoize(cache_group_keys=([0],))
         def my_func2(*args, **kwargs):
             return None
@@ -371,11 +488,27 @@ class TestCacheMemoizeFunctions(object):
         delete_cache_group('key')
         assert not list(test_sentinel.master.keys())
 
+    def test_memoize_with_l2_cache_group_key_one_group(self):
+        @memoize_with_l2_cache(cache_group_keys=([0],))
+        def my_func(*args, **kwargs):
+            return None
+
+        @memoize_with_l2_cache(cache_group_keys=([0],))
+        def my_func2(*args, **kwargs):
+            return None
+        my_func('key')
+        my_func2('key')
+        keys = list(test_sentinel.master.keys())
+        assert len(keys) == 5
+        assert get_cache_group_key('key').encode() in keys  # keys is a list of bytes string
+        delete_cache_group('key')
+        assert not list(test_sentinel.master.keys())
 
     def test_cache_group_key_two_groups(self):
         @memoize(cache_group_keys=([0],))
         def my_func(*args, **kwargs):
             return None
+
         @memoize(cache_group_keys=([0],))
         def my_func2(*args, **kwargs):
             return None
@@ -393,9 +526,30 @@ class TestCacheMemoizeFunctions(object):
         delete_cache_group('key2')
         assert not list(test_sentinel.master.keys())
 
+    def test_memoize_with_l2_cache_group_key_two_groups(self):
+        @memoize_with_l2_cache(cache_group_keys=([0],))
+        def my_func(*args, **kwargs):
+            return None
+
+        @memoize_with_l2_cache(cache_group_keys=([0],))
+        def my_func2(*args, **kwargs):
+            return None
+        my_func('key1')
+        my_func2('key2')
+        keys = list(test_sentinel.master.keys())
+        assert len(keys) == 6
+        assert get_cache_group_key('key1').encode() in keys
+        assert get_cache_group_key('key2').encode() in keys
+        delete_cache_group('key1')
+        keys = list(test_sentinel.master.keys())
+        assert len(keys) == 3
+        assert get_cache_group_key('key1').encode() not in keys
+        assert get_cache_group_key('key2').encode() in keys
+        delete_cache_group('key2')
+        assert not list(test_sentinel.master.keys())
 
     def test_cache_group_key_two_groups_one_key(self):
-        @memoize(cache_group_keys=([0],[1]))
+        @memoize(cache_group_keys=([0], [1]))
         def my_func(*args, **kwargs):
             return None
         my_func('key1', 'key2')
@@ -411,10 +565,38 @@ class TestCacheMemoizeFunctions(object):
         delete_cache_group('key2')
         assert not list(test_sentinel.master.keys())
 
+    def test_memoize_with_l2_cache_group_key_two_groups_one_key(self):
+        @memoize_with_l2_cache(cache_group_keys=([0], [1]))
+        def my_func(*args, **kwargs):
+            return None
+        my_func('key1', 'key2')
+        keys = list(test_sentinel.master.keys())
+        assert len(keys) == 4
+        assert get_cache_group_key('key1').encode() in keys
+        assert get_cache_group_key('key2').encode() in keys
+        delete_cache_group('key1')
+        keys = list(test_sentinel.master.keys())
+        assert len(keys) == 1
+        assert get_cache_group_key('key1').encode() not in keys
+        assert get_cache_group_key('key2').encode() in keys
+        delete_cache_group('key2')
+        assert not list(test_sentinel.master.keys())
+
     def test_cache_group_key_callable(self):
         def cache_group_key_fn(*args, **kwargs):
             return args[0]
+
         @memoize(cache_group_keys=(cache_group_key_fn,))
+        def my_func(*args, **kwargs):
+            return None
+        my_func('a')
+        assert get_cache_group_key('a').encode() in test_sentinel.master.keys()
+
+    def test_memoize_with_l2_cache_group_key_callable(self):
+        def cache_group_key_fn(*args, **kwargs):
+            return args[0]
+
+        @memoize_with_l2_cache(cache_group_keys=(cache_group_key_fn,))
         def my_func(*args, **kwargs):
             return None
         my_func('a')
@@ -430,12 +612,29 @@ class TestCacheMemoizeFunctions(object):
             return
         raise Exception('Should have raised')
 
+    def test_memoize_with_l2_cache_group_key_invalid(self):
+        @memoize_with_l2_cache(cache_group_keys=(0,))
+        def my_func(*args, **kwargs):
+            return None
+        try:
+            my_func('a')
+        except:
+            return
+        raise Exception('Should have raised')
+
     def test_cache_group_key_none(self):
         @memoize()
         def my_func(*args, **kwargs):
             return None
         my_func('a')
         assert len(test_sentinel.master.keys()) == 1
+
+    def test_memoize_with_l2_cache_group_key_none(self):
+        @memoize_with_l2_cache()
+        def my_func(*args, **kwargs):
+            return None
+        my_func('a')
+        assert len(test_sentinel.master.keys()) == 2
 
     def test_memoized_min_timeout(self):
         """Test CACHE memoize for min timeout value."""
@@ -466,3 +665,117 @@ class TestCacheMemoizeFunctions(object):
 
         my_func('a')
         assert len(test_sentinel.master.keys()) == 1
+
+    def test_memoize_with_l2_cache_min_timeout(self):
+        """Test CACHE memoize_with_l2_cache for min timeout value."""
+
+        @memoize_with_l2_cache(timeout=0)
+        def my_func(*args, **kwargs):
+            return [args, kwargs]
+
+        my_func('a')
+        assert len(test_sentinel.master.keys()) == 2
+
+    def test_memoize_allows_multiple_requests_setting_cache(self):
+        """Test memoize allows multiple requests setting cache"""
+
+        execution_time = 1  # in seconds
+
+        @memoize(timeout=60)
+        def simulate_db_query(counts=[], *args, **kwargs):
+            counts.append(1)
+            time.sleep(execution_time)  # Sleep to simulate a slow DB query
+            return len(counts)
+
+        requests = []
+        start = time.time()
+
+        # Simulate 10 requests - all hitting DB
+        for i in range(10):
+            request = threading.Thread(target=simulate_db_query)
+            requests.append(request)
+            request.start()
+
+        for request in requests:
+            request.join()
+
+        end = time.time()
+        assert round(end - start) == execution_time, "parallel running time should close to single running time"
+
+        start = time.time()
+        for i in range(10):
+            result = simulate_db_query()  # This should hit the cache, not DB
+        end = time.time()
+        assert round(end - start) == 0, "hitting cache, the running time should be close to 0"
+        assert result == 10, "hit simulate_db_query 10 times"
+
+        key = b'pybossa_cache:simulate_db_query_args::d41d8cd98f00b204e9800998ecf8427e'
+        assert len(test_sentinel.master.keys()) == 1
+        assert key in test_sentinel.master.keys()
+
+        # simulate cache expires, and all requests are hitting the DB
+        test_sentinel.master.expire(key, 0)
+        start = time.time()
+        for i in range(10):  # All requests hitting the DB
+            request = threading.Thread(target=simulate_db_query)
+            requests.append(request)
+            request.start()
+
+        for request in requests:
+            request.join()
+        result = simulate_db_query()  # This should hit the cache
+        end = time.time()
+        assert round(end - start) == execution_time, "close to single running time"
+        assert result == 20, "hit simulate_db_query 10 more times, total 20 times"
+
+    def test_memoize_with_l2_cache_allows_one_request_setting_cache(self):
+        """Test memoize_with_l2_cache allows only one request setting cache"""
+
+        execution_time = 1  # in seconds
+
+        @memoize_with_l2_cache(timeout=60)
+        def simulate_db_query(counts=[], *args, **kwargs):
+            counts.append(1)
+            time.sleep(execution_time)  # Sleep to simulate a slow DB query
+            return len(counts)
+
+        requests = []
+        start = time.time()
+
+        # Simulate 10 requests - only 1 request hits the DB
+        for i in range(10):
+            request = threading.Thread(target=simulate_db_query)
+            requests.append(request)
+            request.start()
+
+        for request in requests:
+            request.join()
+
+        end = time.time()
+        assert round(end - start) == execution_time, "parallel running time should close to single running time"
+
+        start = time.time()
+        for i in range(10):
+            result = simulate_db_query()  # This should hit the cache, not DB
+        end = time.time()
+        assert round(end - start) == 0, "hitting cache, the running time should be very small"
+        assert result == 1, "hit simulate_db_query once"
+
+        key = b'pybossa_cache:simulate_db_query_args::d41d8cd98f00b204e9800998ecf8427e'
+        assert len(test_sentinel.master.keys()) == 2
+        assert key in test_sentinel.master.keys()
+
+        # simulate cache expires, and only 1 request is hitting the DB
+        test_sentinel.master.expire(key, 0)
+        start = time.time()
+        for i in range(10):  # 1 request hits the DB; the rest 9 hits l2 cache
+            request = threading.Thread(target=simulate_db_query)
+            requests.append(request)
+            request.start()
+
+        for request in requests:
+            request.join()
+        result = simulate_db_query()  # This should hit the cache
+        end = time.time()
+        assert round(end - start) == execution_time, "close to single running time"
+        assert result == 2, "hit simulate_db_query 1 more time, total twice"


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-4904*

**Describe your changes**
Create a new decorator for caching such that when cache miss occurs, only one request is allowed to query the DB. This will greatly reduce the DB load, especially when the DB operation is heavy. Also, longer TTL level 2 cache is used in case of level 1 cache miss. The request can still return a data fast from level 2 cache.

**Testing performed**
Tested locally. Also two unit tests were added([here](https://github.com/bloomberg/pybossa/blob/f8224d6a24a0b4a86c827fa8ab4cb1995693f45a/test/test_cache/__init__.py#L679) and [here](https://github.com/bloomberg/pybossa/blob/f8224d6a24a0b4a86c827fa8ab4cb1995693f45a/test/test_cache/__init__.py#L731)) to compare the behavior of the existing decorator and the improved decorator.

