### PR TITLE
RDISCROWD-4878 ask browse bulk edit state not updating

### DIFF
--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1873,6 +1873,9 @@ def bulk_update_assign_worker(short_name):
             if task_id is not None:
                 t = task_repo.get_task_by(project_id=project.id,
                                         id=int(task_id))
+                # Skip gold task for bulk assign users; allow single assign users for gold task
+                if bool(t.gold_answers) and len(task_ids) > 1:
+                    continue
                 # add new users
                 user_pref = t.user_pref or {}
                 assign_user = user_pref.get("assign_user", [])


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-4878*

**Describe your changes**
Skip gold task for bulk assign users, but allow single assign users for gold task.

**Testing performed**
Tested locally.

**Additional context**
Related pr: https://github.com/bloomberg/pybossa-default-theme/pull/377
