### PR TITLE
RDISCROWD-5704 Completed col in workers task browse

### DIFF
--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1668,7 +1668,7 @@ def tasks_browse(short_name, page=1, records_per_page=None):
 
             # show columns that are permitted for regular users
             if regular_user:
-                dict_args["display_columns"] = ["task_id", "priority", "created"]
+                dict_args["display_columns"] = ["task_id", "priority", "finish_time", "created"]
                 # show task.info columns that are configured under tasklist_columns
                 dict_args["display_info_columns"] = project.info.get('tasklist_columns', [])
                 # restrict filter columns to the columns configured under project settings

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -9481,14 +9481,16 @@ class TestWeb(web.Helper):
         res = self.app.get(url, follow_redirects=True)
         assert res.status_code == 200, res.status_code
         dom = BeautifulSoup(res.data)
-        # confirm that only "Tash #, Priority and Created are listed"
+        # confirm that only "Tash #, Priority, Created, and Completed are listed"
         th_tags = dom.findAll("th", {"class": "sortable"})
-        expected_columns = ["Task #", "Priority", "Created"]
+        expected_columns = ["Task #", "Priority", "Created", "Completed"]
+        print(th_tags)
         assert len(th_tags) == len(expected_columns), th_tags
-        th_tag_1, th_tag_2, th_tag_3 = th_tags[0].text.strip(), th_tags[1].text.strip(), th_tags[2].text.strip()
+        th_tag_1, th_tag_2, th_tag_3, th_tag_4 = th_tags[0].text.strip(), th_tags[1].text.strip(), th_tags[2].text.strip(), th_tags[3].text.strip()
         assert th_tag_1 == expected_columns[0], f"found column {th_tag_1}, expected column {expected_columns[0]} not present"
         assert th_tag_2 == expected_columns[1], f"found column {th_tag_3}, expected column {expected_columns[1]} not present"
         assert th_tag_3 == expected_columns[2], f"found column {th_tag_3}, expected column {expected_columns[2]} not present"
+        assert th_tag_4 == expected_columns[3], f"found column {th_tag_4}, expected column {expected_columns[3]} not present"
 
     @with_context
     def test_projects_account(self):


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-5704](https://jira.prod.bloomberg.com/browse/RDISCROWD-5704)*

**Describe your changes**
Adds a completed column for workers on the task browse screen.
![image](https://user-images.githubusercontent.com/17805819/229174679-c22b2344-fdbf-45ed-b86b-b44015ddf940.png)

**Testing performed**
Tested locally.

