### PR TITLE
RDISCROWD-5372 User responses looks the same even they did not give the same answer

### DIFF
--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1200,6 +1200,16 @@ def make_random_task_gold(short_name):
 @blueprint.route('/<short_name>/task/<int:task_id>/<int:task_submitter_id>')
 @login_required
 def task_presenter(short_name, task_id, task_submitter_id=None):
+    """
+    displaying task presenter code. There are two endpoints. One for submitting
+    task (including read-only viewing tasks and cherry-pick modes) and the other
+    for viewing user's completed response (with task_submitter_id in the
+    endpoint)
+    :param short_name: project's short name
+    :param task_id: task ID
+    :param task_submitter_id: task submitter's user id. It is received only upon
+    viewing the task answers by the user
+    """
     mode = request.args.get('mode')
     project, owner, ps = project_by_shortname(short_name)
     ensure_authorized_to('read', project)

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1201,7 +1201,7 @@ def make_random_task_gold(short_name):
 @login_required
 def task_presenter(short_name, task_id, task_submitter_id=None):
     """
-    displaying task presenter code. There are two endpoints. One for submitting
+    Displaying task presenter code. There are two endpoints. One for submitting
     task (including read-only viewing tasks and cherry-pick modes) and the other
     for viewing user's completed response (with task_submitter_id in the
     endpoint)


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-5372*

**Describe your changes**
- Disable "autosave" in response reviewing mode (doesn't affect "autosave" when submitting the task)
- Consider user can use both "v-bind:data" and shorthanded ":data" for data binding to make the code more robust.

**Testing performed**
tests performed locally and worked as desired.

**Additional context**
The initial investigation due to cache is not correct. The root cause of different users seeing the same response is because the TP code has "autosave" enabled, so that the first opened response is saved to browser's IndexedDB. Thus the following response is reading from the browser's IndexedDB.
