### PR TITLE
Bug fix for task timeout when user closes tab followed by start contr…

### DIFF
--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1345,17 +1345,21 @@ def presenter(short_name):
             flash(gettext("Sorry, but this project is still a draft and does "
                           "not have a task presenter."), "error")
 
+        # Set the original timeout seconds to display in the message.
+        timeout = project.timeout
+        template_args['project'].original_timeout = timeout
+
         # Get locked task for this project.
         task_id, remaining_time = get_task_id_and_duration_for_project_user(project.id, user_id)
         if task_id and remaining_time > 10:
-            # This user already has a locked task, take the first one being served.
-            # Set the original timeout seconds to display in the message.
-            timeout = project.timeout
-            template_args['project'].original_timeout = timeout
-            # Set the seconds remaining to display in the message.
+            # This user already has a locked task, take the timeout for the first one being served.
             template_args['project'].timeout = remaining_time
-            current_app.logger.info("User %s present task %s, remaining time %s, original timeout %s",
-                                    user_id, task_id, remaining_time, timeout)
+        else:
+            template_args['project'].timeout = timeout
+
+        current_app.logger.info("User %s present task %s, remaining time %s, original timeout %s",
+                                user_id, task_id, template_args['project'].timeout,
+                                template_args['project'].original_timeout)
 
         return respond('/projects/presenter.html')
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1346,11 +1346,11 @@ def presenter(short_name):
                           "not have a task presenter."), "error")
 
         # Get locked task for this project.
-        timeout = project.timeout
         task_id, remaining_time = get_task_id_and_duration_for_project_user(project.id, user_id)
-        if task_id and remaining_time:
+        if task_id and remaining_time > 10:
             # This user already has a locked task, take the first one being served.
             # Set the original timeout seconds to display in the message.
+            timeout = project.timeout
             template_args['project'].original_timeout = timeout
             # Set the seconds remaining to display in the message.
             template_args['project'].timeout = remaining_time

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1351,11 +1351,8 @@ def presenter(short_name):
 
         # Get locked task for this project.
         task_id, remaining_time = get_task_id_and_duration_for_project_user(project.id, user_id)
-        if task_id and remaining_time > 10:
-            # This user already has a locked task, take the timeout for the first one being served.
-            template_args['project'].timeout = remaining_time
-        else:
-            template_args['project'].timeout = timeout
+        # If this user already has a locked task, take the timeout for the first one being served else new.
+        template_args['project'].timeout = remaining_time if task_id and remaining_time > 10 else timeout
 
         current_app.logger.info("User %s present task %s, remaining time %s, original timeout %s",
                                 user_id, task_id, template_args['project'].timeout,

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -87,7 +87,8 @@ from pybossa.cache.helpers import n_available_tasks_for_user, latest_submission_
 from pybossa.util import crossdomain
 from pybossa.error import ErrorStatus
 from pybossa.redis_lock import get_locked_tasks_project
-from pybossa.sched import Schedulers, select_task_for_gold_mode, lock_task_for_user, fetch_lock_for_user
+from pybossa.sched import (Schedulers, select_task_for_gold_mode, lock_task_for_user, fetch_lock_for_user,
+    get_task_id_and_duration_for_project_user)
 from pybossa.syncer import NotEnabled, SyncUnauthorized
 from pybossa.syncer.project_syncer import ProjectSyncer
 from pybossa.exporter.csv_reports_export import ProjectReportCsvExporter
@@ -1344,24 +1345,17 @@ def presenter(short_name):
             flash(gettext("Sorry, but this project is still a draft and does "
                           "not have a task presenter."), "error")
 
-        # Get locked tasks for this project.
-        locked_tasks = get_locked_tasks_project(project.id)
-        # Filter locked tasks for this user.
-        user_locked_tasks = list(filter(lambda task, u_id=user_id: task.get('user_id') == str(u_id), locked_tasks))
-        if user_locked_tasks:
+        # Get locked task for this project.
+        timeout = project.timeout
+        task_id, remaining_time = get_task_id_and_duration_for_project_user(project.id, user_id)
+        if task_id and remaining_time:
             # This user already has a locked task, take the first one being served.
-            task = user_locked_tasks[0]
-
-            # Verify the worker has an unexpired lock on the task. Otherwise, task will fail to submit.
-            timeout, ttl = fetch_lock_for_user(project.id, task.get('task_id'), user_id)
-            remaining_time = float(ttl) - time.time() if ttl else None
-
             # Set the original timeout seconds to display in the message.
             template_args['project'].original_timeout = timeout
             # Set the seconds remaining to display in the message.
             template_args['project'].timeout = remaining_time
             current_app.logger.info("User %s present task %s, remaining time %s, original timeout %s",
-                                    user_id, task.get('task_id'), remaining_time, timeout)
+                                    user_id, task_id, remaining_time, timeout)
 
         return respond('/projects/presenter.html')
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1343,6 +1343,26 @@ def presenter(short_name):
         if has_no_presenter(project):
             flash(gettext("Sorry, but this project is still a draft and does "
                           "not have a task presenter."), "error")
+
+        # Get locked tasks for this project.
+        locked_tasks = get_locked_tasks_project(project.id)
+        # Filter locked tasks for this user.
+        user_locked_tasks = list(filter(lambda task, u_id=user_id: task.get('user_id') == str(u_id), locked_tasks))
+        if user_locked_tasks:
+            # This user already has a locked task, take the first one being served.
+            task = user_locked_tasks[0]
+
+            # Verify the worker has an unexpired lock on the task. Otherwise, task will fail to submit.
+            timeout, ttl = fetch_lock_for_user(project.id, task.get('task_id'), user_id)
+            remaining_time = float(ttl) - time.time() if ttl else None
+
+            # Set the original timeout seconds to display in the message.
+            template_args['project'].original_timeout = timeout
+            # Set the seconds remaining to display in the message.
+            template_args['project'].timeout = remaining_time
+            current_app.logger.info("User %s present task %s, remaining time %s, original timeout %s",
+                                    user_id, task.get('task_id'), remaining_time, timeout)
+
         return respond('/projects/presenter.html')
 
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3298,7 +3298,6 @@ class TestWeb(web.Helper):
         # Simulate user closing tab and clicking Start Contributing Now, should receive already locked task.
         res = self.app.get('project/%s/newtask' % (project.short_name), follow_redirects=True, headers={'X-CSRFToken': csrf})
         assert res.status_code == 200, res
-
         # Verify the remaining time (first parameter) has changed due to existing lock.
         assert 'setup_task_timeout_display(10.0, 3600)' in str(res.data), "Incorrect timeout value"
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3263,6 +3263,46 @@ class TestWeb(web.Helper):
         assert '"timeout":10' in str(res.data), "Incorrect value for timeout"
 
     @with_context
+    @patch('pybossa.view.projects.fetch_lock_for_user')
+    @patch('pybossa.view.projects.get_locked_tasks_project')
+    @patch('pybossa.view.projects.time')
+    def test_get_next_task_with_lock_seconds_remaining(self, mock_time, get_locked_tasks_project, fetch_lock_for_user):
+        self.create()
+        self.delete_task_runs()
+        self.register()
+
+        # Sign-in as user.
+        email_addr = 'johndoe@example.com'
+        make_subadmin_by(email_addr=email_addr)
+        csrf = self.get_csrf('/account/signin')
+        self.signin(email=email_addr, csrf=csrf)
+
+        # Get the project, task, and user.
+        project = db.session.query(Project).first()
+        task = db.session.query(Task)\
+                 .filter(Project.id == project.id)\
+                 .first()
+        user = db.session.query(User).filter(User.email_addr == email_addr).first()
+
+        # Simulate lock on task.
+        res = self.app.get('project/%s/newtask' % (project.short_name), follow_redirects=True, headers={'X-CSRFToken': csrf})
+        assert res.status_code == 200, res
+        assert 'setup_task_timeout_display(3600, 3600)' in str(res.data), "Incorrect timeout value"
+
+        # Mock a redis lock return value.
+        get_locked_tasks_project.return_value = [{ "user_id": str(user.id), "task_id": task.id }]
+        mock_now = 1652131709
+        mock_time.time.return_value = mock_now
+        fetch_lock_for_user.return_value = (3600, mock_now+10)
+
+        # Simulate user closing tab and clicking Start Contributing Now, should receive already locked task.
+        res = self.app.get('project/%s/newtask' % (project.short_name), follow_redirects=True, headers={'X-CSRFToken': csrf})
+        assert res.status_code == 200, res
+
+        # Verify the remaining time (first parameter) has changed due to existing lock.
+        assert 'setup_task_timeout_display(10.0, 3600)' in str(res.data), "Incorrect timeout value"
+
+    @with_context
     @patch('pybossa.view.projects.has_no_presenter')
     @patch('pybossa.view.projects.fetch_lock_for_user')
     @patch('pybossa.view.projects.time')

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3289,13 +3289,48 @@ class TestWeb(web.Helper):
         assert 'setup_task_timeout_display(3600, 3600)' in str(res.data), "Incorrect timeout value"
 
         # Mock a redis lock return value.
-        get_task_id_and_duration_for_project_user.return_value = (task.id, 10)
+        get_task_id_and_duration_for_project_user.return_value = (task.id, 11)
 
         # Simulate user closing tab and clicking Start Contributing Now, should receive already locked task.
         res = self.app.get('project/%s/newtask' % (project.short_name), follow_redirects=True, headers={'X-CSRFToken': csrf})
         assert res.status_code == 200, res
         # Verify the remaining time (first parameter) has changed due to existing lock.
-        assert 'setup_task_timeout_display(10, 3600)' in str(res.data), "Incorrect timeout value"
+        assert 'setup_task_timeout_display(11, 3600)' in str(res.data), "Incorrect timeout value"
+
+    @with_context
+    @patch('pybossa.view.projects.get_task_id_and_duration_for_project_user')
+    def test_get_next_task_with_lock_seconds_remaining_less_10(self, get_task_id_and_duration_for_project_user):
+        self.create()
+        self.delete_task_runs()
+        self.register()
+
+        # Sign-in as user.
+        email_addr = 'johndoe@example.com'
+        make_subadmin_by(email_addr=email_addr)
+        csrf = self.get_csrf('/account/signin')
+        self.signin(email=email_addr, csrf=csrf)
+
+        # Get the project, task, and user.
+        project = db.session.query(Project).first()
+        task = db.session.query(Task)\
+                 .filter(Project.id == project.id)\
+                 .first()
+        user = db.session.query(User).filter(User.email_addr == email_addr).first()
+
+        # Simulate lock on task.
+        get_task_id_and_duration_for_project_user.return_value = (None, -1)
+        res = self.app.get('project/%s/newtask' % (project.short_name), follow_redirects=True, headers={'X-CSRFToken': csrf})
+        assert res.status_code == 200, res
+        assert 'setup_task_timeout_display(3600, 3600)' in str(res.data), "Incorrect timeout value"
+
+        # Mock a redis lock return value.
+        get_task_id_and_duration_for_project_user.return_value = (task.id, 10)
+
+        # Simulate user closing tab and clicking Start Contributing Now, should receive already locked task.
+        res = self.app.get('project/%s/newtask' % (project.short_name), follow_redirects=True, headers={'X-CSRFToken': csrf})
+        assert res.status_code == 200, res
+        # Verify the remaining time (first parameter) is the default timeout since remaining was <= 10.
+        assert 'setup_task_timeout_display(3600, 3600)' in str(res.data), "Incorrect timeout value"
 
     @with_context
     @patch('pybossa.view.projects.has_no_presenter')


### PR DESCRIPTION
- Bug fix for task timeout when user closes tab followed by start contrib now with an already locked task.

### Steps to reproduce

1. Click start contributing now.
2. Click the project name to navigate back to the project info page.
3. Click start contributing now.
4. Confirm user receives the same (already) locked task.
5. Confirm the task timeout remaining seconds in the Chrome debug panel inspector are correct.

Solution follows same idea as [here](https://github.com/bloomberg/pybossa/blob/main/pybossa/view/projects.py#L1265-L1280).