### PR TITLE
RDISCROWD-5170 fix race condition

### DIFF
--- a/pybossa/sched.py
+++ b/pybossa/sched.py
@@ -356,7 +356,7 @@ def locked_scheduler(query_factory):
         for task_id, taskcount, n_answers, calibration, _, _, timeout in rows:
             timeout = timeout or TIMEOUT
             remaining = float('inf') if calibration else n_answers - taskcount
-            if acquire_lock(task_id, user_id, remaining, timeout):
+            if acquire_locks(task_id, user_id, remaining, timeout):
                 # reserve tasks
                 acquire_reserve_task_lock(project_id, task_id, user_id, timeout)
                 return _lock_task_for_user(task_id, project_id, user_id, timeout, calibration)
@@ -509,7 +509,6 @@ def locked_task_sql(project_id, user_id=None, limit=1, rand_within_priority=Fals
            LIMIT :limit;
            '''.format(' '.join(filters), task_category_filters,
                       ','.join(order_by))
-    print(sql)
     return text(sql)
 
 
@@ -577,16 +576,13 @@ def has_lock(task_id, user_id, timeout):
     return lock_manager.has_lock(task_users_key, user_id)
 
 
-def acquire_lock(task_id, user_id, limit, timeout, pipeline=None, execute=True):
-    redis_conn = sentinel.master
-    pipeline = pipeline or redis_conn.pipeline(transaction=True)
-    lock_manager = LockManager(redis_conn, timeout)
+def acquire_locks(task_id, user_id, limit, timeout):
+    import pdb; pdb.set_trace()
+    lock_manager = LockManager(sentinel.master, timeout)
     task_users_key = get_task_users_key(task_id)
     user_tasks_key = get_user_tasks_key(user_id)
-    if lock_manager.acquire_lock(task_users_key, user_id, limit, pipeline=pipeline):
-        lock_manager.acquire_lock(user_tasks_key, task_id, float('inf'), pipeline=pipeline)
-        if execute:
-            return all(not isinstance(r, Exception) for r in pipeline.execute())
+    if lock_manager.acquire_lock(task_users_key, user_id, limit):
+        lock_manager.acquire_lock(user_tasks_key, task_id, float('inf'))
         return True
     return False
 
@@ -686,7 +682,7 @@ def lock_task_for_user(task_id, project_id, user_id):
     for task_id, taskcount, n_answers, calibration, timeout in rows:
         timeout = timeout or TIMEOUT
         remaining = float('inf') if calibration else n_answers - taskcount
-        if acquire_lock(task_id, user_id, remaining, timeout):
+        if acquire_locks(task_id, user_id, remaining, timeout):
             # reserve tasks
             acquire_reserve_task_lock(project_id, task_id, user_id, timeout)
             return _lock_task_for_user(task_id, project_id, user_id, timeout, calibration)

--- a/pybossa/sched.py
+++ b/pybossa/sched.py
@@ -577,7 +577,6 @@ def has_lock(task_id, user_id, timeout):
 
 
 def acquire_locks(task_id, user_id, limit, timeout):
-    import pdb; pdb.set_trace()
     lock_manager = LockManager(sentinel.master, timeout)
     task_users_key = get_task_users_key(task_id)
     user_tasks_key = get_user_tasks_key(user_id)

--- a/settings_test.py.tmpl
+++ b/settings_test.py.tmpl
@@ -84,7 +84,7 @@ LDAP_PYBOSSA_FIELDS = {'fullname': 'givenName',
 WEEKLY_ADMIN_REPORTS_EMAIL = ['admin@admin.com']
 
 FLASK_PROFILER = {
-    "enabled": True,
+    "enabled": False, # disable so that sqlite works in multithreading
     "storage": {
         "engine": "sqlite"
     },

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -17,6 +17,7 @@
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 import copy
 import json
+import threading
 from unittest.mock import patch, call, MagicMock
 
 from nose.tools import assert_equal
@@ -26,7 +27,7 @@ from pybossa.repositories import ProjectRepository
 from pybossa.repositories import ResultRepository
 from pybossa.repositories import TaskRepository
 from pybossa.sched import Schedulers
-from test import db, with_context
+from test import db, with_context, flask_app
 from test.factories import (ProjectFactory, TaskFactory, TaskRunFactory,
                             AnonymousTaskRunFactory, UserFactory,
                             CategoryFactory, AuditlogFactory)
@@ -1285,7 +1286,6 @@ class TestProjectAPI(TestAPI):
         err_msg = "There should be a question"
         assert task['info'].get('question') == 'answer', err_msg
 
-
     @with_context
     def test_newtask(self):
         """Test API project new_task method and authentication"""
@@ -1335,6 +1335,42 @@ class TestProjectAPI(TestAPI):
         task = json.loads(res.data)
         assert task['id'] == tasks[0].id
 
+    @with_context
+    @patch('pybossa.api.pwd_manager.ProjectPasswdManager.password_needed')
+    def test_newtask_without_race_condition(self, password_needed):
+        """Test API project new_task method without race condition
+           It simulates 10 users grabbing 1 to 10 tasks simultaneously
+        """
+        password_needed.return_value = False
+        concurrent_user = 10
+
+        n_answers_list = list(range(1, concurrent_user + 1))
+        for n_answers in n_answers_list:
+            project = ProjectFactory.create()
+            project.info['sched'] = Schedulers.locked
+            project_repo.save(project)
+            users = UserFactory.create_batch(concurrent_user)
+            responses = []
+
+            def api_call(user):
+                with patch.dict(flask_app.config, {'RATE_LIMIT_BY_USER_ID': True}):
+                    url = f'/api/project/{project.id}/newtask?api_key={user.api_key}'
+                    # self.set_proj_passwd_cookie(project, user)
+                    res = self.app.get(url)
+                    if res.status_code == 200 and res.data != b'{}':
+                        responses.append(json.loads(res.data))
+
+            task = TaskFactory.create(n_answers=n_answers, project=project)
+
+            threads = []
+            for u in users:
+                thread = threading.Thread(target=api_call, args=(u,))
+                threads.append(thread)
+                thread.start()
+
+            for thread in threads:
+                thread.join()
+            assert_equal(len(responses), task.n_answers)
 
     @with_context
     @patch('pybossa.repositories.project_repository.uploader')


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-5170*

**Describe your changes**
Add a mutex in acquire_lock function so that only one request can perform update Redis hash at a time.

**Testing performed**
Using multiple threads in the unit tests to simulate concurrent users. With the unit tests, the race condition could be reproduced before the fix.
