### PR TITLE
RDISCROWD-5193 Allow case-insensitive required column names in CSV import

### DIFF
--- a/pybossa/importers/csv.py
+++ b/pybossa/importers/csv.py
@@ -280,7 +280,7 @@ class BulkTaskCSVImportBase(BulkTaskImport):
 
     def _check_required_headers(self):
         required_headers = app.config.get("TASK_REQUIRED_FIELDS", {})
-        missing_headers = [r for r in required_headers if r not in self._headers]
+        missing_headers = [r for r in map(str.upper, required_headers) if r not in map(str.upper, self._headers)]
         if missing_headers:
             msg = gettext('The file you uploaded has missing '
                           'required header(s): {0}'.format(','.join(missing_headers)))

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -609,24 +609,15 @@ class TestPybossaUtil(Test):
 
             # Check missing required field DATA_SOURCE_ID. Verify exception is raised.
             cs._headers = ['sentence', 'data_access', 'Data_Owner']
-            try:
-                cs._check_required_headers()
-            except:
-                pass
+            assert_raises(Exception, cs._check_required_headers)
 
             # Check missing required field DATA_OWNER. Verify exception is raised.
             cs._headers = ['sentence', 'data_access', 'data_source_id']
-            try:
-                cs._check_required_headers()
-            except:
-                pass
+            assert_raises(Exception, cs._check_required_headers)
 
-            # Check missing required field DATA_OWNER. Verify exception is raised.
+            # Check missing required field DATA_ACCESS. Verify exception is raised.
             cs._headers = ['sentence', 'data_owner', 'data_source_id']
-            try:
-                cs._check_required_headers()
-            except:
-                pass
+            assert_raises(Exception, cs._check_required_headers)
 
     @with_context
     def test_csv_validate_required_fields_accept_string(self):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -30,6 +30,7 @@ from flask_wtf import FlaskForm as Form
 from nose.tools import nottest, assert_raises
 
 import pybossa.util as util
+from pybossa.importers import BulkImportException
 from pybossa.importers.csv import BulkTaskCSVImport
 from test import with_context, Test, with_request_context
 from test.factories import UserFactory
@@ -583,7 +584,7 @@ class TestPybossaUtil(Test):
                     # Allow client to assert on result.
                     callback(index, invalid_fields)
 
-    @with_context
+    @with_request_context
     def csv_validate_required_fields_case_insensitive(self):
         """Test validate_required_fields against csv data
         with DATA_SOURCE_ID, DATA_OWNER in uppercase."""
@@ -609,15 +610,15 @@ class TestPybossaUtil(Test):
 
             # Check missing required field DATA_SOURCE_ID. Verify exception is raised.
             cs._headers = ['sentence', 'data_access', 'Data_Owner']
-            assert_raises(Exception, cs._check_required_headers)
+            assert_raises(BulkImportException, cs._check_required_headers)
 
             # Check missing required field DATA_OWNER. Verify exception is raised.
             cs._headers = ['sentence', 'data_access', 'data_source_id']
-            assert_raises(Exception, cs._check_required_headers)
+            assert_raises(BulkImportException, cs._check_required_headers)
 
             # Check missing required field DATA_ACCESS. Verify exception is raised.
             cs._headers = ['sentence', 'data_owner', 'data_source_id']
-            assert_raises(Exception, cs._check_required_headers)
+            assert_raises(BulkImportException, cs._check_required_headers)
 
     @with_context
     def test_csv_validate_required_fields_accept_string(self):


### PR DESCRIPTION
- Allow case-insensitive required CSV column names.
- Added unit test.