### PR TITLE
RDISCROWD-5627: Allow editing of taskruns

### DIFF
--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -62,6 +62,10 @@ class TaskAPI(APIBase):
                 raise BadRequest("Reserved keys in payload")
 
     def _update_attribute(self, new, old):
+        for key, value in old.info.items():
+            if not new.info.get(key):
+                new.info[key] = value
+
         gold_task = bool(new.gold_answers)
         n_taskruns = len(new.task_runs)
         if new.state == 'completed':

--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -63,8 +63,7 @@ class TaskAPI(APIBase):
 
     def _update_attribute(self, new, old):
         for key, value in old.info.items():
-            if not new.info.get(key):
-                new.info[key] = value
+            new.info.setdefault(key, value)
 
         gold_task = bool(new.gold_answers)
         n_taskruns = len(new.task_runs)

--- a/pybossa/api/task_run.py
+++ b/pybossa/api/task_run.py
@@ -116,8 +116,7 @@ class TaskRunAPI(APIBase):
 
     def _update_attribute(self, new, old):
         for key, value in old.info.items():
-            if not new.info.get(key):
-                new.info[key] = value
+            new.info.setdefault(key, value)
 
     def _forbidden_attributes(self, data):
         for key in data.keys():

--- a/pybossa/api/task_run.py
+++ b/pybossa/api/task_run.py
@@ -114,6 +114,11 @@ class TaskRunAPI(APIBase):
         self._add_user_info(taskrun)
         self._add_timestamps(taskrun, task, guard)
 
+    def _update_attribute(self, new, old):
+        for key, value in old.info.items():
+            if not new.info.get(key):
+                new.info[key] = value
+
     def _forbidden_attributes(self, data):
         for key in data.keys():
             if key in self.reserved_keys:

--- a/pybossa/auth/taskrun.py
+++ b/pybossa/auth/taskrun.py
@@ -67,7 +67,11 @@ class TaskRunAuth(object):
         return user.is_authenticated
 
     def _update(self, user, taskrun):
-        return self._delete(user, taskrun)
+        if taskrun.user_id is None:
+            return user.admin
+        project = self.project_repo.get(taskrun.project_id)
+        allow_taskrun_edit = project.info.get("allow_taskrun_edit") or False
+        return user.admin or (allow_taskrun_edit and taskrun.user_id == user.id)
 
     def _delete(self, user, taskrun):
         if user.is_anonymous:

--- a/pybossa/auth/taskrun.py
+++ b/pybossa/auth/taskrun.py
@@ -75,7 +75,6 @@ class TaskRunAuth(object):
         project = self.project_repo.get(taskrun.project_id)
         allow_taskrun_edit = project.info.get("allow_taskrun_edit") or False
         return user.admin or (allow_taskrun_edit and taskrun.user_id == user.id)
-        return user.admin or taskrun.user_id == user.id
 
 
     def _delete(self, user, taskrun):

--- a/pybossa/auth/taskrun.py
+++ b/pybossa/auth/taskrun.py
@@ -67,11 +67,16 @@ class TaskRunAuth(object):
         return user.is_authenticated
 
     def _update(self, user, taskrun):
+        if user.is_anonymous:
+            return False
+
         if taskrun.user_id is None:
             return user.admin
         project = self.project_repo.get(taskrun.project_id)
         allow_taskrun_edit = project.info.get("allow_taskrun_edit") or False
         return user.admin or (allow_taskrun_edit and taskrun.user_id == user.id)
+        return user.admin or taskrun.user_id == user.id
+
 
     def _delete(self, user, taskrun):
         if user.is_anonymous:

--- a/test/test_api/test_task_api.py
+++ b/test/test_api/test_task_api.py
@@ -680,7 +680,7 @@ class TestTaskAPI(TestAPI):
         assert_equal(out.info, 'my root task data'), out
         assert_equal(out.project_id, project.id)
 
-        # test user_pref 
+        # test user_pref
         root_data = dict(project_id=project.id, info='my root task data')
         root_data['user_pref'] = dict(languages=["Traditional Chinese"], locations=["United States"], assign_user=["email@domain.com"])
         res = self.app.post('/api/task?api_key=' + admin.api_key,
@@ -787,8 +787,8 @@ class TestTaskAPI(TestAPI):
         make_subadmin(user)
         non_owner = UserFactory.create()
         project = ProjectFactory.create(owner=user)
-        task = TaskFactory.create(project=project)
-        root_task = TaskFactory.create(project=project)
+        task = TaskFactory.create(project=project, info=dict(x=1))
+        root_task = TaskFactory.create(project=project, info=dict(x=1))
         data = {'n_answers': 1}
         datajson = json.dumps(data)
         root_data = {'n_answers': 4}
@@ -852,7 +852,7 @@ class TestTaskAPI(TestAPI):
         user = UserFactory.create()
         project = ProjectFactory.create(owner=user)
         task = TaskFactory.create(project=project, n_answers=1,
-                                  state='ongoing')
+                                  state='ongoing', info=dict(x=1))
         data = {'n_answers': 2}
         datajson = json.dumps(data)
 

--- a/test/test_authorization/test_taskrun_auth.py
+++ b/test/test_authorization/test_taskrun_auth.py
@@ -210,12 +210,12 @@ class TestTaskrunAuthorization(Test):
     @with_context
     @patch('pybossa.auth.current_user', new=mock_admin)
     def test_admin_update_anonymous_taskrun_result(self):
-        """Test admins cannot update anonymously posted taskruns
+        """Test admins can update anonymously posted taskruns
         when there is a result associated."""
         task = TaskFactory.create(n_answers=1)
         anonymous_taskrun = AnonymousTaskRunFactory.create(task=task)
 
-        assert_raises(Forbidden,
+        assert_not_raises(Forbidden,
                       ensure_authorized_to, 'update', anonymous_taskrun)
 
     @with_context
@@ -247,7 +247,7 @@ class TestTaskrunAuthorization(Test):
 
         assert self.mock_authenticated.id == own_taskrun.user.id
         assert self.mock_authenticated.id != other_users_taskrun.user.id
-        assert_not_raises(Exception, ensure_authorized_to,
+        assert_raises(Exception, ensure_authorized_to,
                           'update', own_taskrun)
         assert_raises(Forbidden,
                       ensure_authorized_to, 'update', other_users_taskrun)
@@ -288,7 +288,7 @@ class TestTaskrunAuthorization(Test):
         user_taskrun = TaskRunFactory.create(task=task)
 
         assert self.mock_admin.id != user_taskrun.user.id
-        assert_raises(Forbidden, ensure_authorized_to,
+        assert_not_raises(Forbidden, ensure_authorized_to,
                       'update', user_taskrun)
 
     @with_context


### PR DESCRIPTION
This PR will enable admin and users to edit their submissions. Enable admin for updating submissions such as `__upload_url` when moving files to bucket that has extended expiration upon task completion.
