### PR TITLE
RDISCROWD-5739 Admin Usage Dashboard

### DIFF
--- a/pybossa/cache/__init__.py
+++ b/pybossa/cache/__init__.py
@@ -134,9 +134,9 @@ def cache(key_prefix, timeout=300, cache_group_keys=None):
     """
     Adding a random jitter to reduce DB load
     There are scheduled jobs refreshing cache. When refreshing happens, caches
-    could have the same TTL. Thus they could expires at the same time, and 
-    requests will hitting DB, causing a burst of DB load. By adding a random 
-    jitter, it reduces the possibility that caches expiring at the same time 
+    could have the same TTL. Thus they could expires at the same time, and
+    requests will hitting DB, causing a burst of DB load. By adding a random
+    jitter, it reduces the possibility that caches expiring at the same time
     and balanced the DB load to avoid many requests hitting the DB.
     """
     timeout += randrange(30)

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -1355,6 +1355,23 @@ def delete_file(fname, container):
     from pybossa.core import uploader
     return uploader.delete_file(fname, container)
 
+def load_usage_dashboard_data(days):
+    timed_stats_funcs = [
+        (site_stats.number_of_created_jobs, "Projects"),
+        (site_stats.n_tasks_site, "Tasks"),
+        (site_stats.n_task_runs_site, "Taskruns"),
+    ]
+
+    # total tasks, taskruns, projects over a specified amount of time.
+    stats = OrderedDict()
+    for func, title in timed_stats_funcs:
+        stats[title] = func(days)
+
+    # component usage
+    for name, tag in current_app.config.get("USAGE_DASHBOARD_COMPONENTS", {}).items():
+        stats[name] = site_stats.n_projects_using_component(days=days, component=tag)
+
+    return stats
 
 def load_management_dashboard_data():
     # charts

--- a/pybossa/settings_local.py.tmpl
+++ b/pybossa/settings_local.py.tmpl
@@ -506,3 +506,24 @@ WIZARD_STEPS = OrderedDict([
 )
 
 MAX_IMAGE_UPLOAD_SIZE_MB = 5
+
+USAGE_DASHBOARD_COMPONENTS = {
+    'Annex' : 'annex-shell',
+    'DocX' : 'loadDocument',
+    'NLP Component' : 'text-tagging',
+    'Task Presenter' : 'task-presenter',
+    'All Buttons' : 'button-row',
+    'Submit Button' : 'submit-button',
+    'Submit and Leave Button' : 'submit-last-button',
+    'Cancel Button' : 'cancel-button',
+    'Task Timer' : 'task-timer',
+    'Conditional Display' : 'conditional-display',
+    'File Upload' : 'file-upload',
+    'Text Input' : 'text-input',
+    'Checkbox Input' : 'checkbox-input',
+    'Radio Group Input' : 'radio-group-input',
+    'Dropdown Input' : 'dropdown-input',
+    'Multiselect Input' : 'multi-select-input',
+    'Table' : 'table-element',
+    'Input Text Area' : 'input-text-area'
+}

--- a/pybossa/view/admin.py
+++ b/pybossa/view/admin.py
@@ -50,7 +50,9 @@ from pybossa.feed import get_update_feed
 from pybossa.forms.admin_view_forms import *
 from pybossa.importers import BulkImportException
 from pybossa.jobs import get_dashboard_jobs, export_all_users, \
-    load_management_dashboard_data, perform_completed_tasks_cleanup
+    load_management_dashboard_data, \
+    load_usage_dashboard_data, \
+    perform_completed_tasks_cleanup
 from pybossa.jobs import get_management_dashboard_stats
 from pybossa.jobs import send_mail
 from pybossa.model import make_timestamp
@@ -576,6 +578,23 @@ def management_dashboard():
                            category_chart=category_chart,
                            task_chart=task_chart,
                            submission_chart=submission_chart)
+
+
+@blueprint.route('/usage_dashboard/')
+@login_required
+@admin_required
+def usage_dashboard():
+    days = str(request.args.get('days'))
+    if days == 'all':
+        pass
+    elif not days.isnumeric():
+        return redirect(url_for('admin.usage_dashboard', days=365))
+    else:
+        days = int(days)
+
+    stats = load_usage_dashboard_data(days)
+    return render_template('admin/usage_dashboard.html',
+                           stats=stats)
 
 
 @blueprint.route('/subadminusers', methods=['GET', 'POST'])

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -1338,6 +1338,33 @@ class TestAdmin(web.Helper):
             assert key in data.keys(), data
 
     @with_context
+    def test_usage_dashboard(self):
+        url = '/admin/usage_dashboard/?days=30'
+        self.register()
+        self.signin()
+        res = self.app.get(url, follow_redirects=True)
+        assert res.status_code == 200, 'expected 200 status code'
+        assert '1 Month' in str(res.data), 'expected 1 month in response html'
+
+    @with_context
+    def test_usage_dashboard_redirect_empty_params(self):
+        url = '/admin/usage_dashboard/'
+        self.register()
+        self.signin()
+        res = self.app.get(url, follow_redirects=True)
+        assert res.history and res.history[0], 'expected redirect'
+        assert 'admin/usage_dashboard/?days=365' in str(res.history[0].data)
+
+    @with_context
+    def test_usage_dashboard_redirect_bad_params(self):
+        url = '/admin/usage_dashboard/?months=some_nonsense'
+        self.register()
+        self.signin()
+        res = self.app.get(url, follow_redirects=True)
+        assert res.history and res.history[0], 'expected redirect'
+        assert 'admin/usage_dashboard/?days=365' in str(res.history[0].data)
+
+    @with_context
     def test_announcement_json(self):
         """Test ADMIN JSON announcement"""
         url = '/admin/announcement'


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-5739](https://jira.prod.bloomberg.com/browse/RDISCROWD-5739)*

### Describe your changes
Adds a new admin usage dashboard that displays totals for following fields:
1. Total projects
2. Total tasks
3. Total taskruns
4. Total projects using NLP component (text-tag)
5. Total projects using annex
6. Total projects using DocX

![image](https://user-images.githubusercontent.com/17805819/223851936-f7bcd145-b8e0-45b6-96c4-10a63ed2864b.png)

**Usage**
Takes url parameter 'months' to specify how many previous months to include in the stats. Examples: http://localhost:5000/admin/usage_dashboard/?months=12
http://localhost:5000/admin/usage_dashboard/?months=24
http://localhost:5000/admin/usage_dashboard/?months=123
etc...

**settings_local Config example:**
```
USAGE_DASHBOARD_COMPONENTS = {
    'Annex' : 'annex-shell',
    'DocX' : 'loadDocument',
    'NLP Component' : 'text-tagging'
}
```
### Testing performed
Tested Locally

### Additional context
https://github.com/bloomberg/pybossa-default-theme/pull/405
