### PR TITLE
RDISCROWD-4870 Task Reservation should be released upon submit and leave

### DIFF
--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -562,7 +562,7 @@ def cancel_task(task_id=None):
             current_app.logger.info(
                 'Project {} - user {} cancelled task {}'
                 .format(project.id, current_user.id, task_id))
-            release_reserve_task_lock_by_id(project.id, task_id, current_user.id, timeout, expiry=EXPIRE_LOCK_DELAY)
+            release_reserve_task_lock_by_id(project.id, task_id, current_user.id, timeout, expiry=EXPIRE_LOCK_DELAY, release_all_task=True)
 
     return Response(json.dumps({'success': True}), 200, mimetype="application/json")
 

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -564,6 +564,27 @@ def cancel_task(task_id=None):
                 .format(project.id, current_user.id, task_id))
             release_reserve_task_lock_by_id(project.id, task_id, current_user.id, timeout, expiry=EXPIRE_LOCK_DELAY)
 
+    return Response(json.dumps({'success': True}), 200, mimetype="application/json")
+
+
+@jsonpify
+@csrf.exempt
+@login_required
+@blueprint.route('/task/<int:task_id>/release_category_locks', methods=['POST'])
+@ratelimit(limit=ratelimits.get('LIMIT'), per=ratelimits.get('PER'))
+def release_category_locks(task_id=None):
+    """Unlock all category (reservation) locks reserved by this user"""
+    if not current_user.is_authenticated:
+        return abort(401)
+
+    project_name = request.json.get('projectname', None)
+    project = project_repo.get_by_shortname(project_name)
+    if not project:
+        return abort(400)
+
+    scheduler, timeout = get_scheduler_and_timeout(project)
+    if scheduler == Schedulers.task_queue:
+        release_reserve_task_lock_by_id(project.id, task_id, current_user.id, timeout, expiry=EXPIRE_LOCK_DELAY, release_all_task=True)
 
     return Response(json.dumps({'success': True}), 200, mimetype="application/json")
 

--- a/pybossa/redis_lock.py
+++ b/pybossa/redis_lock.py
@@ -268,7 +268,6 @@ class LockManager(object):
             category_keys = [ key for key in category_keys if drop_user not in key ]
         return category_keys
 
-
     def acquire_reserve_task_lock(self, project_id, task_id, user_id, category):
         if not(project_id and user_id and task_id and category):
             raise BadRequest('Missing required parameters')
@@ -281,8 +280,10 @@ class LockManager(object):
         expiration = timestamp + self._duration + EXPIRE_RESERVE_TASK_LOCK_DELAY
         return self._redis.set(resource_id, expiration)
 
-
     def release_reserve_task_lock(self, resource_id, expiry):
         #cache = pipeline or self._redis # https://pythonrepo.com/repo/andymccurdy-redis-py-python-connecting-and-operating-databases#locks
         cache = self._redis
         cache.expire(resource_id, expiry)
+
+    def scan_keys(self, pattern):
+        return self._redis.scan_iter(pattern)

--- a/pybossa/sched.py
+++ b/pybossa/sched.py
@@ -25,10 +25,10 @@ from pybossa.model.task_run import TaskRun
 from pybossa.model.counter import Counter
 from pybossa.core import db, sentinel, project_repo, task_repo
 from .redis_lock import (LockManager, get_active_user_key, get_user_tasks_key,
-                        get_task_users_key, get_task_id_project_id_key,
-                        register_active_user, unregister_active_user,
-                        get_active_user_count,
-                        EXPIRE_RESERVE_TASK_LOCK_DELAY)
+                         get_task_users_key, get_task_id_project_id_key,
+                         register_active_user, unregister_active_user,
+                         get_active_user_count,
+                         EXPIRE_RESERVE_TASK_LOCK_DELAY)
 from .contributions_guard import ContributionsGuard
 from werkzeug.exceptions import BadRequest, Forbidden
 import random
@@ -384,6 +384,7 @@ def reserve_task_sql_filters(project_id, reserve_task_keys, exclude):
 
         category_keys += [item]
         category = data.group(1)
+
         if category in filter_dict:
             continue
 
@@ -590,20 +591,28 @@ def acquire_lock(task_id, user_id, limit, timeout, pipeline=None, execute=True):
     return False
 
 
-def release_reserve_task_lock_by_id(project_id, task_id, user_id, timeout, expiry=EXPIRE_RESERVE_TASK_LOCK_DELAY):
+def release_reserve_task_lock_by_id(project_id, task_id, user_id, timeout, expiry=EXPIRE_RESERVE_TASK_LOCK_DELAY, release_all_task=None):
     reserve_key = get_reserve_task_key(task_id)
     if not reserve_key:
         return
 
     redis_conn = sentinel.master
     lock_manager = LockManager(redis_conn, timeout)
-    resource_id = "reserve_task:project:{}:category:{}:user:{}:task:{}".format(
-        project_id, reserve_key, user_id, task_id)
-    lock_manager.release_reserve_task_lock(resource_id, expiry)
-    current_app.logger.info(
-        "Release reserve task lock. project %s, task %s, user %s, expiry %d",
-        project_id, task_id, user_id, expiry
-    )
+    if release_all_task:
+        pattern = "reserve_task:project:{}:category:{}:user:{}:task:*".format(
+            project_id, reserve_key, user_id)
+        resource_ids = lock_manager.scan_keys(pattern)
+        for k in resource_ids:
+            lock_manager.release_reserve_task_lock(k, expiry)
+            current_app.logger.info("Release reserve task locks: %s", k)
+    else:
+        resource_id = "reserve_task:project:{}:category:{}:user:{}:task:{}".format(
+            project_id, reserve_key, user_id, task_id)
+        lock_manager.release_reserve_task_lock(resource_id, expiry)
+        current_app.logger.info(
+            "Release reserve task lock. project %s, task %s, user %s, expiry %d",
+            project_id, task_id, user_id, expiry
+        )
 
 
 def release_reserve_task_lock_by_keys(resource_ids, timeout, pipeline=None, expiry=EXPIRE_RESERVE_TASK_LOCK_DELAY):

--- a/pybossa/sched.py
+++ b/pybossa/sched.py
@@ -591,7 +591,7 @@ def acquire_lock(task_id, user_id, limit, timeout, pipeline=None, execute=True):
     return False
 
 
-def release_reserve_task_lock_by_id(project_id, task_id, user_id, timeout, expiry=EXPIRE_RESERVE_TASK_LOCK_DELAY, release_all_task=None):
+def release_reserve_task_lock_by_id(project_id, task_id, user_id, timeout, expiry=EXPIRE_RESERVE_TASK_LOCK_DELAY, release_all_task=False):
     reserve_key = get_reserve_task_key(task_id)
     if not reserve_key:
         return
@@ -607,7 +607,7 @@ def release_reserve_task_lock_by_id(project_id, task_id, user_id, timeout, expir
             # If a task is locked by the user(in other tab), then the category lock should not be released
             if task_id_in_key == task_id or not lock_manager.has_lock(get_task_users_key(task_id_in_key), user_id):
                 lock_manager.release_reserve_task_lock(k, expiry)
-                current_app.logger.info("Release reserve task locks: %s, task %d", k, task_id_in_key)
+                current_app.logger.info("Release reserve task locks: %s, task: %d, project: %s, user: %s", k, task_id_in_key, project_id, user_id)
     else:
         resource_id = "reserve_task:project:{}:category:{}:user:{}:task:{}".format(
             project_id, reserve_key, user_id, task_id)

--- a/test/test_reserve_task_category.py
+++ b/test/test_reserve_task_category.py
@@ -274,7 +274,31 @@ class TestReserveTaskCategory(sched.Helper):
         expiry = 1
         release_reserve_task_lock_by_id(project.id, task.id, user.id, timeout, expiry=expiry)
         time.sleep(expiry)
-        assert expected_reserve_task_key not in sentinel.master.keys(), "reserve task key should not exist in redis cache"
+        assert expected_reserve_task_key.encode() not in sentinel.master.keys(), "reserve task key should not exist in redis cache"
+
+        # test releasing multiple locks
+        batch_number = 10
+        tasks = TaskFactory.create_batch(
+            batch_number, project=project, n_answers=1,
+            info=dict(field_1="abc", field_2=123)
+        )
+        for task in tasks:
+            acquire_reserve_task_lock(project.id, task.id, user.id, timeout)
+            category_key = ":".join([f"{field}:{task.info[field]}" for field in category_fields])
+            expected_reserve_task_key = f"reserve_task:project:{project.id}:category:{category_key}:user:{user.id}:task:{task.id}"
+            assert expected_reserve_task_key.encode() in sentinel.master.keys(), "reserve task key must exist in redis cache"
+
+        expiry = 1
+        # import pdb; pdb.set_trace()
+        release_reserve_task_lock_by_id(project.id, tasks[0].id, user.id, timeout,
+                                        expiry=expiry, release_all_task=True)
+        time.sleep(expiry)
+        for task in tasks:
+            category_key = ":".join([f"{field}:{task.info[field]}" for field in category_fields])
+            expected_reserve_task_key = f"reserve_task:project:{project.id}:category:{category_key}:user:{user.id}:task:{task.id}"
+            assert expected_reserve_task_key.encode() not in sentinel.master.keys(), "reserve task key should not exist in redis cache"
+
+        time.sleep(expiry*2)
 
 
     @with_context

--- a/test/test_reserve_task_category.py
+++ b/test/test_reserve_task_category.py
@@ -288,8 +288,6 @@ class TestReserveTaskCategory(sched.Helper):
             expected_reserve_task_key = f"reserve_task:project:{project.id}:category:{category_key}:user:{user.id}:task:{task.id}"
             assert expected_reserve_task_key.encode() in sentinel.master.keys(), "reserve task key must exist in redis cache"
 
-        expiry = 1
-        # import pdb; pdb.set_trace()
         release_reserve_task_lock_by_id(project.id, tasks[0].id, user.id, timeout,
                                         expiry=expiry, release_all_task=True)
         time.sleep(expiry)
@@ -297,9 +295,6 @@ class TestReserveTaskCategory(sched.Helper):
             category_key = ":".join([f"{field}:{task.info[field]}" for field in category_fields])
             expected_reserve_task_key = f"reserve_task:project:{project.id}:category:{category_key}:user:{user.id}:task:{task.id}"
             assert expected_reserve_task_key.encode() not in sentinel.master.keys(), "reserve task key should not exist in redis cache"
-
-        time.sleep(expiry*2)
-
 
     @with_context
     def test_get_reserve_task_key(self):

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -9753,7 +9753,7 @@ class TestWebUserMetadataUpdate(web.Helper):
         assert data.get('status_code') == 400, data
 
     @with_context
-    def test_cancel_task_without_auth(self):
+    def test_release_category_locks_without_auth(self):
         """Test cancel task without auth"""
 
         url = "/api/task/1/release_category_locks"
@@ -9768,7 +9768,7 @@ class TestWebUserMetadataUpdate(web.Helper):
 
     @with_context
     @patch('pybossa.api.release_reserve_task_lock_by_id')
-    def test_cancel_task_succeed(self, release_reserve_task_lock_by_id):
+    def test_release_category_locks_succeed(self, release_reserve_task_lock_by_id):
         """Test cancel """
 
         url = "/api/task/1/release_category_locks"


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-4870*

**Describe your changes**
Add an endpoint for the front-end to call to release category locks. 

The call stack is as follows:
Click "Submit and Leave" (or "Submit") button -> pybossa-vue/app.js/submit() -> pybossa.js/saveTask() -> pybossa.js/_createTaskRun() -> pybossa.js/_saveTaskRun -> API POST call to 'api/taskrun' or 'api/project/<projectId>/taskgold' -> event_listeners.py/on_taskrun_submit() -> sched.py/after_save() -> sched.py/release_reserve_task_lock_by_id()

**Testing performed**
Tested locally

**Additional context**
https://github.com/bloomberg/pybossa.js/pull/14
https://github.com/bloomberg/pybossa-default-theme/pull/361
https://bbgithub.dev.bloomberg.com/GIGwork/pybossa-vue/pull/117