### PR TITLE
RDISCROWD-5196: Add new api bulktasks

### DIFF
--- a/create_bulk_tasks.py
+++ b/create_bulk_tasks.py
@@ -11,7 +11,7 @@ task create date ranges.
 import argparse
 import pandas as pd
 import json
-import datetime
+from datetime import datetime
 import numpy as np
 from random import randrange
 import logging
@@ -35,7 +35,7 @@ handler.setLevel(logging.DEBUG)
 handler.setFormatter(formatter)
 root_logger.addHandler(handler)
 logger = logging.getLogger("datapurge")
-
+current_year = datetime.today().year
 
 def create_task(project_id, created, num_answers, priority, year):
     sql = """
@@ -110,11 +110,11 @@ def create_result(project_id, task_id, task_run_ids, created):
         logger.exception("Error: ", error)
 
 
-def create_bulk_data(project_id, num_records):
+def create_bulk_data(project_id, num_records, random_year):
     for _ in range(num_records):
         month = randrange(1, 12)
         day = randrange(1, 30)
-        year = randrange(2018, 2022)
+        year = randrange(current_year - 2, current_year) if random_year else current_year
         hour = randrange(1, 23)
         min = randrange(1, 59)
         priority=randrange(10)/10
@@ -136,6 +136,7 @@ def setup_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("-n", "--numtasks", dest="num_tasks", type=int, required=True, help="number of tasks to create")
     parser.add_argument("-p", "--projectid", dest="project_id", type=int, required=True, help="project id under which tasks to create")
+    parser.add_argument("-y", "--no-random-year", dest="random_year", default=True, help="generate tasks by current year; disable random create year range", action="store_false")
     args = parser.parse_args()
     return args
 
@@ -144,7 +145,8 @@ def main():
     args = setup_args()
     logger.info(f"number of tasks to create: {args.num_tasks}")
     logger.info(f"number of projects: {args.project_id}")
-    create_bulk_data(project_id=args.project_id, num_records=args.num_tasks)
+    logger.info(f"generate tasks with random year: {args.random_year}")
+    create_bulk_data(project_id=args.project_id, num_records=args.num_tasks, random_year=args.random_year)
 
 if __name__ == "__main__":
     main()

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -88,6 +88,7 @@ from pybossa.cache.task_browse_helpers import get_searchable_columns
 from pybossa.cache.users import get_user_pref_metadata
 from pybossa.view.projects import get_locked_tasks
 from pybossa.redis_lock import EXPIRE_LOCK_DELAY
+from pybossa.api.bulktasks import BulkTasksAPI
 
 task_fields = [
     "id",
@@ -158,6 +159,7 @@ register_api(CompletedTaskAPI, 'api_completedtask', '/completedtask', pk='oid', 
 register_api(CompletedTaskRunAPI, 'api_completedtaskrun', '/completedtaskrun', pk='oid', pk_type='int')
 register_api(ProjectByNameAPI, 'api_projectbyname', '/projectbyname', pk='key', pk_type='string')
 register_api(PerformanceStatsAPI, 'api_performancestats', '/performancestats', pk='oid', pk_type='int')
+register_api(BulkTasksAPI, 'api_bulktasks', '/bulktasks', pk='oid', pk_type='int')
 
 
 def add_task_signature(tasks):

--- a/pybossa/api/bulktasks.py
+++ b/pybossa/api/bulktasks.py
@@ -74,11 +74,10 @@ class BulkTasksAPI(TaskAPI):
                 task = task_repo.get_task(data.get("id"))
                 if not (task and task.project_id == project.id):
                     dropped_payload.append(data)
-                    continue
                 elif [k for k in data.keys() if k not in allowed_attributes]:
                     dropped_payload.append(data)
-                    continue
-                update_payload.append(data)
+                else:
+                    update_payload.append(data)
 
             current_app.logger.info(f"Project {project.id}, input for bulk update {str(update_info)}, dropped payload {dropped_payload}")
             current_app.logger.info(f"Calling bulk update for project {project.id} with payload {str(update_payload)}")

--- a/pybossa/api/bulktasks.py
+++ b/pybossa/api/bulktasks.py
@@ -23,15 +23,13 @@ from flask import current_app
 from flask_login import current_user
 from werkzeug.exceptions import NotFound, BadRequest
 from werkzeug.exceptions import MethodNotAllowed, Unauthorized
-from pybossa.cache import memoize
-from pybossa.core import project_repo, task_repo, timeouts
+from pybossa.core import project_repo, task_repo
 from pybossa.error import ErrorStatus
 from pybossa.api.task import TaskAPI
 from pybossa.model.task import Task
 from pybossa.util import jsonpify, crossdomain
 from pybossa.core import ratelimits
 from pybossa.ratelimit import ratelimit
-from pybossa.util import admin_or_subadmin_required
 
 
 cors_headers = ["Content-Type", "Authorization"]
@@ -88,6 +86,7 @@ class BulkTasksAPI(TaskAPI):
             json_response = {}
             return Response(json_response, mimetype="application/json")
         except Exception as e:
+            current_app.logger.exception(f"Error in bulktasks PUT request, {str(e)}")
             return error.format_exception(
                 e,
                 target=self.__class__.__name__.lower(),

--- a/pybossa/api/bulktasks.py
+++ b/pybossa/api/bulktasks.py
@@ -1,0 +1,95 @@
+# -*- coding: utf8 -*-
+# This file is part of PYBOSSA.
+#
+# Copyright (C) 2022 Scifabric LTD.
+#
+# PYBOSSA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PYBOSSA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
+"""
+PYBOSSA api module for exposing domain object BulkTaskUpdate via an API.
+"""
+from flask import request, Response
+from flask import current_app
+from flask_login import current_user
+from werkzeug.exceptions import NotFound, BadRequest
+from werkzeug.exceptions import MethodNotAllowed, Unauthorized
+from pybossa.cache import memoize
+from pybossa.core import project_repo, task_repo, timeouts
+from pybossa.error import ErrorStatus
+from pybossa.api.task import TaskAPI
+from pybossa.model.task import Task
+from pybossa.util import jsonpify, crossdomain
+from pybossa.core import ratelimits
+from pybossa.ratelimit import ratelimit
+from pybossa.util import admin_or_subadmin_required
+
+
+cors_headers = ["Content-Type", "Authorization"]
+allowed_attributes = ["id", "priority_0"]
+error = ErrorStatus()
+
+class BulkTasksAPI(TaskAPI):
+
+    """Class for domain object Task."""
+
+    __class__ = Task
+
+    def get(self, oid=None):
+        raise MethodNotAllowed
+
+    def post(self):
+        raise MethodNotAllowed
+
+    def delete(self, oid=None):
+        raise MethodNotAllowed
+
+    @jsonpify
+    @crossdomain(origin="*", headers=cors_headers)
+    @ratelimit(limit=ratelimits.get("LIMIT"), per=ratelimits.get("PER"))
+    def put(self, oid):
+        """Update task attributes in bulk. Need atleast subadmin access"""
+        if current_user.is_anonymous or not(current_user.admin or current_user.subadmin):
+            raise Unauthorized("Insufficient privilege to the request")
+
+        project = project_repo.get(oid)
+        update_info = request.json
+        if not (project and update_info):
+            raise BadRequest
+
+        all_owners = project.owners_ids + ([project.owner_id] if project.owner_id not in project.owners_ids else [])
+        if not (current_user.admin or current_user.id in all_owners):
+            raise Unauthorized("Insufficient privilege to the request")
+
+        try:
+            update_payload, dropped_payload = [], []
+            for data in update_info:
+                task = task_repo.get_task(data.get("id"))
+                if not (task and task.project_id == project.id):
+                    dropped_payload.append(data)
+                    continue
+                elif [k for k in data.keys() if k not in allowed_attributes]:
+                    dropped_payload.append(data)
+                    continue
+                update_payload.append(data)
+
+            current_app.logger.info(f"Project {project.id}, input for bulk update {str(update_info)}, dropped payload {dropped_payload}")
+            current_app.logger.info(f"Calling bulk update for project {project.id} with payload {str(update_payload)}")
+            task_repo.bulk_update(update_payload)
+            json_response = {}
+            return Response(json_response, mimetype="application/json")
+        except Exception as e:
+            return error.format_exception(
+                e,
+                target=self.__class__.__name__.lower(),
+            action="PUT")
+

--- a/pybossa/repositories/task_repository.py
+++ b/pybossa/repositories/task_repository.py
@@ -544,3 +544,24 @@ class TaskRepository(Repository):
             task_expiration=task_expiration, **params)).fetchall()
         tasks_not_updated = '\n'.join([str(task.id) for task in tasks])
         return tasks_not_updated
+
+
+    def bulk_update(self, payload):
+        return
+        exp = filters.pop('exported', None)
+        finish_time = filters.pop('finish_time', None)
+        filters.pop('state', None) # exclude state param
+
+        conditions = []
+        if exp:
+            conditions.append(Task.exported == exp)
+        if finish_time:
+            conditions.append(TaskRun.finish_time >= finish_time)
+
+        query = self.db.session.query(TaskRun).join(Task).\
+            filter(or_(Task.state == 'completed', Task.calibration == 1)).\
+            filter(*conditions).\
+            filter_by(**filters)
+
+        results = self._filter_query(query, Task, limit, offset, last_id, yielded, desc)
+        return results

--- a/pybossa/repositories/task_repository.py
+++ b/pybossa/repositories/task_repository.py
@@ -33,6 +33,7 @@ import json
 from datetime import datetime, timedelta
 from flask import current_app
 from sqlalchemy import or_
+from sqlalchemy.sql import case as sqlalchemy_case
 
 
 class TaskRepository(Repository):
@@ -547,21 +548,26 @@ class TaskRepository(Repository):
 
 
     def bulk_update(self, payload):
-        return
-        exp = filters.pop('exported', None)
-        finish_time = filters.pop('finish_time', None)
-        filters.pop('state', None) # exclude state param
+        """
+        use sqlalchemy case clause to update db rows in bulk
+        construct payload in the form {task_id: priority} as
+        sqlalchemy case works passing payload in the form
+        WHEN task_id THEN priority
+        https://stackoverflow.com/questions/54365873/sqlalchemy-update-multiple-rows-in-one-transaction
+        """
 
-        conditions = []
-        if exp:
-            conditions.append(Task.exported == exp)
-        if finish_time:
-            conditions.append(TaskRun.finish_time >= finish_time)
+        if not payload:
+            return
 
-        query = self.db.session.query(TaskRun).join(Task).\
-            filter(or_(Task.state == 'completed', Task.calibration == 1)).\
-            filter(*conditions).\
-            filter_by(**filters)
+        formatted_payload = {}
+        for data in payload:
+            formatted_payload[data["id"]] = data["priority_0"]
 
-        results = self._filter_query(query, Task, limit, offset, last_id, yielded, desc)
-        return results
+        task_ids = formatted_payload.keys()
+        tasks = self.db.session.query(Task).filter(Task.id.in_(task_ids))
+        tasks.update({Task.priority_0: sqlalchemy_case(formatted_payload, value=Task.id)}, synchronize_session=False)
+        self.db.session.commit()
+
+
+
+

--- a/pybossa/repositories/task_repository.py
+++ b/pybossa/repositories/task_repository.py
@@ -559,10 +559,7 @@ class TaskRepository(Repository):
         if not payload:
             return
 
-        formatted_payload = {}
-        for data in payload:
-            formatted_payload[data["id"]] = data["priority_0"]
-
+        formatted_payload = {data["id"]: data["priority_0"] for data in payload}
         task_ids = formatted_payload.keys()
         tasks = self.db.session.query(Task).filter(Task.id.in_(task_ids))
         tasks.update({Task.priority_0: sqlalchemy_case(formatted_payload, value=Task.id)}, synchronize_session=False)

--- a/test/test_api/test_bulktasks_api.py
+++ b/test/test_api/test_bulktasks_api.py
@@ -79,7 +79,7 @@ class TestBulkTasksApi(TestAPI):
         # subadmin not coowner on project
         payload =[{"id": task.id, "priority_0": 0.6}]
         res = self.app.put(f"/api/bulktasks/{projects[0].id}?api_key={user.api_key}", json=payload)
-        assert_equal(res.status, "401 UNAUTHORIZED", "User not admin/subadmin owner should should not be allowed to update task")
+        assert_equal(res.status, "403 FORBIDDEN", "User not admin/subadmin owner should should not be allowed to update task")
 
         # subadmin coowner on project updating task from another project
         payload =[{"id": tasks2[0].id, "priority_0": 0.6}]

--- a/test/test_api/test_bulktasks_api.py
+++ b/test/test_api/test_bulktasks_api.py
@@ -1,0 +1,98 @@
+# -*- coding: utf8 -*-
+# This file is part of PYBOSSA.
+#
+# Copyright (C) 2022 Scifabric LTD.
+#
+# PYBOSSA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PYBOSSA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
+import json
+import datetime
+from test import db, with_context, with_request_context
+from nose.tools import assert_equal, assert_raises
+from werkzeug.exceptions import MethodNotAllowed, Unauthorized
+
+
+from test.test_api import TestAPI
+from pybossa.core import project_repo, task_repo
+
+from test.factories import ProjectFactory, TaskFactory, TaskRunFactory, UserFactory
+
+from unittest.mock import patch
+from pybossa.repositories import TaskRepository
+from pybossa.api.bulktasks import BulkTasksAPI
+from test.helper.gig_helper import make_subadmin
+
+
+class TestBulkTasksApi(TestAPI):
+
+    def setUp(self):
+        super(TestBulkTasksApi, self).setUp()
+
+    data_classification=dict(input_data="L4 - public", output_data="L4 - public")
+
+    @with_context
+    @patch('pybossa.api.task.TaskAPI._verify_auth')
+    def test_api_unauthorized_access_disallowed_methods(self, auth):
+        """Test bulktasks API unauthorized access and disallowed method works"""
+
+        # test disallowed methods
+        bulktasks = BulkTasksAPI()
+        assert_raises(MethodNotAllowed, bulktasks.get)
+        assert_raises(MethodNotAllowed, bulktasks.post)
+        assert_raises(MethodNotAllowed, bulktasks.delete)
+
+        # test unauthorized access
+        admin, owner, user = UserFactory.create_batch(3)
+        projects = ProjectFactory.create_batch(2, owner=owner)
+        auth.return_value = True
+
+        tasks = TaskFactory.create_batch(2, project=projects[0])
+        for task in tasks:
+            TaskRunFactory.create(task=task)
+
+        tasks2 = TaskFactory.create_batch(2, project=projects[1])
+        for task in tasks2:
+            TaskRunFactory.create(task=task)
+
+        res = self.app.put(f"/api/bulktasks/{projects[0].id}")
+        assert_equal(res.status, "401 UNAUTHORIZED", "Anonymous user should not be allowed")
+
+        # incorrect project id
+        make_subadmin(user)
+        res = self.app.put(f"/api/bulktasks/999?api_key={user.api_key}")
+        assert_equal(res.status, "400 BAD REQUEST", "Update should fail due to incorrect project id")
+
+        # missing payload to be updated
+        res = self.app.put(f"/api/bulktasks/{projects[0].id}?api_key={user.api_key}")
+        assert_equal(res.status, "400 BAD REQUEST", "Update should fail due to missing payload for update")
+
+        # subadmin not coowner on project
+        payload =[{"id": task.id, "priority_0": 0.6}]
+        res = self.app.put(f"/api/bulktasks/{projects[0].id}?api_key={user.api_key}", json=payload)
+        assert_equal(res.status, "401 UNAUTHORIZED", "User not admin/subadmin owner should should not be allowed to update task")
+
+        # subadmin coowner on project updating task from another project
+        payload =[{"id": tasks2[0].id, "priority_0": 0.6}]
+        make_subadmin(owner)
+        res = self.app.put(f"/api/bulktasks/{projects[0].id}?api_key={owner.api_key}", json=payload)
+        assert res.status_code == 200, "Updating task for different project returns 200"
+
+        # subadmin coowner on project; task from another project dropped from updating
+        payload = [
+            {"id": tasks[0].id, "priority_0": 0.2},
+            {"id": tasks2[0].id, "priority_0": 0.6},
+            {"id": tasks[1].id, "priority_0": 0.6}
+        ]
+        make_subadmin(owner)
+        res = self.app.put(f"/api/bulktasks/{projects[0].id}?api_key={owner.api_key}", json=payload)
+        assert res.status_code == 200, "Updating task for different project returns 200"


### PR DESCRIPTION
* add option to createbulktask script so that tasks can be created for current year
* new api `/api/bulktasks` to updata task priority of tasks in bulk. expected payload to pass along is list of dict containing `task id` and `priority` values