### PR TITLE
RDISCROWD-4967 Optimize slow queries used by Gigwork poller

### DIFF
--- a/alembic/versions/ed775af5e086_rdiscrowd_4967_add_partial_index_for_.py
+++ b/alembic/versions/ed775af5e086_rdiscrowd_4967_add_partial_index_for_.py
@@ -14,12 +14,14 @@ from alembic import op
 
 
 def upgrade():
+    op.execute('COMMIT')
     op.create_index('task_state_calibration_exported_idx', 'task',
                     ['id', 'created', 'project_id', 'state', 'quorum',
                      'calibration', 'priority_0', 'info', 'n_answers',
                      'fav_user_ids', 'exported', 'user_pref', 'worker_pref',
                      'worker_filter', 'gold_answers', 'expiration'],
-                    postgresql_where="(state = 'completed'::text OR calibration = 1) AND exported = false"
+                    postgresql_where="(state = 'completed'::text OR calibration = 1) AND exported = false",
+                    postgresql_concurrently=True
                     )
 
 

--- a/alembic/versions/ed775af5e086_rdiscrowd_4967_add_partial_index_for_.py
+++ b/alembic/versions/ed775af5e086_rdiscrowd_4967_add_partial_index_for_.py
@@ -1,0 +1,27 @@
+"""RDISCROWD-4967 add partial index for task table
+
+Revision ID: ed775af5e086
+Revises: 29c0cc545d6d
+Create Date: 2022-02-28 15:01:53.582867
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'ed775af5e086'
+down_revision = '29c0cc545d6d'
+
+from alembic import op
+
+
+def upgrade():
+    op.create_index('task_state_calibration_exported_idx', 'task',
+                    ['id', 'created', 'project_id', 'state', 'quorum',
+                     'calibration', 'priority_0', 'info', 'n_answers',
+                     'fav_user_ids', 'exported', 'user_pref', 'worker_pref',
+                     'worker_filter', 'gold_answers', 'expiration'],
+                    postgresql_where="(state = 'completed'::text OR calibration = 1) AND exported = false"
+                    )
+
+
+def downgrade():
+    op.drop_index('task_state_calibration_exported_idx')

--- a/alembic/versions/ed775af5e086_rdiscrowd_4967_add_partial_index_for_.py
+++ b/alembic/versions/ed775af5e086_rdiscrowd_4967_add_partial_index_for_.py
@@ -14,7 +14,9 @@ from alembic import op
 
 
 def upgrade():
+    # Workaround of "CREATE INDEX CONCURRENTLY cannot run inside a transaction block" exception
     op.execute('COMMIT')
+
     op.create_index('task_state_calibration_exported_idx', 'task',
                     ['id', 'created', 'project_id', 'state', 'quorum',
                      'calibration', 'priority_0', 'info', 'n_answers',

--- a/alembic/versions/ed775af5e086_rdiscrowd_4967_add_partial_index_for_.py
+++ b/alembic/versions/ed775af5e086_rdiscrowd_4967_add_partial_index_for_.py
@@ -17,6 +17,8 @@ def upgrade():
     # Workaround of "CREATE INDEX CONCURRENTLY cannot run inside a transaction block" exception
     op.execute('COMMIT')
 
+    # passing all columns to avoid DB trip to query original table making indexing efficient.
+    # when new columns are added and used in the query, the index might need to be rebuilt.
     op.create_index('task_state_calibration_exported_idx', 'task',
                     ['id', 'created', 'project_id', 'state', 'quorum',
                      'calibration', 'priority_0', 'info', 'n_answers',


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-4967*

**Describe your changes**
Add a partial index for task table based on the two slow SQLs

**Testing performed**
**Test machine**: Mac Pro with 5M records of task table and 10M records of task_run table(half volume of Prod but Prod servers are more powerful)

The SQL 1 tasks **32s**(without a partial index), very close to 34s in Prod, see the following explain plan screenshot.

![without index](https://user-images.githubusercontent.com/5487100/156064666-c085db0c-6c8a-4777-a1bf-e6e53d7f83d7.png)

With a partial index added, the execution time from explain plan reduces to **~3ms**(actual SQL with data could be ~60ms), screenshot as follows:
![with partial index](https://user-images.githubusercontent.com/5487100/156064728-e0b3bb58-122a-4438-8eba-fe5328873adc.png)

The running time from explain plan of SQL 2 reduces to a **0.1ms**(actual SQL with data could be ~60ms)
<img width="1602" alt="Screen Shot 2022-02-28 at 5 01 31 PM" src="https://user-images.githubusercontent.com/5487100/156065820-b04fb5c3-c69e-45bb-81a5-4f355b1e74cd.png">


**Insert Performance Impact**
The test in the local machine showed the impact of adding partial index for "insert" SQL is neglectable, see the screenshot below:
<img width="1359" alt="Screen Shot 2022-02-28 at 5 06 18 PM" src="https://user-images.githubusercontent.com/5487100/156066377-fc29820a-0a76-45a4-8d54-e3c3c8e672c7.png">

**Update Performance Impact**
The test in the local machine showed the impact of adding partial index for "update" SQL is neglectable, see the screenshot below:
<img width="631" alt="Screen Shot 2022-02-28 at 5 05 54 PM" src="https://user-images.githubusercontent.com/5487100/156066522-bdd801fb-866e-42eb-add3-9da6dd1d3bd3.png">

