### PR TITLE
RDISCROWD 5743 task browse bookmarks

### DIFF
--- a/pybossa/cache/users.py
+++ b/pybossa/cache/users.py
@@ -350,6 +350,22 @@ def delete_user_pref_metadata(user):
     delete_memoized(get_user_by_id, user.id)
 
 
+@memoize(timeout=timeouts.get('APP_TIMEOUT'))
+def get_taskbrowse_bookmarks(name):
+    sql = text("""
+    SELECT info->'taskbrowse_bookmarks' FROM "user" WHERE name=:name;
+    """)
+    cursor = session.execute(sql, dict(name=name))
+    row = cursor.fetchone()
+    taskbrowse_bookmarks = row[0] or {}
+    return taskbrowse_bookmarks
+
+
+def delete_taskbrowse_bookmarks(user):
+    delete_memoized(get_taskbrowse_bookmarks, user.name)
+    delete_memoized(get_user_by_id, user.id)
+
+
 def get_user_preferences(user_id):
     user = get_user_by_id(user_id)
     user_pref = user.user_pref or {} if user else {}

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -1205,7 +1205,7 @@ def taskbrowse_bookmarks(user_name, short_name):
     if current_user.name != user_name:
         return abort(404)
 
-    # get all bookmarks for project from cache
+    # get bookmarks for project from cache
     if request.method == 'GET':
         res_bookmarks = _get_bookmarks(user_name, short_name)
 

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -1156,6 +1156,11 @@ def add_metadata(name):
 @login_required
 def taskbrowse_bookmarks(user_name, short_name):
     user = user_repo.get_by_name(name=user_name)
+    if user is None:
+        return abort(404)
+    if current_user.name != user_name:
+        return abort(403)
+
     all_bookmarks = user.info.get('taskbrowse_bookmarks', {})
     proj_bookmarks = all_bookmarks.get(short_name, {})
     # get all bookmarks for project
@@ -1163,9 +1168,6 @@ def taskbrowse_bookmarks(user_name, short_name):
         return jsonify(proj_bookmarks)
     # add a bookmark
     if request.method == 'POST':
-        (can_update, disabled_fields, hidden_fields) = can_update_user_info(current_user, user)
-        if not can_update:
-            abort(403)
         url = request.body.get('url', None)
         name = request.body.get('name', None)
         if name is None or len(name) > 100 or \
@@ -1182,13 +1184,13 @@ def taskbrowse_bookmarks(user_name, short_name):
 @login_required
 def delete_taskbrowse_bookmarks(user_name, short_name, bookmark_name):
     user = user_repo.get_by_name(name=user_name)
-    #del user.info['taskbrowse_bookmarks']
-    #user_repo.update(user)
+    if user is None:
+        return abort(404)
+    if current_user.name != user_name:
+        return abort(403)
+
     all_bookmarks = user.info.get('taskbrowse_bookmarks', {})
     proj_bookmarks = all_bookmarks.get(short_name, {})
-    (can_update, disabled_fields, hidden_fields) = can_update_user_info(current_user, user)
-    if not can_update:
-        abort(403)
     if bookmark_name not in proj_bookmarks:
         abort(400)
     del proj_bookmarks[bookmark_name]

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -76,6 +76,8 @@ mail_queue = Queue('email', connection=sentinel.master)
 export_queue = Queue('high', connection=sentinel.master)
 super_queue = Queue('super', connection=sentinel.master)
 
+MAX_BOOKMARK_NAME_LEN = 100
+MAX_BOOKMARK_URL_LEN = 500
 
 @blueprint.route('/')
 @blueprint.route('/page/<int:page>')
@@ -1168,9 +1170,6 @@ def taskbrowse_bookmarks(user_name, short_name):
         user = user_repo.get_by_name(name=user_name)
         taskbrowse_bookmarks = user.info.get('taskbrowse_bookmarks', {})
         proj_bookmarks = taskbrowse_bookmarks.get(short_name, {})
-
-        MAX_BOOKMARK_NAME_LEN = 100
-        MAX_BOOKMARK_URL_LEN = 500
 
         url = request.body.get('url', None)
         name = request.body.get('name', None)

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -1158,15 +1158,17 @@ def taskbrowse_bookmarks(user_name, short_name):
     if current_user.name != user_name:
         return abort(403)
 
-    taskbrowse_bookmarks = cached_users.get_taskbrowse_bookmarks(user_name)
-    proj_bookmarks = taskbrowse_bookmarks.get(short_name, {})
-
     # get all bookmarks for project
     if request.method == 'GET':
+        taskbrowse_bookmarks = cached_users.get_taskbrowse_bookmarks(user_name)
+        proj_bookmarks = taskbrowse_bookmarks.get(short_name, {})
         return jsonify(proj_bookmarks)
     # add a bookmark
     if request.method == 'POST':
         user = user_repo.get_by_name(name=user_name)
+        taskbrowse_bookmarks = user.info.get('taskbrowse_bookmarks', {})
+        proj_bookmarks = taskbrowse_bookmarks.get(short_name, {})
+
         MAX_BOOKMARK_NAME_LEN = 100
         MAX_BOOKMARK_URL_LEN = 500
 

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -1156,7 +1156,6 @@ def add_metadata(name):
 @login_required
 def taskbrowse_bookmarks(name, short_name):
     user = user_repo.get_by_name(name=name)
-    print(user.info)
     all_bookmarks = user.info.get('taskbrowse_bookmarks', {})
     proj_bookmarks = all_bookmarks.get(short_name, [])
     # get all bookmarks for project
@@ -1182,11 +1181,7 @@ def taskbrowse_bookmarks(name, short_name):
 @blueprint.route('/<name>/taskbrowse_bookmarks/<short_name>/<index>', methods=['DELETE'])
 @login_required
 def delete_taskbrowse_bookmarks(name, short_name, index):
-
-
     user = user_repo.get_by_name(name=name)
-    del user.info['taskbrowse_bookmarks']
-    user_repo.update(user)
     all_bookmarks = user.info.get('taskbrowse_bookmarks', {})
     proj_bookmarks = all_bookmarks.get(short_name, [])
     (can_update, disabled_fields, hidden_fields) = can_update_user_info(current_user, user)

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -1157,7 +1157,6 @@ def add_metadata(name):
 def taskbrowse_bookmarks(user_name, short_name):
     user = user_repo.get_by_name(name=user_name)
     all_bookmarks = user.info.get('taskbrowse_bookmarks', {})
-    # TODO: validate short_name?
     proj_bookmarks = all_bookmarks.get(short_name, {})
     # get all bookmarks for project
     if request.method == 'GET':
@@ -1167,7 +1166,6 @@ def taskbrowse_bookmarks(user_name, short_name):
         (can_update, disabled_fields, hidden_fields) = can_update_user_info(current_user, user)
         if not can_update:
             abort(403)
-        # TODO: validate url?
         url = request.body.get('url', None)
         name = request.body.get('name', None)
         if name is None or len(name) > 100 or \

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -1156,6 +1156,7 @@ def add_metadata(name):
 @login_required
 def taskbrowse_bookmarks(name):
     user = user_repo.get_by_name(name=name)
+    print(user.info)
     bookmarks = user.info.get('taskbrowse_bookmarks', [])
     # get all bookmarks
     if request.method == 'GET':
@@ -1168,7 +1169,7 @@ def taskbrowse_bookmarks(name):
         url = request.body.get('url', None)
         name = request.body.get('name', None)
         if name is None or len(name) > 100 or \
-            url is None or len(url) > 150:
+            url is None or len(url) > 500:
             abort(400)
         bookmarks.append((name, url))
         user.info['taskbrowse_bookmarks'] = bookmarks

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -1176,11 +1176,11 @@ def taskbrowse_bookmarks(user_name, short_name):
 
         if name is None or len(name) > MAX_BOOKMARK_NAME_LEN:
             error = f'Bookmark name must be between 1-{MAX_BOOKMARK_NAME_LEN} characters.'
-            current_app.logger.exception(f'Bad request: {error},  project: {short_name}, name:{name}')
+            current_app.logger.exception(f'Bad request: {error},  project: {short_name}, bookmark_name:{name}')
             return Response(json.dumps({"description": error}), 400, mimetype='application/json')
         if url is None or len(url) > MAX_BOOKMARK_URL_LEN:
             error = 'Bookmark URL must be between 1-100 characters.'
-            current_app.logger.exception(f'Bad request: {error}, project: {short_name}, url:{url}')
+            current_app.logger.exception(f'Bad request: {error}, project: {short_name}, bookmark_url:{url}')
             return Response(json.dumps({"description": error}), 400, mimetype='application/json')
 
         proj_bookmarks[name] =  url
@@ -1202,7 +1202,7 @@ def delete_taskbrowse_bookmarks(user_name, short_name, bookmark_name):
     taskbrowse_bookmarks = user.info.get('taskbrowse_bookmarks', {})
     proj_bookmarks = taskbrowse_bookmarks.get(short_name, {})
     if bookmark_name not in proj_bookmarks:
-        current_app.logger.exception(f'Bookmark not found. project: {short_name}, bookmark: {bookmark_name}')
+        current_app.logger.exception(f'Bookmark not found. project: {short_name}, bookmark_name: {bookmark_name}')
         return Response(json.dumps({"description":"Bookmark not found."}), 400, mimetype='application/json')
     del proj_bookmarks[bookmark_name]
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -1748,6 +1748,7 @@ class TestWeb(web.Helper):
         res = self.app.get(url)
         assert res.status_code == 403
 
+
     @with_context
     def test_05a_get_nonexistant_app(self):
         """Test WEB get not existant project should return 404"""
@@ -10587,6 +10588,62 @@ class TestWebUserMetadataUpdate(web.Helper):
         url = f"/api/project/{project.short_name}/has_partial_answer"
         resp = self.app_get_json(url)
         assert resp.status_code == 401, resp
+
+
+    @with_context
+    def test_get_taskbrowse_bookmarks(self):
+        data = self.original
+        bookmarks = [
+                        [
+                            "bookmark 1",
+                            "https://gigwork.net/project/testproject66/tasks/browse/1/10?changed=true&display_columns=%5B%22task_id%22%2C%22priority%22%2C%22pcomplete%22%2C%22created%22%2C%22finish_time%22%2C%22gold_task%22%2C%22actions%22%2C%22lock_status%22%5D&order_by=task_id+asc&pcomplete_from=46&pcomplete_to=100&priority_from=0.45&priority_to=1.00&display_info_columns=%5B%5D"
+                        ],
+                        [
+                            "bookmark 2",
+                            "https://gigwork.net/project/testproject66/tasks/browse"
+                        ]
+        ]
+        info = {
+                'metadata':{
+                    'user_type':data['user_type'],
+                    'work_hours_from':data['work_hours_from'],
+                    'work_hours_to':data['work_hours_to'],
+                    'timezone':data['timezone'],
+                    'review':data['review']
+                },
+                'taskbrowse_bookmarks' : bookmarks
+            }
+        user = UserFactory.create(info=info)
+        self.signin_user(user)
+        url = f"/account/{user.name}/taskbrowse_bookmarks/"
+        res = self.app.get(url)
+
+        assert res.status_code == 200, res.status_code
+        data = json.loads(res.data)
+        assert str(data) == str(bookmarks)
+
+
+    @with_context
+    def test_post_taskbrowse_bookmarks(self):
+        pass
+
+    @with_context
+    def test_post_taskbrowse_bookmarks_missing_arguments(self):
+        pass
+
+    @with_context
+    def test_delete_taskbrowse_bookmarks(self):
+        pass
+
+    @with_context
+    def test_delete_taskbrowse_bookmarks_index_outofbounds(self):
+        pass
+
+    @with_context
+    def test_delete_taskbrowse_bookmarks_non_integer_index(self):
+        pass
+
+
 
 
 class TestWebQuizModeUpdate(web.Helper):

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -10592,7 +10592,7 @@ class TestWebUserMetadataUpdate(web.Helper):
 
     @with_context
     def test_get_taskbrowse_bookmarks(self):
-        """Test get taskbrowse_bookmark works"""
+        """Test get taskbrowse_bookmark works."""
         data = self.original
         target_project = "project1"
         bookmarks = {

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -10592,7 +10592,7 @@ class TestWebUserMetadataUpdate(web.Helper):
 
     @with_context
     def test_get_taskbrowse_bookmarks(self):
-        """Test get taskbrowse_bookmark works."""
+        """Test get taskbrowse_bookmark works"""
         data = self.original
         target_project = "project1"
         bookmarks = {

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -10678,13 +10678,13 @@ class TestWebUserMetadataUpdate(web.Helper):
         url = f"/account/{user.name}/taskbrowse_bookmarks/{target_project}"
 
         # test first time insertion
-        res = self.app.post(url, data={"name":name1, "url":url1})
+        res = self.app.post(url, json={"name":name1, "url":url1})
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
         assert str(data) == str({name1:url1})
 
         # test if new url is appended correctly
-        res = self.app.post(url, data={"name":name2, "url":url2})
+        res = self.app.post(url, json={"name":name2, "url":url2})
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
         assert str(data) == str({name1:url1, name2:url2})
@@ -10697,7 +10697,7 @@ class TestWebUserMetadataUpdate(web.Helper):
 
         # test adding bookmark for a different project
         new_url = f"/account/{user.name}/taskbrowse_bookmarks/project2"
-        res = self.app.post(new_url, data={"name":name2, "url":url2})
+        res = self.app.post(new_url, json={"name":name2, "url":url2})
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
         assert str(data) == str({name2:url2})
@@ -10722,12 +10722,13 @@ class TestWebUserMetadataUpdate(web.Helper):
         url = f"/account/{user.name}/taskbrowse_bookmarks/{target_project}"
 
         # test no name
-        res = self.app.post(url, data={"url":url1})
+        res = self.app.post(url, json={"url":url1})
         assert res.status_code == 400, res.status_code
 
         # test no url
-        res = self.app.post(url, data={"name":name1})
+        res = self.app.post(url, json={"name":name1})
         assert res.status_code == 400, res.status_code
+
 
     @with_context
     def test_delete_taskbrowse_bookmarks(self):
@@ -10750,8 +10751,9 @@ class TestWebUserMetadataUpdate(web.Helper):
 
         user = UserFactory.create(info=info)
         self.signin_user(user)
-        url = f"/account/{user.name}/taskbrowse_bookmarks/{target_project}/bookmark1"
-        res = self.app.delete(url)
+        url = f"/account/{user.name}/taskbrowse_bookmarks/{target_project}"
+        data = {"name": "bookmark1"}
+        res = self.app.delete(url, json=data)
 
         expected_res = {"bookmark2" : "https://gigwork.net/project/testproject66/tasks/browse"}
         assert res.status_code == 200, res.status_code
@@ -10759,8 +10761,9 @@ class TestWebUserMetadataUpdate(web.Helper):
         assert str(data) == str(expected_res)
 
         # ensure deleting last bookmark does not result in error
-        url = f"/account/{user.name}/taskbrowse_bookmarks/{target_project}/bookmark2"
-        res = self.app.delete(url)
+        url = f"/account/{user.name}/taskbrowse_bookmarks/{target_project}"
+        data = {"name" : "bookmark2"}
+        res = self.app.delete(url, json=data)
 
         expected_res = {}
         assert res.status_code == 200, res.status_code
@@ -10787,14 +10790,15 @@ class TestWebUserMetadataUpdate(web.Helper):
             }
         user = UserFactory.create(info=info)
         self.signin_user(user)
-        url = f"/account/{user.name}/taskbrowse_bookmarks/{target_project}/thisbookmarkdoesnotexist"
-        res = self.app.delete(url)
+        url = f"/account/{user.name}/taskbrowse_bookmarks/{target_project}"
+        data = {"name": "thisbookmarkdoesnotexist"}
+        res = self.app.delete(url, json=data)
         assert res.status_code == 400, res.status_code
 
 
     @with_context
     def test_get_taskbrowse_bookmarks_user_errors(self):
-        """Test create and retrive taskbrowse bookmarks"""
+        """Test retrive taskbrowse bookmarks returns errors"""
         data = self.original
         target_project = "project1"
 
@@ -10809,17 +10813,17 @@ class TestWebUserMetadataUpdate(web.Helper):
         url = f"/account/{user2.name}/taskbrowse_bookmarks/{target_project}"
 
         res = self.app.post(url, data={"name":name1, "url":url1})
-        assert res.status_code == 403, res.status_code
-        res = self.app.delete(f"{url}/bookmark_name")
-        assert res.status_code == 403, res.status_code
+        assert res.status_code == 404, res.status_code
+        res = self.app.delete(url, data={"name":name1})
+        assert res.status_code == 404, res.status_code
 
         # try to access bookmarks of a user that does not exist
         url = f"/account/somefakeuser/taskbrowse_bookmarks/{target_project}"
 
         res = self.app.post(url, data={"name":name1, "url":url1})
-        assert res.status_code == 403, res.status_code
-        res = self.app.delete(f"{url}/bookmark_name")
-        assert res.status_code == 403, res.status_code
+        assert res.status_code == 404, res.status_code
+        res = self.app.delete(url, data={"name":name1})
+        assert res.status_code == 404, res.status_code
 
 
 class TestWebQuizModeUpdate(web.Helper):

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -10817,11 +10817,9 @@ class TestWebUserMetadataUpdate(web.Helper):
         url = f"/account/somefakeuser/taskbrowse_bookmarks/{target_project}"
 
         res = self.app.post(url, data={"name":name1, "url":url1})
-        assert res.status_code == 404, res.status_code
+        assert res.status_code == 403, res.status_code
         res = self.app.delete(f"{url}/bookmark_name")
-        assert res.status_code == 404, res.status_code
-
-
+        assert res.status_code == 403, res.status_code
 
 
 class TestWebQuizModeUpdate(web.Helper):


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-5743](https://jira.prod.bloomberg.com/browse/RDISCROWD-5743)*

**Describe your changes**
Add new API methods:

1. `GET /<user_name>/taskbrowse_bookmarks/<short_name>`: get a list of the user's bookmarks for the specified user and project.
Response JSON: 
`{ name1: url1, name2: url2...}`

2. `POST /<user_name>/taskbrowse_bookmarks/<short_name>`: add a new bookmark for the specified user and project.
Request JSON:
`{name: <new bookmark name>, url: <new bookmark url>}`
Response JSON: new list of bookmarks
`{ name1: url1, name2: url2...}`

3. `DELETE /<user_name>/taskbrowse_bookmarks/<short_name>`: delete the specified bookmark by name
Request JSON:
`{name: <bookmark to delete>}`
Response JSON: new list of bookmarks
`{ name1: url1, name2: url2...}`

Bookmarks are stored in user data (in postgres db) in the following format:
```
user.info = { 
             metadata...,
             taskbrowse_bookmarks : {
	                            project_name : {
			                         bookmark_name : url,
                                                 bookmark_name : url,
                                                 bookmark_name : url
                                                 ....
		                    },
	                            project_name : {
			                         bookmark_name : url,
                                                 bookmark_name : url,
                                                 bookmark_name : url
                                                 ....
		                    }
                                    ...
                  }
}
```
**Testing performed**
Tested locally

