### PR TITLE
RDISCROWD-5322: Default task expiration as per configuration

### DIFF
--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -43,6 +43,7 @@ from pybossa.cache import delete_memoized
 from pybossa.cache.task_browse_helpers import get_searchable_columns
 import json
 import copy
+from pybossa.task_creator_helper import get_task_expiration
 
 
 class TaskAPI(APIBase):
@@ -110,6 +111,7 @@ class TaskAPI(APIBase):
                     data['exported'] = True
             except Exception as e:
                 raise BadRequest('Invalid gold_answers')
+        data["expiration"] = get_task_expiration(data.get('expiration'))
 
     def _verify_auth(self, item):
         if not current_user.is_authenticated:

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -276,7 +276,7 @@ def setup_repositories(app):
     global helping_repo
     global performance_stats_repo
     language = app.config.get('FULLTEXTSEARCH_LANGUAGE')
-    rdancy_upd_exp = app.config.get('REDUNDANCY_UPDATE_EXPIRATION', 30)
+    rdancy_upd_exp = app.config.get('TASK_EXPIRATION', 60)
     user_repo = UserRepository(db)
     project_repo = ProjectRepository(db)
     project_stats_repo = ProjectStatsRepository(db)

--- a/pybossa/default_settings.py
+++ b/pybossa/default_settings.py
@@ -161,7 +161,6 @@ AVATAR_ABSOLUTE = True
 
 # Spam accounts to avoid
 SPAM = []
-REQUEST_FILE_VALIDITY_IN_DAYS = 60
 
 # Task routing batch size
 DB_MAXIMUM_BATCH_SIZE = 10000

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -153,7 +153,6 @@ class Importer(object):
         file_name = 'task_private_data.json'
         urls = upload_files_priv(task, project_id, private_fields, file_name)
         use_file_url = (task.get('state') == 'enrich')
-        task['expiration'] = get_task_expiration(task.get('expiration'))
         task['info']['private_json__upload_url'] = urls if use_file_url else urls['externalUrl']
 
     def _validate_headers(self, importer, project, **form_data):
@@ -209,6 +208,7 @@ class Importer(object):
         try:
             for task_data in tasks:
                 self.upload_private_data(task_data, project.id)
+                task_data['expiration'] = get_task_expiration(task_data.get('expiration'))
 
                 task = Task(project_id=project.id, n_answers=n_answers)
                 [setattr(task, k, v) for k, v in task_data.items()]

--- a/pybossa/repositories/__init__.py
+++ b/pybossa/repositories/__init__.py
@@ -51,7 +51,7 @@ from datetime import datetime
 
 class Repository(object):
 
-    def __init__(self, db, language='english', rdancy_upd_exp=30):
+    def __init__(self, db, language='english', rdancy_upd_exp=60):
         self.db = db
         self.language = language
         self.rdancy_upd_exp = rdancy_upd_exp

--- a/pybossa/settings_local.py.tmpl
+++ b/pybossa/settings_local.py.tmpl
@@ -373,7 +373,7 @@ TTL_ZIP_SEC_FILES = 3
 # Request signature secret key
 # SIGNATURE_SECRET = 'my-sig-secret'
 
-REDUNDANCY_UPDATE_EXPIRATION=30
+TASK_EXPIRATION=60
 
 # Access control configurations
 ENABLE_ACCESS_CONTROL = True

--- a/pybossa/task_creator_helper.py
+++ b/pybossa/task_creator_helper.py
@@ -47,7 +47,7 @@ def get_task_expiration(current_expiration):
     the smallest between the current expiration and the data expiration.
     current_expiration can be a iso datetime string or a datetime object
     """
-    validity = current_app.config.get('REQUEST_FILE_VALIDITY_IN_DAYS', 60)
+    validity = current_app.config.get('TASK_EXPIRATION', 60)
     return _get_task_expiration(current_expiration, validity)
 
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1653,7 +1653,7 @@ def tasks_browse(short_name, page=1, records_per_page=None):
             if app_settings.upref_mdata else {}
         language_options = valid_user_preferences.get('languages')
         location_options = valid_user_preferences.get('locations')
-        rdancy_upd_exp = current_app.config.get('REDUNDANCY_UPDATE_EXPIRATION', 30)
+        rdancy_upd_exp = current_app.config.get('TASK_EXPIRATION', 60)
 
         data = dict(template='/projects/tasks_browse.html',
                     users=[],
@@ -1893,7 +1893,7 @@ def bulk_redundancy_update(short_name):
             tasks_updated = _update_task_redundancy(project.id, task_ids, n_answers)
             if not tasks_updated:
                 flash('Redundancy not updated for tasks containing files that are either completed or older than '
-                      '{} days.'.format(current_app.config.get('REDUNDANCY_UPDATE_EXPIRATION', 30)))
+                      '{} days.'.format(current_app.config.get('TASK_EXPIRATION', 60)))
             new_value = json.dumps({
                 'task_ids': task_ids,
                 'n_answers': n_answers
@@ -1925,7 +1925,7 @@ def _update_task_redundancy(project_id, task_ids, n_answers):
     and task was already exported
     """
     tasks_updated = False
-    rdancy_upd_exp = current_app.config.get('REDUNDANCY_UPDATE_EXPIRATION', 30)
+    rdancy_upd_exp = current_app.config.get('TASK_EXPIRATION', 60)
     for task_id in task_ids:
         if task_id:
             t = task_repo.get_task_by(project_id=project_id,

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -9287,7 +9287,7 @@ class TestWeb(web.Helper):
 
     @with_context
     def test_task_redundancy_update_tasks_created_within_max_date_range(self):
-        """Test task redundancy update applies to tasks created within days as per configured under REDUNDANCY_UPDATE_EXPIRATION"""
+        """Test task redundancy update applies to tasks created within days as per configured under TASK_EXPIRATION"""
 
         self.register()
         self.signin()


### PR DESCRIPTION
* set default task expiration at the time of task creation instead of expiration getting set as null
* uniformly set task expiration to 60 days when not present in config.
* consolidate configurations wherever applicable. deprecate different configs(`REDUNDANCY_UPDATE_EXPIRATION`, `REQUEST_FILE_VALIDITY_IN_DAYS`) set for same purpose into a generic config `TASK_EXPIRATION`