### PR TITLE
RDISCROWD-5093 Retain coowners when transferring project ownership.

### DIFF
--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -3039,10 +3039,12 @@ def transfer_ownership(short_name):
             project.owner_id = new_owner_id
 
             # Remove old project owner id from coowners.
-            project.owners_ids.remove(old_owner_id)
+            if old_owner_id in project.owners_ids:
+                project.owners_ids.remove(old_owner_id)
 
             # Add new project owner id to coowners.
-            project.owners_ids.append(new_owner_id)
+            if new_owner_id not in project.owners_ids:
+                project.owners_ids.append(new_owner_id)
 
             # Update project.
             project_repo.update(project)

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -3032,10 +3032,21 @@ def transfer_ownership(short_name):
     if request.method == 'POST' and form.validate():
         new_owner = user_repo.filter_by(email_addr=form.email_addr.data)
         if len(new_owner) == 1:
-            new_owner = new_owner[0]
-            project.owner_id = new_owner.id
-            project.owners_ids = [new_owner.id]
+            old_owner_id = project.owner_id
+            new_owner_id = new_owner[0].id
+
+            # Assign new project owner id.
+            project.owner_id = new_owner_id
+
+            # Remove old project owner id from coowners.
+            project.owners_ids.remove(old_owner_id)
+
+            # Add new project owner id to coowners.
+            project.owners_ids.append(new_owner_id)
+
+            # Update project.
             project_repo.update(project)
+
             msg = gettext("Project owner updated")
             flash(msg, 'info')
             return redirect_content_type(url_for('.details',

--- a/test/test_view/test_project_transferownership.py
+++ b/test/test_view/test_project_transferownership.py
@@ -146,3 +146,41 @@ class TestProjectTransferOwnership(web.Helper):
                                  follow_redirects=True)
         data = json.loads(res.data)
         assert data['code'] == 403, data
+
+    @with_context
+    def test_transfer_retain_coowners(self):
+        """Test transfer ownership retains existing coowners after transfer to new owner."""
+        admin, owner, user1, user2 = UserFactory.create_batch(4)
+        coowners = [user2.id]
+        project = ProjectFactory.create(owner=owner, owners_ids=coowners)
+        url = '/project/%s/transferownership?api_key=%s' % (project.short_name,
+                                                            admin.api_key)
+
+        # Sanity check that the correct owner and coowners have been set on the project.
+        assert project.owner_id == owner.id
+        assert user2.id in project.owners_ids
+
+        csrf = self.get_csrf(url)
+        headers = {'X-CSRFToken': csrf}
+
+        # Transfer the project from owner to user1.
+        payload = dict(email_addr=user1.email_addr)
+        res = self.app_post_json(url, data=payload, headers=headers, follow_redirects=True)
+        data = json.loads(res.data)
+        assert data['next'] is not None, data
+
+        # Confirm the new owner id.
+        err_msg = "The project owner id should be different"
+        assert project.owner_id == user1.id, err_msg
+
+        # Confirm the existing coowners are retained.
+        err_msg = "Co-owner should still exist on project after transfer"
+        assert user2.id in project.owners_ids, err_msg
+
+        # Confirm the new project owner is included in the coowners.
+        err_msg = "New owner should exist in coowners after transfer"
+        assert user1.id in project.owners_ids, err_msg
+
+        # Confirm the old project owner is no longer included in the coowners.
+        err_msg = "Old owner should not exist in coowners after transfer"
+        assert owner.id not in project.owners_ids, err_msg

--- a/test/test_view/test_project_transferownership.py
+++ b/test/test_view/test_project_transferownership.py
@@ -184,3 +184,46 @@ class TestProjectTransferOwnership(web.Helper):
         # Confirm the old project owner is no longer included in the coowners.
         err_msg = "Old owner should not exist in coowners after transfer"
         assert owner.id not in project.owners_ids, err_msg
+
+    @with_context
+    def test_transfer_retain_coowners_multi(self):
+        """Test transfer ownership retains existing coowners (multiple) after transfer to new owner."""
+        admin, owner, user1, user2, user3 = UserFactory.create_batch(5)
+        coowners = [owner.id, user2.id, user3.id]
+        project = ProjectFactory.create(owner=owner, owners_ids=coowners)
+        url = '/project/%s/transferownership?api_key=%s' % (project.short_name,
+                                                            admin.api_key)
+
+        # Sanity check that the correct owner and coowners have been set on the project.
+        assert project.owner_id == owner.id
+        assert len(project.owners_ids) == 3
+        assert owner.id in project.owners_ids
+        assert user2.id in project.owners_ids
+        assert user3.id in project.owners_ids
+
+        csrf = self.get_csrf(url)
+        headers = {'X-CSRFToken': csrf}
+
+        # Transfer the project from owner to user1.
+        payload = dict(email_addr=user1.email_addr)
+        res = self.app_post_json(url, data=payload, headers=headers, follow_redirects=True)
+        data = json.loads(res.data)
+        assert data['next'] is not None, data
+
+        # Confirm the new owner id.
+        err_msg = "The project owner id should be different"
+        assert project.owner_id == user1.id, err_msg
+
+        # Confirm the existing coowners are retained.
+        err_msg = "Co-owner should still exist on project after transfer"
+        assert len(project.owners_ids) == 3
+        assert user2.id in project.owners_ids, err_msg
+        assert user3.id in project.owners_ids, err_msg
+
+        # Confirm the new project owner is included in the coowners.
+        err_msg = "New owner should exist in coowners after transfer"
+        assert user1.id in project.owners_ids, err_msg
+
+        # Confirm the old project owner is no longer included in the coowners.
+        err_msg = "Old owner should not exist in coowners after transfer"
+        assert owner.id not in project.owners_ids, err_msg

--- a/test/test_view/test_project_transferownership.py
+++ b/test/test_view/test_project_transferownership.py
@@ -151,13 +151,14 @@ class TestProjectTransferOwnership(web.Helper):
     def test_transfer_retain_coowners(self):
         """Test transfer ownership retains existing coowners after transfer to new owner."""
         admin, owner, user1, user2 = UserFactory.create_batch(4)
-        coowners = [user2.id]
+        coowners = [owner.id, user2.id]
         project = ProjectFactory.create(owner=owner, owners_ids=coowners)
         url = '/project/%s/transferownership?api_key=%s' % (project.short_name,
                                                             admin.api_key)
 
         # Sanity check that the correct owner and coowners have been set on the project.
         assert project.owner_id == owner.id
+        assert owner.id in project.owners_ids
         assert user2.id in project.owners_ids
 
         csrf = self.get_csrf(url)


### PR DESCRIPTION
- Retain coowners when transferring project ownership.
- Added unit tests.

## Unit Tests

```text
(env3) /mnt/c/Projects/gigwork/pybossa$ nosetests 'test/test_view/test_project_transferownership.py:TestProjectTransferOwnership.test_transfer_retain_coowners' -s
Test transfer ownership retains existing coowners after transfer to new owner. ... passed

----------- coverage: platform linux, python 3.9.5-final-0 -----------
Coverage HTML written to dir htmlcov
-----------------------------------------------------------------------------
1 test run in 30.246 seconds (1 test passed)
```

```
(env3) /mnt/c/Projects/gigwork/pybossa$ nosetests 'test/test_view/test_project_transferownership.py:TestProjectTransferOwnership.test_transfer_retain_coowners_multi' -s
Test transfer ownership retains existing coowners (multiple) after transfer to new owner. ... passed

----------- coverage: platform linux, python 3.9.5-final-0 -----------
Coverage HTML written to dir htmlcov
-----------------------------------------------------------------------------
1 test run in 29.916 seconds (1 test passed)
```

Re: https://github.com/bloomberg/pybossa-default-theme/pull/357