### PR TITLE
RDISCROWD-5631 Retrieving partially saved tasks from a different queue

### DIFF
--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -186,7 +186,8 @@ def new_task(project_id, task_id=None):
         if saved_task_position:
             try:
                 saved_task_position = SavedTaskPositionEnum(saved_task_position.decode('utf-8'))
-            except ValueError as e: pass
+            except ValueError as e:
+                pass
 
     # Check if the request has an arg:
     try:

--- a/pybossa/sched.py
+++ b/pybossa/sched.py
@@ -369,6 +369,8 @@ def locked_scheduler(query_factory):
                 if meet_requirement:
                     score = cached_task_browse_helpers.get_task_preference_score(w_pref, user_profile)
                     task_rank_info.append((task_id, taskcount, n_answers, calibration, score, None, timeout))
+            else:  # Default/locker schedulers
+                task_rank_info.append((task_id, taskcount, n_answers, calibration, score, None, timeout))
         rows = sorted(task_rank_info, key=lambda tup: tup[4], reverse=True)
 
         # Iterate a list of tasks but only lock one task and return the locked task

--- a/pybossa/sched.py
+++ b/pybossa/sched.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 """Scheduler module for PYBOSSA tasks."""
+import sys
 from functools import wraps
 from sqlalchemy.sql import func, desc, text
 from sqlalchemy.sql import and_, or_
@@ -40,6 +41,7 @@ from pybossa import data_access
 from datetime import datetime
 import re
 
+from pybossa.util import SavedTaskPositionEnum, get_user_saved_partial_tasks
 
 session = db.slave_session
 
@@ -58,7 +60,7 @@ TIMEOUT = ContributionsGuard.STAMP_TTL
 def new_task(project_id, sched, user_id=None, user_ip=None,
              external_uid=None, offset=0, limit=1, orderby='priority_0',
              desc=True, rand_within_priority=False,
-             gold_only=False, task_id=None):
+             gold_only=False, task_id=None, saved_task_position=None):
     """Get a new task by calling the appropriate scheduler function."""
     sched_map = {
         'default': get_locked_task,
@@ -94,7 +96,8 @@ def new_task(project_id, sched, user_id=None, user_ip=None,
                      rand_within_priority=rand_within_priority,
                      filter_user_prefs=(sched in [Schedulers.user_pref, Schedulers.task_queue]),
                      task_type=task_type,
-                     task_id=task_id if sched in [Schedulers.task_queue] else None)
+                     task_id=task_id if sched in [Schedulers.task_queue] else None,
+                     saved_task_position=saved_task_position)
 
 
 def is_locking_scheduler(sched):
@@ -262,7 +265,8 @@ def locked_scheduler(query_factory):
                                  rand_within_priority=False, task_type='gold_last',
                                  filter_user_prefs=False,
                                  task_category_filters="",
-                                 task_id=None):
+                                 task_id=None,
+                                 saved_task_position=None):
         if task_id:
             task = session.query(Task).get(task_id)
             if task:
@@ -276,12 +280,14 @@ def locked_scheduler(query_factory):
         timeout = project.info.get('timeout', TIMEOUT)
         task_queue_scheduler = project.info.get("sched", "default") in [Schedulers.task_queue]
         reserve_task_config = project.info.get("reserve_tasks", {}).get("category", [])
-        task_id, lock_seconds = get_task_id_and_duration_for_project_user(project_id, user_id)
+
+        # "first" or "last" value of saved_task_position will result tasks retrieving from DB
+        task_id, lock_seconds = (None, 0) if saved_task_position else get_task_id_and_duration_for_project_user(project_id, user_id)
+
         if lock_seconds > 10:
             task = session.query(Task).get(task_id)
             if task:
                 return [task]
-        task_id = None
         user_count = get_active_user_count(project_id, sentinel.master)
         assign_user = json.dumps({'assign_user': [cached_users.get_user_email(user_id)]}) if user_id else None
         current_app.logger.info(
@@ -338,21 +344,34 @@ def locked_scheduler(query_factory):
 
         user_profile = cached_users.get_user_profile_metadata(user_id)
 
-        if filter_user_prefs:
-            # validate user qualification and calculate task preference score
-            user_profile = json.loads(user_profile) if user_profile else {}
-            task_rank_info = []
-            for task_id, taskcount, n_answers, calibration, w_filter, w_pref, timeout in rows:
+        # Get all saved task IDs from Redis for the current user
+        task_id_map = None
+        if saved_task_position:
+            task_id_map = get_user_saved_partial_tasks(sentinel, project_id, user_id)
+
+        # validate user qualification and calculate task preference score
+        user_profile = json.loads(user_profile) if user_profile else {}
+        task_rank_info = []
+        for task_id, taskcount, n_answers, calibration, w_filter, w_pref, timeout in rows:
+            score = 0
+            # Check the dictionary task_id_map for the saved task and set the score for sorting
+            if task_id_map:
+                ttl = task_id_map.get(task_id, -1)
+                if ttl > 0 and saved_task_position == SavedTaskPositionEnum.LAST:
+                    score = -ttl  # Saved tasks sink to the bottom, but with earliest saved task first
+                elif ttl > 0 and saved_task_position == SavedTaskPositionEnum.FIRST:
+                    score = sys.maxsize - ttl  # Earliest saved task first
+                task_rank_info.append((task_id, taskcount, n_answers, calibration, score, None, timeout))
+            elif filter_user_prefs:  # Only include when filter requirement is met
                 w_pref = w_pref or {}
                 w_filter = w_filter or {}
                 meet_requirement = cached_task_browse_helpers.user_meet_task_requirement(task_id, w_filter, user_profile)
                 if meet_requirement:
                     score = cached_task_browse_helpers.get_task_preference_score(w_pref, user_profile)
                     task_rank_info.append((task_id, taskcount, n_answers, calibration, score, None, timeout))
-            rows = sorted(task_rank_info, key=lambda tup: tup[4], reverse=True)
-        else:
-            rows = [r for r in rows]
+        rows = sorted(task_rank_info, key=lambda tup: tup[4], reverse=True)
 
+        # Iterate a list of tasks but only lock one task and return the locked task
         for task_id, taskcount, n_answers, calibration, _, _, timeout in rows:
             timeout = timeout or TIMEOUT
             remaining = float('inf') if calibration else n_answers - taskcount
@@ -540,7 +559,7 @@ def select_task_for_gold_mode(project, user_id):
 
 @locked_scheduler
 def get_locked_task(project_id, user_id=None, limit=1, rand_within_priority=False,
-                    task_type='gold_last', task_category_filters=""):
+                    task_type='gold_last', task_category_filters="", saved_task_position=None):
     return locked_task_sql(project_id, user_id=user_id, limit=limit,
                            rand_within_priority=rand_within_priority, task_type=task_type,
                            filter_user_prefs=False, task_category_filters=task_category_filters)
@@ -548,7 +567,7 @@ def get_locked_task(project_id, user_id=None, limit=1, rand_within_priority=Fals
 
 @locked_scheduler
 def get_user_pref_task(project_id, user_id=None, limit=1, rand_within_priority=False,
-                       task_type='gold_last', filter_user_prefs=True, task_category_filters=""):
+                       task_type='gold_last', filter_user_prefs=True, task_category_filters="", saved_task_position=None):
     """ Select a new task based on user preference set under user profile.
 
     For each incomplete task, check if the number of users working on the task

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1303,6 +1303,19 @@ class TestPybossaUtil(Test):
         res = util.extract_task_info_data(task, task_info_str)
         assert res == '123', res
 
+    @with_request_context
+    def test_get_user_saved_partial_tasks(self):
+        sentinel = MagicMock()
+        master = MagicMock()
+        sentinel.master = master
+        master.zrangebyscore.return_value = [(b'000','not a number' ), (b'123', 666666.0), (b'456', 777777.1)]
+
+        project_id = 1
+        user_id = 1
+        result = util.get_user_saved_partial_tasks(sentinel, project_id, user_id)
+
+        assert result == {123: 666666, 456: 777777}
+
 
 class TestIsReservedName(object):
     from test import flask_app as app

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -10038,26 +10038,6 @@ class TestWeb(web.Helper):
         assert "class=\" sort-asc sortable\" data-sort=\"completed_by\"" not in str(res.data), "Unexpected sorted column (sort-asc) indicator on Completed By."
         assert "class=\" sort-asc sortable\" data-sort=\"priority\"" not in str(res.data), "Missing sorted column indicator (sort-asc) on Priority."
 
-    @with_context
-    @patch('pybossa.view.projects.sentinel.master.get')
-    def test_new_task_with_saved_task_position(self, sentinel_mock):
-        """Test fetch lock works."""
-        admin = UserFactory.create(admin=True)
-        admin.set_password('1234')
-        user_repo.save(admin)
-        self.signin(email=admin.email_addr, password='1234')
-
-        # Test locked_scheduler
-        project = ProjectFactory.create(owner=admin, short_name='test', info={'sched':'locked_scheduler'})
-        task = TaskFactory.create(project=project)
-
-        sentinel_mock.return_value = b'first'
-
-        url = f'/api/project/{project.id}/newtask'
-        res = self.app.get(url, follow_redirects=True)
-
-        assert res.status_code == 200, res.status_code
-
 class TestWebUserMetadataUpdate(web.Helper):
 
     original = {

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3334,6 +3334,34 @@ class TestWeb(web.Helper):
         assert 'setup_task_timeout_display(3600, 3600)' in str(res.data), "Incorrect timeout value"
 
     @with_context
+    @patch('pybossa.view.projects.get_task_id_and_duration_for_project_user')
+    def test_get_next_task_with_saved_task_position(self, get_task_id_and_duration_for_project_user):
+        self.create()
+        self.delete_task_runs()
+        self.register()
+
+        # Sign-in as user.
+        email_addr = 'johndoe@example.com'
+        make_subadmin_by(email_addr=email_addr)
+        csrf = self.get_csrf('/account/signin')
+        self.signin(email=email_addr, csrf=csrf)
+
+        # Get the project, task, and user.
+        project = db.session.query(Project).first()
+        task = db.session.query(Task)\
+                 .filter(Project.id == project.id)\
+                 .first()
+        user = db.session.query(User).filter(User.email_addr == email_addr).first()
+
+        # Mock a redis lock return value.
+        get_task_id_and_duration_for_project_user.return_value = (task.id, 11)
+
+        # Simulate user closing tab and clicking Start Contributing Now, should receive already locked task.
+        url = f'project/{project.short_name}/newtask?saved_task_position=first'
+        res = self.app.get(url, follow_redirects=True, headers={'X-CSRFToken': csrf})
+        assert res.status_code == 200, res
+
+    @with_context
     @patch('pybossa.view.projects.has_no_presenter')
     @patch('pybossa.view.projects.fetch_lock_for_user')
     @patch('pybossa.view.projects.time')
@@ -10010,6 +10038,25 @@ class TestWeb(web.Helper):
         assert "class=\" sort-asc sortable\" data-sort=\"completed_by\"" not in str(res.data), "Unexpected sorted column (sort-asc) indicator on Completed By."
         assert "class=\" sort-asc sortable\" data-sort=\"priority\"" not in str(res.data), "Missing sorted column indicator (sort-asc) on Priority."
 
+    @with_context
+    @patch('pybossa.view.projects.sentinel.master.get')
+    def test_new_task_with_saved_task_position(self, sentinel_mock):
+        """Test fetch lock works."""
+        admin = UserFactory.create(admin=True)
+        admin.set_password('1234')
+        user_repo.save(admin)
+        self.signin(email=admin.email_addr, password='1234')
+
+        # Test locked_scheduler
+        project = ProjectFactory.create(owner=admin, short_name='test', info={'sched':'locked_scheduler'})
+        task = TaskFactory.create(project=project)
+
+        sentinel_mock.return_value = b'first'
+
+        url = f'/api/project/{project.id}/newtask'
+        res = self.app.get(url, follow_redirects=True)
+
+        assert res.status_code == 200, res.status_code
 
 class TestWebUserMetadataUpdate(web.Helper):
 
@@ -10472,19 +10519,47 @@ class TestWebUserMetadataUpdate(web.Helper):
         assert other_email in task2_modified.user_pref.get('assign_user')
 
     @with_context
-    def test_partial_answer_exception(self):
+    def test_partial_answer_user_exception(self):
         """Test partial answer API with exception as user doesn't sign in """
-        url = f"/api/task/123/partial_answer"
+        user = UserFactory.create(email_addr='a@a.com', fullname="test_user")
+        project = ProjectFactory.create(
+            info={
+                'sched': 'user_pref_scheduler',
+                'timeout': 60 * 60,
+                'data_classification': dict(input_data="L4 - public",
+                                            output_data="L4 - public")
+            },
+            owner=user
+        )
+        url = f"/api/project/{project.short_name}/task/123/partial_answer"
         resp = self.app_get_json(url)
         assert resp.status_code == 415
+
+    @with_context
+    def test_partial_answer_project_exception(self):
+        """Test partial answer API with exception as project short name invalid """
+        user = UserFactory.create(email_addr='a@a.com', fullname="test_user")
+        self.signin_user(user)
+        url = f"/api/project/invalid_shortname/task/123/partial_answer"
+        resp = self.app_get_json(url)
+        assert resp.status_code == 400
 
     @with_context
     def test_partial_answer(self):
         """Test partial answer API """
         user = UserFactory.create(email_addr='a@a.com', fullname="test_user")
         self.signin_user(user)
+        project = ProjectFactory.create(
+            info={
+                'sched': 'user_pref_scheduler',
+                'timeout': 60 * 60,
+                'data_classification': dict(input_data="L4 - public",
+                                            output_data="L4 - public")
+            },
+            owner=user
+        )
 
-        url = f"/api/task/123/partial_answer"
+        url = f"/api/project/{project.short_name}/task/123/partial_answer"
         data = {"my_answer": {"k1: ": "test", "k2": [1, 2, "abc"]}}
         resp = self.app_post_json(url, data=data, follow_redirects=False)
         assert json.loads(resp.data).get('success')
@@ -10494,6 +10569,44 @@ class TestWebUserMetadataUpdate(web.Helper):
 
         resp = self.app.delete(url)
         assert json.loads(resp.data).get('success')
+
+    @with_context
+    def test_user_has_partial_answer(self):
+        """Test user_has_partial_answer API """
+        user = UserFactory.create(email_addr='a@a.com', fullname="test_user")
+        self.signin_user(user)
+        project = ProjectFactory.create(
+            info={
+                'sched': 'user_pref_scheduler',
+                'timeout': 60 * 60,
+                'data_classification': dict(input_data="L4 - public",
+                                            output_data="L4 - public")
+            },
+            owner=user
+        )
+
+        url = f"/api/project/{project.short_name}/has_partial_answer"
+        resp = self.app_get_json(url)
+        assert resp.json.get('has_answer') == False, resp.status_code == 200
+
+    @with_context
+    def test_user_has_partial_answer_without_auth(self):
+        """Test user_has_partial_answer without auth"""
+
+        user = UserFactory.create(email_addr='a@a.com', fullname="test_user")
+        project = ProjectFactory.create(
+            info={
+                'sched': 'user_pref_scheduler',
+                'timeout': 60 * 60,
+                'data_classification': dict(input_data="L4 - public",
+                                            output_data="L4 - public")
+            },
+            owner=user
+        )
+
+        url = f"/api/project/{project.short_name}/has_partial_answer"
+        resp = self.app_get_json(url)
+        assert resp.status_code == 401, resp
 
 
 class TestWebQuizModeUpdate(web.Helper):


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-5631*

**Describe your changes**
- /project/<shortname>/new_task API now accepts saved_task_position=first or saved_task_position=last to indicate the saved tasks should be placed at the head of the queue or at the tail of the queue
- Task list will always display the saved tasks first
- partial_answer API's endpoint has been updated to include project_shortname. Also, a sorted set is used to track all tasks IDs saved by the user.
- /project/<short_name>/has_partial_answer API is added to check whether a user has any saved tasks for the project

**Testing performed**
Tested locally

**Additional context**
Related PRs:
- https://github.com/bloomberg/pybossa.js/pull/24
- https://github.com/bloomberg/pybossa-default-theme/pull/407
