### PR TITLE
Project API fix - Added None check on content length when size exceeds limit.

### DIFF
--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -56,7 +56,7 @@ class ProjectAPI(APIBase):
         content_length = request.content_length if request else 0
         max_length_mb = current_app.config.get('TASK_PRESENTER_MAX_SIZE_MB', 2)
         max_length_bytes = max_length_mb * 1024 * 1024 # Maximum POST data size (MB)
-        if content_length > max_length_bytes:
+        if content_length and content_length > max_length_bytes:
             raise BadRequest('The task presenter/guidelines content exceeds ' +
                 str(max_length_mb) +
                 ' MB. Please move large content to an external file.')


### PR DESCRIPTION
- Added fix for None content length: `'>' not supported between instances of 'NoneType' and 'int'`

*The missing `request.content_length` appears to occur when issuing a PUT request to **http://** instead of **https://**.*

## Fix for the following

PUT http://qa.gigwork.net/api/project/1887

### Request

```json
{
	"info": {
		"task_presenter": "acb123...",
		"task_guidelines": "",
		"data_classification": {
			"input_data": "abc",
			"output_data": "xyz"
		}
        }
}
```

### Response

```json
{
	"action": "PUT",
	"status": "failed",
	"status_code": 415,
	"target": "project",
	"exception_cls": "TypeError",
	"exception_msg": "'>' not supported between instances of 'NoneType' and 'int'"
}
```
