### PR TITLE
RDISCROWD-5733 Enforce size limit for task presenter HTML

### DIFF
--- a/pybossa/api/api_base.py
+++ b/pybossa/api/api_base.py
@@ -370,7 +370,7 @@ class APIBase(MethodView):
 
     def _preprocess_request(self, request):
         """Method to be overridden by inheriting classes that will
-        perform preprocessong on the POST request"""
+        perform preprocessong on the POST and PUT request"""
         pass
 
     def _create_instance_from_request(self, data):

--- a/pybossa/api/api_base.py
+++ b/pybossa/api/api_base.py
@@ -325,7 +325,8 @@ class APIBase(MethodView):
             cls_name = self.__class__.__name__
             data = None
             self.valid_args()
-            self._preprocess_request(request)
+            max_length_mb = current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB', 2)
+            self._preprocess_request(request, max_length_mb)
             data = self._file_upload(request)
             if data is None:
                 data = self._parse_request_data()
@@ -434,7 +435,8 @@ class APIBase(MethodView):
         """
         try:
             self.valid_args()
-            self._preprocess_request(request)
+            max_length_mb = current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB', 2)
+            self._preprocess_request(request, max_length_mb)
             cls_name = self.__class__.__name__
             repo = repos[cls_name]['repo']
             query_func = repos[cls_name]['get']

--- a/pybossa/api/api_base.py
+++ b/pybossa/api/api_base.py
@@ -325,8 +325,7 @@ class APIBase(MethodView):
             cls_name = self.__class__.__name__
             data = None
             self.valid_args()
-            max_length_mb = current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB', 2)
-            self._preprocess_request(request, max_length_mb)
+            self._preprocess_request(request)
             data = self._file_upload(request)
             if data is None:
                 data = self._parse_request_data()
@@ -369,7 +368,7 @@ class APIBase(MethodView):
         perform preprocessing on the POST data"""
         pass
 
-    def _preprocess_request(self, request, max_length_mb):
+    def _preprocess_request(self, request):
         """Method to be overridden by inheriting classes that will
         perform preprocessong on the POST request"""
         pass
@@ -435,8 +434,7 @@ class APIBase(MethodView):
         """
         try:
             self.valid_args()
-            max_length_mb = current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB', 2)
-            self._preprocess_request(request, max_length_mb)
+            self._preprocess_request(request)
             cls_name = self.__class__.__name__
             repo = repos[cls_name]['repo']
             query_func = repos[cls_name]['get']

--- a/pybossa/api/api_base.py
+++ b/pybossa/api/api_base.py
@@ -325,6 +325,7 @@ class APIBase(MethodView):
             cls_name = self.__class__.__name__
             data = None
             self.valid_args()
+            self._preprocess_request(request)
             data = self._file_upload(request)
             if data is None:
                 data = self._parse_request_data()
@@ -363,8 +364,13 @@ class APIBase(MethodView):
         return data
 
     def _preprocess_post_data(self, data):
-        """Method to be overriden by inheriting classes that will
+        """Method to be overridden by inheriting classes that will
         perform preprocessing on the POST data"""
+        pass
+
+    def _preprocess_request(self, request):
+        """Method to be overridden by inheriting classes that will
+        perform preprocessong on the POST request"""
         pass
 
     def _create_instance_from_request(self, data):
@@ -428,6 +434,7 @@ class APIBase(MethodView):
         """
         try:
             self.valid_args()
+            self._preprocess_request(request)
             cls_name = self.__class__.__name__
             repo = repos[cls_name]['repo']
             query_func = repos[cls_name]['get']

--- a/pybossa/api/api_base.py
+++ b/pybossa/api/api_base.py
@@ -369,7 +369,7 @@ class APIBase(MethodView):
         perform preprocessing on the POST data"""
         pass
 
-    def _preprocess_request(self, request):
+    def _preprocess_request(self, request, max_length_mb):
         """Method to be overridden by inheriting classes that will
         perform preprocessong on the POST request"""
         pass

--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -54,9 +54,9 @@ class ProjectAPI(APIBase):
     def _preprocess_request(self, request):
         # Limit maximum post data size.
         content_length = request.content_length if request else 0
-        max_length_mb = current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB', 2) if current_app and current_app.config else 0
+        max_length_mb = current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB', 2)
         max_length_bytes = max_length_mb * 1024 * 1024 # Maximum POST data size (MB)
-        if content_length and max_length_bytes and content_length > max_length_bytes:
+        if content_length > max_length_bytes:
             raise BadRequest('The task presenter/guidelines content exceeds ' +
                 str(max_length_mb) +
                 ' MB. Please move large content to an external file.')

--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -53,7 +53,7 @@ class ProjectAPI(APIBase):
 
     def _preprocess_request(self, request, max_length_mb):
         # Limit maximum post data size.
-        content_length = request.content_length
+        content_length = request.content_length if request else None
         max_length_bytes = max_length_mb * 1024 * 1024 # 2 MB maximum POST data size
         if content_length is not None and content_length > max_length_bytes:
             raise BadRequest('The task presenter/guidelines content exceeds ' +

--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -53,10 +53,10 @@ class ProjectAPI(APIBase):
 
     def _preprocess_request(self, request):
         # Limit maximum post data size.
-        content_length = request.content_length if request else None
+        content_length = request.content_length if request else 0
         max_length_mb = current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB', 2) if current_app and current_app.config else 0
         max_length_bytes = max_length_mb * 1024 * 1024 # Maximum POST data size (MB)
-        if content_length is not None and max_length_bytes > 0 and content_length > max_length_bytes:
+        if content_length and max_length_bytes and content_length > max_length_bytes:
             raise BadRequest('The task presenter/guidelines content exceeds ' +
                 str(max_length_mb) +
                 ' MB. Please move large content to an external file.')

--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -51,11 +51,12 @@ class ProjectAPI(APIBase):
     private_keys = set(['secret_key'])
     restricted_keys = set()
 
-    def _preprocess_request(self, request, max_length_mb):
+    def _preprocess_request(self, request):
         # Limit maximum post data size.
         content_length = request.content_length if request else None
-        max_length_bytes = max_length_mb * 1024 * 1024 # 2 MB maximum POST data size
-        if content_length is not None and content_length > max_length_bytes:
+        max_length_mb = current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB', 2) if current_app and current_app.config else 0
+        max_length_bytes = max_length_mb * 1024 * 1024 # Maximum POST data size (MB)
+        if content_length is not None and max_length_bytes > 0 and content_length > max_length_bytes:
             raise BadRequest('The task presenter/guidelines content exceeds ' +
                 str(max_length_mb) +
                 ' MB. Please move large content to an external file.')

--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -51,10 +51,9 @@ class ProjectAPI(APIBase):
     private_keys = set(['secret_key'])
     restricted_keys = set()
 
-    def _preprocess_request(self, request):
+    def _preprocess_request(self, request, max_length_mb):
         # Limit maximum post data size.
         content_length = request.content_length
-        max_length_mb = current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB', 2)
         max_length_bytes = max_length_mb * 1024 * 1024 # 2 MB maximum POST data size
         if content_length is not None and content_length > max_length_bytes:
             raise BadRequest('The task presenter/guidelines content exceeds ' +

--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -51,6 +51,16 @@ class ProjectAPI(APIBase):
     private_keys = set(['secret_key'])
     restricted_keys = set()
 
+    def _preprocess_request(self, request):
+        # Limit maximum post data size.
+        content_length = request.content_length
+        max_length_mb = current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB', 2)
+        max_length_bytes = max_length_mb * 1024 * 1024 # 2 MB maximum POST data size
+        if content_length is not None and content_length > max_length_bytes:
+            raise BadRequest('The task presenter/guidelines content exceeds ' +
+                str(max_length_mb) +
+                ' MB. Please move large content to an external file.')
+
     def _preprocess_post_data(self, data):
         # set amp_store default as true when not passed as input param
         amp_config = data.get('info', {}).get('annotation_config', {}).get('amp_store')

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -618,7 +618,7 @@ def task_presenter_editor(short_name):
             flash(gettext('Ooops! Only project owners can update.'),
                   'error')
             errors = True
-        elif content_length is not None and content_length > max_length_bytes:
+        elif content_length and content_length > max_length_bytes:
             flash(gettext('The task presenter/guidelines content exceeds ' + str(max_length_mb) +
                   ' MB. Please move large content to an external file.'),
                   'error')

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -606,11 +606,21 @@ def task_presenter_editor(short_name):
         flash(gettext(disabled_msg), 'error')
 
     if request.method == 'POST':
+        # Limit maximum post data size.
+        content_length = request.content_length
+        max_length_mb = current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB', 2)
+        max_length_bytes = max_length_mb * 1024 * 1024 # 2 MB maximum POST data size
+
         if disable_editor:
             flash(gettext(disabled_msg), 'error')
             errors = True
         elif not is_admin_or_owner:
             flash(gettext('Ooops! Only project owners can update.'),
+                  'error')
+            errors = True
+        elif content_length is not None and content_length > max_length_bytes:
+            flash(gettext('The task presenter/guidelines content exceeds ' + str(max_length_mb) +
+                  ' MB. Please move large content to an external file.'),
                   'error')
             errors = True
         elif form.validate():

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -398,7 +398,7 @@ class TestProjectAPI(TestAPI):
     @with_context
     def test_project_post(self):
         """Test API project creation and auth"""
-        delete current_app.config['TASK_PRESENTER_MAX_SIZE_MB'] = 2
+        current_app.config['TASK_PRESENTER_MAX_SIZE_MB'] = 2
         users = UserFactory.create_batch(2)
         make_subadmin(users[1])
         cat1 = CategoryFactory.create()

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -398,6 +398,7 @@ class TestProjectAPI(TestAPI):
     @with_context
     def test_project_post(self):
         """Test API project creation and auth"""
+        delete current_app.config['TASK_PRESENTER_MAX_SIZE_MB'] = 2
         users = UserFactory.create_batch(2)
         make_subadmin(users[1])
         cat1 = CategoryFactory.create()

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -398,6 +398,7 @@ class TestProjectAPI(TestAPI):
     @with_context
     def test_project_post(self):
         """Test API project creation and auth"""
+        from flask import current_app
         current_app.config['TASK_PRESENTER_MAX_SIZE_MB'] = 2
         users = UserFactory.create_batch(2)
         make_subadmin(users[1])

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -2282,11 +2282,10 @@ class TestProjectAPI(TestAPI):
     @with_context
     @patch('pybossa.model.project.signer')
     def test_project_create_task_presenter_too_large(self, hasher_mock):
-        """Test API project task presenter on PUT and POST with too large payload"""
+        """Test API project task presenter on PUT and POST with too large payload create"""
         from flask import current_app
         from pybossa.core import setup_task_presenter_editor
 
-        current_app.config['DISABLE_TASK_PRESENTER_EDITOR'] = True
         current_app.config['TASK_PRESENTER_MAX_SIZE_MB'] = 0.001
         setup_task_presenter_editor(current_app)
 
@@ -2331,11 +2330,10 @@ class TestProjectAPI(TestAPI):
     @with_context
     @patch('pybossa.model.project.signer')
     def test_project_update_task_presenter_too_large(self, hasher_mock):
-        """Test API project task presenter on PUT and POST with too large payload"""
+        """Test API project task presenter on PUT and POST with too large payload update"""
         from flask import current_app
         from pybossa.core import setup_task_presenter_editor
 
-        current_app.config['DISABLE_TASK_PRESENTER_EDITOR'] = True
         current_app.config['TASK_PRESENTER_MAX_SIZE_MB'] = 0.001
         setup_task_presenter_editor(current_app)
 

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -398,8 +398,6 @@ class TestProjectAPI(TestAPI):
     @with_context
     def test_project_post(self):
         """Test API project creation and auth"""
-        from flask import current_app
-        current_app.config['TASK_PRESENTER_MAX_SIZE_MB'] = 2
         users = UserFactory.create_batch(2)
         make_subadmin(users[1])
         cat1 = CategoryFactory.create()

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -2277,3 +2277,145 @@ class TestProjectAPI(TestAPI):
 
         assert res.status_code == 404, "POST project locks api should return 404"
         assert res_data == [], "POST project locks api should return empty array"
+
+
+    @with_context
+    @patch('pybossa.model.project.signer')
+    def test_project_create_task_presenter_too_large(self, hasher_mock):
+        """Test API project task presenter on PUT and POST with too large payload"""
+        from flask import current_app
+        from pybossa.core import setup_task_presenter_editor
+
+        current_app.config['DISABLE_TASK_PRESENTER_EDITOR'] = True
+        current_app.config['TASK_PRESENTER_MAX_SIZE_MB'] = 0.001
+        setup_task_presenter_editor(current_app)
+
+        [admin, subadmin] = UserFactory.create_batch(2)
+        make_admin(admin)
+        make_subadmin(subadmin)
+        CategoryFactory.create()
+
+        hasher_mock.generate_password_hash.return_value = "hashedpwd"
+
+        # Admin can create project with task presenter
+        too_large = '1_EOqi0apgy0cd8IPREKDe9yhtT1RTXZDASgwdyDzmK6a2FeQgc2XgkknSOG7EHbBZAUh3EWo86iAC8a8P3F0I9K9Ko44AdodZSeN0T8UAzVCMj6C1nxTEG4TYmVqRJw8MFjDYAt2xuc5Wr2rhggokcJxMgzzf0Dt32nr4aWIxklF07Y6ic7zWNkZJ1Jt4dwQxZtwMBQH7FFcHmDzsZ8ZTgth5QvpE7MQOa8hnzztFB7YGQxptQx09Qj314kCk0UGbJMO3WZHCl5f9KJzJlEsjuMk5TX9ZkbQlBfR4CRTMLVSt1n3jYvbjmMKaPV678sZCSfGj7do3ljOVuqfXYIsuWajObbmGKR1WOWFNb47EYAB3YHlrEvCL7kv52boc2KAgh5HihtP2wrfMAOXAms1eOmcG2UsDQ802JtcIlVNvyU3mJ87RkRcAy2R3oUaMWmyhI8DLvbPFU1AaIm597TTjKKxrMeivcs56QelXulHdPS8kCReFwkOPJzTxfHPf6QobmbIyvqV9n8HDb8rz9Zh50Rqz5HoYIFipZ9wJxNUxFY7wj10h1waTGRaUp7DMqfsHqwhaGiLql8ey0jamQvU9ZQRDxRPdYcXzaqy6asNvebPwMxwSCUHeH98zxwpNid1fQs0wzMidxPi1yyHyBxCRggV5TtLdo8icQCXhMN1kZqYlc0looL0ROXBKbAlXHMbx5CjULYRybz6PuT2ROi6FOwEhbaxZVQ5b1TTsDUjOukyrYmLtWj0rL3ee6EUnRQezwSc0CZLKXj4ezy2m2atWqqW6fTEcKKbr2XlWB1T91HwD4mHk45OfyuMeqvMJtoAH9U9jubsRTTQQNKake03ghj0SmRls8yDnTqg7uLiySpwyS93by6D50DxQYZJuYQWxOaQ9rlxXy2KSem309ua62V9ZGDIXiMW7BiqyWCPrgJTSOPL2w2YrSH9OGoFXccICIKaXRgZgxIZLfbYeyZrQzjAbESzM8wKhbNOpuRq5EOqi0apgy0cd8IPREKDe9yhtT1RTXZDASgwdyDzmK6a2FeQgc2XgkknSOG7EHbBZAUh3EWo86iAC8a8P3F0I9K9Ko44AdodZSeN0T8UAzVCMj6C1nxTEG4TYmVqRJw8MFjDYAt2xuc5Wr2rhggokcJxMgzzf0Dt32nr4aWIxklF07Y6ic7zWNkZJ1Jt4dwQxZtwMBQH7FFcHmDzsZ8ZTgth5QvpE7MQOa8hnzztFB7YGQxptQx09Qj314kCk0UGbJMO3WZHCl5f9KJzJlEsjuMk5TX9ZkbQlBfR4CRTMLVSt1n3jYvbjmMKaPV678sZCSfGj7do3ljOVuqfXYIsuWajObbmGKR1WOWFNb47EYAB3YHlrEvCL7kv52boc2KAgh5HihtP2wrfMAOXAms1eOmcG2UsDQ802JtcIlVNvyU3mJ87RkRcAy2R3oUaMWmyhI8DLvbPFU1AaIm597TTjKKxrMeivcs56QelXulHdPS8kCReFwkOPJzTxfHPf6QobmbIyvqV9n8HDb8rz9Zh50Rqz5HoYIFipZ9wJxNUxFY7wj10h1waTGRaUp7DMqfsHqwhaGiLql8ey0jamQvU9ZQRDxRPdYcXzaqy6asNvebPwMxwSCUHeH98zxwpNid1fQs0wzMidxPi1yyHyBxCRggV5TtLdo8icQCXhMN1kZqYlc0looL0ROXBKbAlXHMbx5CjULYRybz6PuT2ROi6FOwEhbaxZVQ5b1TTsDUjOukyrYmLtWj0rL3ee6EUnRQezwSc0CZLKXj4ezy2m2atWqqW6fTEcKKbr2XlWB1T91HwD4mHk45OfyuMeqvMJtoAH9U9jubsRTTQQNKake03ghj0SmRls8yDnTqg7uLiySpwyS93by6D50DxQYZJuYQWxOaQ9rlxXy2KSem309ua62V9ZGDIXiMW7BiqyWCPrgJTSOPL2w2YrSH9OGoFXccICIKaXRgZgxIZLfbYeyZrQzjAbESzM8wKhbNOpuRq5_1'
+        name='XXXX Project 2'
+        data = dict(
+            name=name,
+            short_name='xxxx-project-2',
+            description='description',
+            owner_id=admin.id,
+            long_description='Long Description\n================',
+            password='hello',
+            info=dict(
+                task_presenter=too_large,
+                data_classification=dict(input_data="L4 - public", output_data="L4 - public"),
+                kpi=0.5,
+                product="abc",
+                subproduct="def",
+            ))
+
+        newdata = json.dumps(data)
+        res = self.app.post('/api/project?api_key=' + admin.api_key,
+                            data=newdata)
+        res_data = json.loads(res.data)
+        project = project_repo.get_by(name=name)
+
+        # Verify failed to update.
+        assert res.status_code == 400, "BadRequest"
+        assert res_data['action'] == 'POST', res_data
+        assert "content exceeds " + str(current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB')) + " MB" in res_data['exception_msg'], res_data
+        assert project is None
+
+
+    @with_context
+    @patch('pybossa.model.project.signer')
+    def test_project_update_task_presenter_too_large(self, hasher_mock):
+        """Test API project task presenter on PUT and POST with too large payload"""
+        from flask import current_app
+        from pybossa.core import setup_task_presenter_editor
+
+        current_app.config['DISABLE_TASK_PRESENTER_EDITOR'] = True
+        current_app.config['TASK_PRESENTER_MAX_SIZE_MB'] = 0.001
+        setup_task_presenter_editor(current_app)
+
+        [admin, subadmin] = UserFactory.create_batch(2)
+        make_admin(admin)
+        make_subadmin(subadmin)
+        CategoryFactory.create()
+
+        hasher_mock.generate_password_hash.return_value = "hashedpwd"
+
+        # Admin can create project with task presenter
+        name='XXXX Project 2'
+        data = dict(
+            name=name,
+            short_name='xxxx-project-2',
+            description='description',
+            owner_id=admin.id,
+            long_description='Long Description\n================',
+            password='hello',
+            info=dict(
+                task_presenter='test123',
+                data_classification=dict(input_data="L4 - public", output_data="L4 - public"),
+                kpi=0.5,
+                product="abc",
+                subproduct="def",
+            ))
+
+        newdata = json.dumps(data)
+        res = self.app.post('/api/project?api_key=' + admin.api_key,
+                            data=newdata)
+        project = project_repo.get_by(name=name)
+        assert res.status_code == 200, "Project created"
+
+         # Admin can not update project task presenter with too large payload
+        too_large = '1_EOqi0apgy0cd8IPREKDe9yhtT1RTXZDASgwdyDzmK6a2FeQgc2XgkknSOG7EHbBZAUh3EWo86iAC8a8P3F0I9K9Ko44AdodZSeN0T8UAzVCMj6C1nxTEG4TYmVqRJw8MFjDYAt2xuc5Wr2rhggokcJxMgzzf0Dt32nr4aWIxklF07Y6ic7zWNkZJ1Jt4dwQxZtwMBQH7FFcHmDzsZ8ZTgth5QvpE7MQOa8hnzztFB7YGQxptQx09Qj314kCk0UGbJMO3WZHCl5f9KJzJlEsjuMk5TX9ZkbQlBfR4CRTMLVSt1n3jYvbjmMKaPV678sZCSfGj7do3ljOVuqfXYIsuWajObbmGKR1WOWFNb47EYAB3YHlrEvCL7kv52boc2KAgh5HihtP2wrfMAOXAms1eOmcG2UsDQ802JtcIlVNvyU3mJ87RkRcAy2R3oUaMWmyhI8DLvbPFU1AaIm597TTjKKxrMeivcs56QelXulHdPS8kCReFwkOPJzTxfHPf6QobmbIyvqV9n8HDb8rz9Zh50Rqz5HoYIFipZ9wJxNUxFY7wj10h1waTGRaUp7DMqfsHqwhaGiLql8ey0jamQvU9ZQRDxRPdYcXzaqy6asNvebPwMxwSCUHeH98zxwpNid1fQs0wzMidxPi1yyHyBxCRggV5TtLdo8icQCXhMN1kZqYlc0looL0ROXBKbAlXHMbx5CjULYRybz6PuT2ROi6FOwEhbaxZVQ5b1TTsDUjOukyrYmLtWj0rL3ee6EUnRQezwSc0CZLKXj4ezy2m2atWqqW6fTEcKKbr2XlWB1T91HwD4mHk45OfyuMeqvMJtoAH9U9jubsRTTQQNKake03ghj0SmRls8yDnTqg7uLiySpwyS93by6D50DxQYZJuYQWxOaQ9rlxXy2KSem309ua62V9ZGDIXiMW7BiqyWCPrgJTSOPL2w2YrSH9OGoFXccICIKaXRgZgxIZLfbYeyZrQzjAbESzM8wKhbNOpuRq5EOqi0apgy0cd8IPREKDe9yhtT1RTXZDASgwdyDzmK6a2FeQgc2XgkknSOG7EHbBZAUh3EWo86iAC8a8P3F0I9K9Ko44AdodZSeN0T8UAzVCMj6C1nxTEG4TYmVqRJw8MFjDYAt2xuc5Wr2rhggokcJxMgzzf0Dt32nr4aWIxklF07Y6ic7zWNkZJ1Jt4dwQxZtwMBQH7FFcHmDzsZ8ZTgth5QvpE7MQOa8hnzztFB7YGQxptQx09Qj314kCk0UGbJMO3WZHCl5f9KJzJlEsjuMk5TX9ZkbQlBfR4CRTMLVSt1n3jYvbjmMKaPV678sZCSfGj7do3ljOVuqfXYIsuWajObbmGKR1WOWFNb47EYAB3YHlrEvCL7kv52boc2KAgh5HihtP2wrfMAOXAms1eOmcG2UsDQ802JtcIlVNvyU3mJ87RkRcAy2R3oUaMWmyhI8DLvbPFU1AaIm597TTjKKxrMeivcs56QelXulHdPS8kCReFwkOPJzTxfHPf6QobmbIyvqV9n8HDb8rz9Zh50Rqz5HoYIFipZ9wJxNUxFY7wj10h1waTGRaUp7DMqfsHqwhaGiLql8ey0jamQvU9ZQRDxRPdYcXzaqy6asNvebPwMxwSCUHeH98zxwpNid1fQs0wzMidxPi1yyHyBxCRggV5TtLdo8icQCXhMN1kZqYlc0looL0ROXBKbAlXHMbx5CjULYRybz6PuT2ROi6FOwEhbaxZVQ5b1TTsDUjOukyrYmLtWj0rL3ee6EUnRQezwSc0CZLKXj4ezy2m2atWqqW6fTEcKKbr2XlWB1T91HwD4mHk45OfyuMeqvMJtoAH9U9jubsRTTQQNKake03ghj0SmRls8yDnTqg7uLiySpwyS93by6D50DxQYZJuYQWxOaQ9rlxXy2KSem309ua62V9ZGDIXiMW7BiqyWCPrgJTSOPL2w2YrSH9OGoFXccICIKaXRgZgxIZLfbYeyZrQzjAbESzM8wKhbNOpuRq5_1'
+        data = dict(info=dict(task_presenter=too_large))
+        newdata = json.dumps(data)
+        res = self.app.put(
+            '/api/project/{}?api_key={}'.format(project.id, admin.api_key),
+            data=newdata)
+        res_data = json.loads(res.data)
+
+        # Verify failed to update.
+        assert res.status_code == 400, "BadRequest"
+        assert res_data['action'] == 'PUT', res_data
+        assert "content exceeds " + str(current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB')) + " MB" in res_data['exception_msg'], res_data
+
+
+    @with_context
+    def test_project_update_api_too_large(self):
+        """Test API project task presenter on PUT with too large payload"""
+        from flask import current_app
+        current_app.config['TASK_PRESENTER_MAX_SIZE_MB'] = 0.001
+        user = UserFactory.create(id=500)
+        project = ProjectFactory.create(
+            short_name='test_project',
+            name='Test Project',
+            info={
+                'total': 150,
+                'task_presenter': 'foo',
+                'data_classification': dict(input_data="L4 - public", output_data="L4 - public"),
+                'kpi': 0.5,
+                'product': 'abc',
+                'subproduct': 'def',
+            },
+            owner=user)
+        tasks = TaskFactory.create_batch(2, project=project, n_answers=2)
+        headers = [('Authorization', user.api_key)]
+
+        too_large = '1_EOqi0apgy0cd8IPREKDe9yhtT1RTXZDASgwdyDzmK6a2FeQgc2XgkknSOG7EHbBZAUh3EWo86iAC8a8P3F0I9K9Ko44AdodZSeN0T8UAzVCMj6C1nxTEG4TYmVqRJw8MFjDYAt2xuc5Wr2rhggokcJxMgzzf0Dt32nr4aWIxklF07Y6ic7zWNkZJ1Jt4dwQxZtwMBQH7FFcHmDzsZ8ZTgth5QvpE7MQOa8hnzztFB7YGQxptQx09Qj314kCk0UGbJMO3WZHCl5f9KJzJlEsjuMk5TX9ZkbQlBfR4CRTMLVSt1n3jYvbjmMKaPV678sZCSfGj7do3ljOVuqfXYIsuWajObbmGKR1WOWFNb47EYAB3YHlrEvCL7kv52boc2KAgh5HihtP2wrfMAOXAms1eOmcG2UsDQ802JtcIlVNvyU3mJ87RkRcAy2R3oUaMWmyhI8DLvbPFU1AaIm597TTjKKxrMeivcs56QelXulHdPS8kCReFwkOPJzTxfHPf6QobmbIyvqV9n8HDb8rz9Zh50Rqz5HoYIFipZ9wJxNUxFY7wj10h1waTGRaUp7DMqfsHqwhaGiLql8ey0jamQvU9ZQRDxRPdYcXzaqy6asNvebPwMxwSCUHeH98zxwpNid1fQs0wzMidxPi1yyHyBxCRggV5TtLdo8icQCXhMN1kZqYlc0looL0ROXBKbAlXHMbx5CjULYRybz6PuT2ROi6FOwEhbaxZVQ5b1TTsDUjOukyrYmLtWj0rL3ee6EUnRQezwSc0CZLKXj4ezy2m2atWqqW6fTEcKKbr2XlWB1T91HwD4mHk45OfyuMeqvMJtoAH9U9jubsRTTQQNKake03ghj0SmRls8yDnTqg7uLiySpwyS93by6D50DxQYZJuYQWxOaQ9rlxXy2KSem309ua62V9ZGDIXiMW7BiqyWCPrgJTSOPL2w2YrSH9OGoFXccICIKaXRgZgxIZLfbYeyZrQzjAbESzM8wKhbNOpuRq5EOqi0apgy0cd8IPREKDe9yhtT1RTXZDASgwdyDzmK6a2FeQgc2XgkknSOG7EHbBZAUh3EWo86iAC8a8P3F0I9K9Ko44AdodZSeN0T8UAzVCMj6C1nxTEG4TYmVqRJw8MFjDYAt2xuc5Wr2rhggokcJxMgzzf0Dt32nr4aWIxklF07Y6ic7zWNkZJ1Jt4dwQxZtwMBQH7FFcHmDzsZ8ZTgth5QvpE7MQOa8hnzztFB7YGQxptQx09Qj314kCk0UGbJMO3WZHCl5f9KJzJlEsjuMk5TX9ZkbQlBfR4CRTMLVSt1n3jYvbjmMKaPV678sZCSfGj7do3ljOVuqfXYIsuWajObbmGKR1WOWFNb47EYAB3YHlrEvCL7kv52boc2KAgh5HihtP2wrfMAOXAms1eOmcG2UsDQ802JtcIlVNvyU3mJ87RkRcAy2R3oUaMWmyhI8DLvbPFU1AaIm597TTjKKxrMeivcs56QelXulHdPS8kCReFwkOPJzTxfHPf6QobmbIyvqV9n8HDb8rz9Zh50Rqz5HoYIFipZ9wJxNUxFY7wj10h1waTGRaUp7DMqfsHqwhaGiLql8ey0jamQvU9ZQRDxRPdYcXzaqy6asNvebPwMxwSCUHeH98zxwpNid1fQs0wzMidxPi1yyHyBxCRggV5TtLdo8icQCXhMN1kZqYlc0looL0ROXBKbAlXHMbx5CjULYRybz6PuT2ROi6FOwEhbaxZVQ5b1TTsDUjOukyrYmLtWj0rL3ee6EUnRQezwSc0CZLKXj4ezy2m2atWqqW6fTEcKKbr2XlWB1T91HwD4mHk45OfyuMeqvMJtoAH9U9jubsRTTQQNKake03ghj0SmRls8yDnTqg7uLiySpwyS93by6D50DxQYZJuYQWxOaQ9rlxXy2KSem309ua62V9ZGDIXiMW7BiqyWCPrgJTSOPL2w2YrSH9OGoFXccICIKaXRgZgxIZLfbYeyZrQzjAbESzM8wKhbNOpuRq5_1'
+        data = dict(
+            info=dict(task_presenter=too_large)
+        )
+        datajson = json.dumps(data)
+
+        # Call API method to update the project task presenter.
+        res = self.app.put('/api/project/{}'.format(project.id), data=datajson, headers=headers, follow_redirects=True)
+        res_data = json.loads(res.data)
+
+        # Verify failed to update.
+        assert res.status_code == 400, "BadRequest"
+        assert res_data['action'] == 'PUT', res_data
+        assert "content exceeds " + str(current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB')) + " MB" in res_data['exception_msg'], res_data


### PR DESCRIPTION
- Enforce size limit for task presenter HTML.
- Added check to view/projects.py (task presenter update from web page).
- Added check to api/project.py (task presenter update from PUT request).
- Size limit is configurable via settings_local.py value `TASK_PRESENTER_MAX_SIZE_MB`, default to 2 MB.
## Screenshots

### Task presenter web page update

![error-message-example](https://user-images.githubusercontent.com/50708624/220757274-525d6984-c59f-4d62-a88e-f5d2256848e2.png)

### Project API update

![example-api-error](https://user-images.githubusercontent.com/50708624/220757144-a31f3146-458a-4b68-9832-049979c296af.png)

