### PR TITLE
RDISCROWD-5251: Reset cache upon bulktasks update

### DIFF
--- a/pybossa/api/bulktasks.py
+++ b/pybossa/api/bulktasks.py
@@ -86,7 +86,7 @@ class BulkTasksAPI(TaskAPI):
 
             current_app.logger.info(f"Project {project.id}, input for bulk update {str(update_info)}, dropped payload {dropped_payload}")
             current_app.logger.info(f"Calling bulk update for project {project.id} with payload {str(update_payload)}")
-            task_repo.bulk_update(update_payload)
+            task_repo.bulk_update(project.id, update_payload)
             json_response = {}
             return Response(json_response, mimetype="application/json")
         except Exception as e:

--- a/pybossa/repositories/task_repository.py
+++ b/pybossa/repositories/task_repository.py
@@ -547,7 +547,7 @@ class TaskRepository(Repository):
         return tasks_not_updated
 
 
-    def bulk_update(self, payload):
+    def bulk_update(self, project_id, payload):
         """
         use sqlalchemy case clause to update db rows in bulk
         construct payload in the form {task_id: priority} as
@@ -564,6 +564,7 @@ class TaskRepository(Repository):
         tasks = self.db.session.query(Task).filter(Task.id.in_(task_ids))
         tasks.update({Task.priority_0: sqlalchemy_case(formatted_payload, value=Task.id)}, synchronize_session=False)
         self.db.session.commit()
+        cached_projects.clean_project(project_id)
 
 
 


### PR DESCRIPTION
Similar to updating task priorities via bulktasks [here](https://github.com/bloomberg/pybossa/blob/main/pybossa/repositories/task_repository.py#L195), reset cache so that latest priority updates are available immediately instead of after cache rebuild that cause lag in user experience with priority updates.