### PR TITLE
RDISCROWD-5775 limit task expiration

### DIFF
--- a/pybossa/api/api_base.py
+++ b/pybossa/api/api_base.py
@@ -368,6 +368,11 @@ class APIBase(MethodView):
         perform preprocessing on the POST data"""
         pass
 
+    def _preprocess_update_data(self, data):
+        """Method to be overridden by inheriting classes that will
+        perform preprocessing on the PUT data"""
+        pass
+
     def _preprocess_request(self, request):
         """Method to be overridden by inheriting classes that will
         perform preprocessong on the POST and PUT request"""
@@ -460,6 +465,7 @@ class APIBase(MethodView):
         if new_upload is None:
             data = json.loads(request.data)
             new_data = data
+            # self._preprocess_update_data(new_data)
         else:
             new_data = request.form
         self._forbidden_attributes(new_data)

--- a/pybossa/api/api_base.py
+++ b/pybossa/api/api_base.py
@@ -368,11 +368,6 @@ class APIBase(MethodView):
         perform preprocessing on the POST data"""
         pass
 
-    def _preprocess_update_data(self, data):
-        """Method to be overridden by inheriting classes that will
-        perform preprocessing on the PUT data"""
-        pass
-
     def _preprocess_request(self, request):
         """Method to be overridden by inheriting classes that will
         perform preprocessong on the POST and PUT request"""
@@ -465,7 +460,6 @@ class APIBase(MethodView):
         if new_upload is None:
             data = json.loads(request.data)
             new_data = data
-            # self._preprocess_update_data(new_data)
         else:
             new_data = request.form
         self._forbidden_attributes(new_data)

--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -136,9 +136,6 @@ class TaskAPI(APIBase):
     def _select_attributes(self, data):
         return TaskAuth.apply_access_control(data, user=current_user, project_data=get_project_data(data['project_id']))
 
-    def _preprocess_update_data(self, data):
-        data['expiration'] = get_task_expiration(data.get('expiration'))
-
     def put(self, oid):
         # reset cache / memoized
         delete_memoized(get_searchable_columns)

--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -79,6 +79,8 @@ class TaskAPI(APIBase):
                                 "old exported: %s, new exported: %s",
                                 new.id, old.state, new.state,
                                 str(old.exported), str(new.exported))
+        if new.expiration is not None:
+            new.expiration = get_task_expiration(new.expiration)
 
     def _preprocess_post_data(self, data):
         project_id = data["project_id"]
@@ -133,6 +135,9 @@ class TaskAPI(APIBase):
 
     def _select_attributes(self, data):
         return TaskAuth.apply_access_control(data, user=current_user, project_data=get_project_data(data['project_id']))
+
+    def _preprocess_update_data(self, data):
+        data['expiration'] = get_task_expiration(data.get('expiration'))
 
     def put(self, oid):
         # reset cache / memoized


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-5775](https://jira.prod.bloomberg.com/browse/RDISCROWD-5775)*

**Describe your changes**
Modifies the task API so that task expiration cannot be set beyond the permitted max expiration (60 days for private and 180 days for public) using a PUT request.
If the user tries to set task expiration beyond the limit, it is set to the maximum possible expiration and the method returns a 200 response code.

**Testing performed**
Tested Locally
