### PR TITLE
fixing assign users' list is empty

### DIFF
--- a/pybossa/cache/task_browse_helpers.py
+++ b/pybossa/cache/task_browse_helpers.py
@@ -344,7 +344,6 @@ def validate_user_preferences(user_pref):
         raise ValueError('invalid locations user preference: {}'
                         .format(loc))
 
-
 def _get_field_filters(filters):
     filters = filters if type(filters) is list else json.loads(filters)
     return [(name, operator, value)

--- a/pybossa/cache/task_browse_helpers.py
+++ b/pybossa/cache/task_browse_helpers.py
@@ -344,8 +344,9 @@ def validate_user_preferences(user_pref):
         raise ValueError('invalid locations user preference: {}'
                         .format(loc))
 
-def _get_field_filters(filter_string):
-    filters = json.loads(filter_string)
+
+def _get_field_filters(filters):
+    filters = filters if type(filters) is list else json.loads(filters)
     return [(name, operator, value)
             for name, operator, value in filters
             if value and is_valid_searchable_column(name)]

--- a/pybossa/cache/task_browse_helpers.py
+++ b/pybossa/cache/task_browse_helpers.py
@@ -344,6 +344,7 @@ def validate_user_preferences(user_pref):
         raise ValueError('invalid locations user preference: {}'
                         .format(loc))
 
+
 def _get_field_filters(filters):
     filters = filters if type(filters) is list else json.loads(filters)
     return [(name, operator, value)

--- a/test/test_cache/test_task_browse_helpers.py
+++ b/test/test_cache/test_task_browse_helpers.py
@@ -1,0 +1,15 @@
+from test import Test
+from pybossa.cache import task_browse_helpers
+
+
+class TestTaskBrowseHelpers(Test):
+
+    def test_get_field_filters(self):
+        filter1 = [["fruit", "contains", "orange"]]
+        result1 = task_browse_helpers._get_field_filters(filter1)
+
+        filter2 = '[["fruit", "contains", "orange"]]'
+        result2 = task_browse_helpers._get_field_filters(filter2)
+        assert type(result1) is list
+        assert type(result2) is list
+        assert result1 == result2


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-4878*

**Describe your changes**
When filter is passed for bulk assigning workers, there was an exception causing the "assign users" list to be empty. 

**Testing performed**
Tested locally