### PR TITLE
RDISCROWD-5206 Display Completed Responses in the Task View - Annex s…

### DIFF
--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -1153,3 +1153,49 @@ def generate_bsso_account_notification(user):
                                   server_url=server_url,
                                   is_qa=is_qa)
     return msg
+
+
+def is_annex_response(key, value):
+    """
+    Check whether a response is a odfoa response.
+    """
+    if key == "odfoa":
+        return True
+
+    odfoa_keys = {"version", "source-uri", "odf", "oa"}
+    return all(odfoa_key in value for odfoa_key in odfoa_keys)
+
+
+def process_annex_load(tp_code, response_value):
+    """
+    Process the tp_code so that after annex document is loaded, it also loads
+    annotations from the response_value
+    """
+    # Looking for loadDocument() or loadDocumentLite() code snippet
+    regex = r"(\w+)\.(loadDocument|loadDocumentLite)\s*\(\s*.*\s*(\))"
+    match = re.search(regex, tp_code)
+
+    if match:  # maching for pure javascript Annex code
+        annex_tab = match[1]  # the first group: (\w+)
+        odfoa = json.dumps(response_value)
+        code_to_append = f".then(() => {annex_tab}.loadAnnotationFromJson('{odfoa}'))"
+
+        right_parenthesis_end = match.end(3)  # the 3rd group: (\)) - exclusive
+        tp_code = tp_code[:right_parenthesis_end] + code_to_append + tp_code[right_parenthesis_end:]
+    else:
+        # Looking for code snippet like shell.setAttribute("hash", "abc");
+        regex = r"(\w+)\.setAttribute\(\"hash\",\s*\"\w+\"\);"
+        match = re.search(regex, tp_code)
+        if match:  # matching for annex_shell code
+            shell = match[1]
+            odfoa = json.dumps(response_value)
+            code_to_append = (
+                f"\n"
+                f"    {shell}.addEventListener('urn:bloomberg:annex:event:instance-success', () => {{\n"
+                f"      {shell}.internalModel.activeTab().loadAnnotationFromJson('{odfoa}')\n"
+                f"    }});"
+            )
+
+            semi_colon_end = match.end()  # semi colon position - exclusive
+            tp_code = tp_code[:semi_colon_end] + code_to_append + tp_code[semi_colon_end:]
+    return tp_code

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -1186,16 +1186,18 @@ def process_annex_load(tp_code, response_value):
         # Looking for code snippet like shell.setAttribute("hash", "abc");
         regex = r"(\w+)\.setAttribute\(\"hash\",\s*\"\w+\"\);"
         match = re.search(regex, tp_code)
-        if match:  # matching for annex_shell code
-            shell = match[1]
-            odfoa = json.dumps(response_value)
-            code_to_append = (
-                f"\n"
-                f"    {shell}.addEventListener('urn:bloomberg:annex:event:instance-success', () => {{\n"
-                f"      {shell}.internalModel.activeTab().loadAnnotationFromJson('{odfoa}')\n"
-                f"    }});"
-            )
+        if not match:
+            return tp_code
 
-            semi_colon_end = match.end()  # semi colon position - exclusive
-            tp_code = tp_code[:semi_colon_end] + code_to_append + tp_code[semi_colon_end:]
+        shell = match[1]
+        odfoa = json.dumps(response_value)
+        code_to_append = (
+            f"\n"
+            f"    {shell}.addEventListener('urn:bloomberg:annex:event:instance-success', () => {{\n"
+            f"      {shell}.internalModel.activeTab().loadAnnotationFromJson('{odfoa}')\n"
+            f"    }});"
+        )
+
+        semi_colon_end = match.end()  # semi colon position - exclusive
+        tp_code = tp_code[:semi_colon_end] + code_to_append + tp_code[semi_colon_end:]
     return tp_code

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1255,11 +1255,11 @@ def task_presenter(short_name, task_id, task_submitter_id=None):
         "user_id": user_id
     }
 
-    if task_submitter_id is not None:
+    if task_submitter_id:
         taskruns = task_repo.filter_task_runs_by(task_id=task_id,
-                                                 project_id=project.id)
-        taskruns_dict = {tr.user_id: tr.info for tr in taskruns}
-        user_response = taskruns_dict.get(task_submitter_id, {})
+                                                 project_id=project.id,
+                                                 user_id=task_submitter_id)
+        user_response = taskruns[0].info
         tp_code = template_args["project"].get("info", {}).get("task_presenter", '')
 
         for response_field, response_value in user_response.items():

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -51,8 +51,10 @@ from pybossa.model.blogpost import Blogpost
 from pybossa.util import (Pagination, admin_required, get_user_id_or_ip, rank,
                           handle_content_type, redirect_content_type,
                           get_avatar_url, admin_or_subadmin_required,
-                          s3_get_file_contents, fuzzyboolean, is_own_url_or_else,
-                          description_from_long_description)
+                          s3_get_file_contents, fuzzyboolean,
+                          is_own_url_or_else,
+                          description_from_long_description, is_annex_response,
+                          process_annex_load)
 from pybossa.auth import ensure_authorized_to
 from pybossa.cache import projects as cached_projects
 from pybossa.cache import users as cached_users
@@ -1192,8 +1194,9 @@ def make_random_task_gold(short_name):
 
 
 @blueprint.route('/<short_name>/task/<int:task_id>')
+@blueprint.route('/<short_name>/task/<int:task_id>/<int:task_submitter_id>')
 @login_required
-def task_presenter(short_name, task_id):
+def task_presenter(short_name, task_id, task_submitter_id=None):
     mode = request.args.get('mode')
     project, owner, ps = project_by_shortname(short_name)
     ensure_authorized_to('read', project)
@@ -1252,8 +1255,28 @@ def task_presenter(short_name, task_id):
         "user_id": user_id
     }
 
+    if task_submitter_id is not None:
+        taskruns = task_repo.filter_task_runs_by(task_id=task_id,
+                                                 project_id=project.id)
+        taskruns_dict = {tr.user_id: tr.info for tr in taskruns}
+        user_response = taskruns_dict.get(task_submitter_id, {})
+        tp_code = template_args["project"].get("info", {}).get("task_presenter", '')
+
+        for response_field, response_value in user_response.items():
+            placeholder_regex = r"{{\s*" + response_field + r"\s*}}"
+            if type(response_value) == str or type(response_value) == int:
+                tp_code = re.sub(placeholder_regex, str(response_value), tp_code)
+            elif type(response_value) == dict:
+                if is_annex_response(response_field, response_value):
+                    tp_code = process_annex_load(tp_code, response_value)
+                else:  # TODO - for TP component
+                    response_value = json.dumps(response_value)
+                    tp_code = re.sub(placeholder_regex, response_value, tp_code)
+
+        template_args["project"]["info"]["task_presenter"] = tp_code
+
     def respond(tmpl):
-        response = dict(template = tmpl, **template_args)
+        response = dict(template=tmpl, **template_args)
         return handle_content_type(response)
 
     if not (task.project_id == project.id):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -760,6 +760,129 @@ class TestPybossaUtil(Test):
         assert ned.email_addr in message["bcc"] and robb.email_addr not in message["bcc"], "Filtered enabled users not to be part of email list"
         assert tyrion.email_addr in message["recipients"], "Enabled user to be part of recipients list"
 
+    def test_is_annex_response(self):
+        key, value = "odfoa", "anything"
+        assert util.is_annex_response(key, value)
+
+        key = "abc"
+        valid_value = {"oa": [{"body": [{"@type": "bb:Transparency.Text.Text", "transparency": [{"selector": {"end": 2142, "@type": "oa:DataPositionSelector", "start": 2136}}]}],
+                               "target": [{"selector": {"id": "829dd359-d18c-fead-d4f500000000000b", "@type": "bb:OdfElementSelector"}}]},
+                              {"body": [{"@type": "reportYear", "value": "2022"}], "target": [{}]}],
+                       "odf": {"office:document": {"office:body": {"office:text": [{"text:p": {"xml:id": "829dd359-d18c-fead-d4f500000000000b", "office:string-value": "ANNUAL"}}]}, "office:meta": {}}},
+                       "version": "1.0",
+                       "source-uri": "https://s3.amazonaws.com/cf-s3uploads/tjb/comppres/0000764478-19-000009.html?task-signature=undefined"}
+        assert util.is_annex_response(key, valid_value)
+
+        key = "efg"
+        invalid_value = {"odf": {"office:document": {"office:body": {
+                           "office:text": [{"text:p": {
+                               "xml:id": "829dd359-d18c-fead-d4f500000000000b",
+                               "office:string-value": "ANNUAL"}}]},
+                                                   "office:meta": {}}},
+                       "version": "1.0",
+                       "source-uri": "https://s3.amazonaws.com/cf-s3uploads/tjb/comppres/0000764478-19-000009.html?task-signature=undefined"}
+        assert not util.is_annex_response(key, invalid_value)
+
+    def test_process_annex_load(self):
+        annex_shell_tp_code = """function loadAnnex(task) {
+            const shell = document.getElementById("shell-container");
+            // this is the document field in your task.
+            shell.setAttribute("gigwork:doc-url", task.info.document__upload_url);
+            // this is the annotation field in your task
+            //shell.setAttribute("gigwork:annotation-url", task.info.annotation__upload_url);
+            // you need the task signature to load encrypted files
+            shell.setAttribute("gigwork:task-sig", task.signature);
+            // you should customize this for users.
+            console.log('483902jg')
+            console.log(task)
+            shell.setAttribute("user", "skorala");
+            // hash comes from gigwork task. for example, task.info.annex_hash.
+            shell.setAttribute("hash", "8A0FAE8EC1D64DF7539210CF9658C1C3");
+            shell.addEventListener("urn:bloomberg:annex:event:instance-ready", () => {
+              console.log("ready to start");
+              // add any code you need to run when Annex is ready.
+            });
+            shell.addEventListener("urn:bloomberg:annex:event:instance-error", () => {
+              document.getElementById("skipButton").classList.toggle('invisible')
+              document.getElementById("submitButton").classList.toggle('invisible')
+              // add any code you need to run when Annex is ready.
+            });
+          }
+        </script>"""
+        odfoa_data = {"a": 1}
+        tp_code = util.process_annex_load(annex_shell_tp_code, odfoa_data)
+        assert "shell.addEventListener('urn:bloomberg:annex:event:instance-success', () => {" in tp_code
+        assert f"shell.internalModel.activeTab().loadAnnotationFromJson('{json.dumps(odfoa_data)}')" in tp_code
+
+        annex_js_tp_code = """async function doPybossa(pybossa, gigConfig) {
+            document.getElementById('collapse-guidelines').classList.remove('show');
+        
+            const Annex = await window.loadDocx();
+            const annex = window.loadeddocx = new Annex();
+            document.getElementById('annex').appendChild(annex.getDom()[0]);
+        
+            // Annex supports multiple tabs with a document in each one.
+            // However, for a single document you will not see the tab or its title.
+            const annexTab = annex.addTab('tab title', gigConfig.annex);
+            const {getAnswer, reset} = pointAndShoot(annexTab);
+            const annexModel = annexTab._internal.model;
+            annexModel.isAutoFormatRowColumnEnabled(false);
+            annexModel.isFillTableContentEnabled(false);
+        
+            // 'LEFT', 'RIGHT', 'TOP', 'BOTTOM'
+            annexModel.annotatorPosition('BOTTOM');
+            annexModel.isThumbnailBarPinned(false);
+        
+            pybossa.beforeSubmit(beforePybossaSubmitTask);
+            pybossa.beforePresent(beforePybossaPresentTask);
+         //   pybossa.run(gigConfig.project.name);
+        
+            function beforePybossaSubmitTask(answer, task) {
+                // Return the actual answer you want to submit.
+                // We are ignoring the answer parameter provided by the framework
+                // and handling the entire answer construction ourselves.
+                return getAnswer(task);
+            }
+        
+            function beforePybossaPresentTask(task) {
+                reset();
+                $('#field1').prop('disabled', false);
+                console.log('beforePybossaPresentTask, task.info=', JSON.stringify(task.info));
+                return annexTab.loadDocumentLite(
+                  task.info.doc_url + '?t=' + Date.now(), {}
+                );
+            }
+          }
+        </script>"""
+        tp_code = util.process_annex_load(annex_js_tp_code, odfoa_data)
+        assert f".then(() => annexTab.loadAnnotationFromJson('{json.dumps(odfoa_data)}'))" in tp_code
+
+        annex_js_tp_code = """pybossa.presentTask(function (task, deferred) {
+        console.log('pybossa:presentTask', arguments);
+
+        if (!$.isEmptyObject(task)) {
+          //var docUrl = Object.values(task.info)[2];
+          var docUrl = task.info.docUrl;
+          console.log('docUrl', docUrl);
+
+          // Load document into Annex tab
+          const loadDocumentPromise = () => tab.loadDocumentLite(docUrl)
+          const loadOdfoaPromise = () => $.ajax({
+            url: odfUrl,
+            dataType: 'text'
+          });
+
+          Promise.all([
+            loadDocumentPromise(),
+          ]).then(([_void]) => {
+            console.log('doc loaded');
+          }).catch((err) => {
+            console.error(err);
+          });
+        }"""
+        tp_code = util.process_annex_load(annex_js_tp_code, odfoa_data)
+        assert f".then(() => tab.loadAnnotationFromJson('{json.dumps(odfoa_data)}'))" in tp_code
+
 
 class TestIsReservedName(object):
     from test import flask_app as app

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3375,6 +3375,29 @@ class TestWeb(web.Helper):
 
         assert fake_guard_instance.stamp.called
 
+    @with_context
+    def test_task_presenter(self):
+        """Test WEB get correct task.id for a project works"""
+        self.register()
+        self.signin()
+        self.create()
+        project = db.session.query(Project).get(1)
+        self.new_task(project.id)
+        project_short_name = project.short_name
+
+        task = db.session.query(Task).filter(Task.project_id == 1).first()
+
+        user = db.session.query(User).first()
+        task_run = TaskRun(project_id=project.id, task_id=task.id,
+                           info={'answer': 1,
+                                 'odfoa': {'a': 26},
+                                 'fake': {'b': 27}},
+                           user_id=user.id)
+        db.session.add(task_run)
+        db.session.commit()
+
+        res = self.app.get('/project/%s/task/%s/%s' % (project_short_name, task.id, user.id))
+        assert b'TaskPresenter' in res.data
 
     @with_context
     @patch('pybossa.view.projects.uploader.upload_file', return_value=True)


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-5206*

**Describe your changes**
Process the TP code so that after Annex doc is added, a callback function is added to load the response to the document. There are two types Annex TP code supported, annex-shell and original pure javascript code.

**Testing performed**
Tested locally.

**Additional context**
Related PR: https://github.com/bloomberg/pybossa-default-theme/pull/364 
