### PR TITLE
RDISCROWD-5091 Added audit log when adding coowner to a project

### DIFF
--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -3185,6 +3185,8 @@ def coowners(short_name):
             old_list = project.owners_ids or []
             new_list = [int(x) for x in json.loads(request.data).get('coowners') or []]
             overlap_list = [value for value in old_list if value in new_list]
+            auditlogger.log_event(project, current_user, 'update', 'project.coowners',
+                old_list, new_list)
             # delete ids that don't exist anymore
             delete = [value for value in old_list if value not in overlap_list]
             for _id in delete:


### PR DESCRIPTION
- Added audit log when adding coowner to a project.

## Audit Log

|When	|Who	|Source	|Action	|Attribute	|Old Value	|New Value|
|-----------|----------|----------|-----------|----------|----------------|-----------|
|2022-08-03T19:11:17.749298	|You	|web	|update	|project.coowners	|{1,2,3}	|[1]|
|2022-08-03T19:11:10.519822	|You	|web	|update	|project.coowners	|{1,2}	|[1, 2, 3]|
|2022-08-03T19:10:44.110738	|You	|web	|update	|project.coowners	|{1}	|[1, 2]|
|2022-08-03T19:10:34.775497	|You	|web	|update	|project.coowners	|{1,2}	|[1]|

## Screenshot

![cap](https://user-images.githubusercontent.com/50708624/182690727-e7869963-5e84-45e4-9814-f65972c4733c.png)

