### PR TITLE
RDISCROWD-5852 Calc task expiration by create date

### DIFF
--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -80,7 +80,7 @@ class TaskAPI(APIBase):
                                 new.id, old.state, new.state,
                                 str(old.exported), str(new.exported))
         if new.expiration is not None:
-            new.expiration = get_task_expiration(new.expiration)
+            new.expiration = get_task_expiration(new.expiration, old.created)
 
     def _preprocess_post_data(self, data):
         project_id = data["project_id"]

--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -44,6 +44,7 @@ from pybossa.cache.task_browse_helpers import get_searchable_columns
 import json
 import copy
 from pybossa.task_creator_helper import get_task_expiration
+from pybossa.model import make_timestamp
 
 
 class TaskAPI(APIBase):
@@ -116,7 +117,8 @@ class TaskAPI(APIBase):
                     data['exported'] = True
             except Exception as e:
                 raise BadRequest('Invalid gold_answers')
-        data["expiration"] = get_task_expiration(data.get('expiration'))
+        create_time = data.get("created") or make_timestamp()
+        data["expiration"] = get_task_expiration(data.get('expiration'), create_time)
 
     def _verify_auth(self, item):
         if not current_user.is_authenticated:

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -40,6 +40,7 @@ import hashlib
 from flask import url_for
 from pybossa.task_creator_helper import set_gold_answers, upload_files_priv, get_task_expiration
 from pybossa.data_access import data_access_levels
+from pybossa.model import make_timestamp
 
 
 def validate_s3_bucket(task, *args):
@@ -207,7 +208,9 @@ class Importer(object):
         try:
             for task_data in tasks:
                 self.upload_private_data(task_data, project.id)
-                task_data['expiration'] = get_task_expiration(task_data.get('expiration'))
+                # As tasks are getting created, pass current date as create_date
+                create_date = make_timestamp()
+                task_data['expiration'] = get_task_expiration(task_data.get('expiration'), create_date)
 
                 task = Task(project_id=project.id, n_answers=n_answers)
                 [setattr(task, k, v) for k, v in task_data.items()]

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -29,8 +29,7 @@ from .iiif import BulkTaskIIIFImporter
 from .s3 import BulkTaskS3Import
 from .base import BulkImportException
 from .usercsv import BulkUserCSVImport
-from pybossa.util import (check_password_strength, valid_or_no_s3_bucket,
-    get_now_plus_delta_ts)
+from pybossa.util import (check_password_strength, valid_or_no_s3_bucket)
 from flask_login import current_user
 from werkzeug.datastructures import MultiDict
 import copy

--- a/pybossa/repositories/task_repository.py
+++ b/pybossa/repositories/task_repository.py
@@ -34,6 +34,7 @@ from datetime import datetime, timedelta
 from flask import current_app
 from sqlalchemy import or_
 from sqlalchemy.sql import case as sqlalchemy_case
+from pybossa.task_creator_helper import get_task_expiration
 
 
 class TaskRepository(Repository):
@@ -179,6 +180,9 @@ class TaskRepository(Repository):
     def save(self, element, clean_project=True):
         self._validate_can_be(self.SAVE_ACTION, element)
         try:
+            # set task default expiration
+            if element.__class__.__name__ == "Task":
+                element.expiration = get_task_expiration(element.expiration, make_timestamp())
             self.db.session.add(element)
             self.db.session.commit()
             if clean_project:

--- a/pybossa/task_creator_helper.py
+++ b/pybossa/task_creator_helper.py
@@ -18,8 +18,9 @@
 """Module with PyBossa create task helper."""
 from flask import current_app
 import hashlib
+import datetime
 from pybossa.cloud_store_api.s3 import upload_json_data, get_content_from_s3
-from pybossa.util import get_now_plus_delta_ts, get_time_plus_delta_ts
+from pybossa.util import get_time_plus_delta_ts
 from flask import url_for
 import json
 from six import string_types
@@ -53,7 +54,7 @@ def get_task_expiration(current_expiration, create_time=None):
 
 def _get_task_expiration(current_expiration, create_time, validity):
     if create_time is None:
-        task_exp = get_now_plus_delta_ts(days=validity)
+        task_exp = get_time_plus_delta_ts(datetime.utcnow(), days=validity)
     else:
         task_exp = get_time_plus_delta_ts(create_time, days=validity)
     if isinstance(current_expiration, string_types):

--- a/pybossa/task_creator_helper.py
+++ b/pybossa/task_creator_helper.py
@@ -64,7 +64,6 @@ def set_gold_answers(task, gold_answers):
     if encrypted():
         url = upload_files_priv(task, task.project_id, gold_answers, TASK_PRIVATE_GOLD_ANSWER_FILE_NAME)['externalUrl']
         gold_answers = dict([(TASK_GOLD_ANSWER_URL_KEY, url)])
-        task.expiration = get_task_expiration(task.expiration)
 
     task.gold_answers = gold_answers
     task.calibration = 1

--- a/pybossa/task_creator_helper.py
+++ b/pybossa/task_creator_helper.py
@@ -44,8 +44,7 @@ def s3_conn_type():
 def get_task_expiration(current_expiration, create_time=None):
     """
     Find the appropriate expiration to be added to a task with expiring data.
-    If no expiration is set, return the data expiration; otherwise, return
-    the smallest between the current expiration and the data expiration.
+    If current_expiration is outside the valid range, return the maximum possible expiration.
     current_expiration can be a iso datetime string or a datetime object
     """
     validity = current_app.config.get('TASK_EXPIRATION', 60)

--- a/pybossa/task_creator_helper.py
+++ b/pybossa/task_creator_helper.py
@@ -51,11 +51,11 @@ def get_task_expiration(expiration, create_time):
     max_expiration_days = current_app.config.get('TASK_EXPIRATION', 60)
     max_expiration = get_time_plus_delta_ts(create_time, days=max_expiration_days)
 
-    if not expiration and isinstance(expiration, string_types):
-        expiration = expiration.fromisoformat()
+    if expiration and isinstance(expiration, string_types):
+        max_expiration = max_expiration.isoformat()
+
     expiration = expiration or max_expiration
-    expiration = min(expiration, max_expiration)
-    return expiration.isoformat()
+    return min(expiration, max_expiration)
 
 
 def set_gold_answers(task, gold_answers):

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -56,6 +56,8 @@ from pybossa.cloud_store_api.s3 import s3_upload_file_storage
 
 from bs4 import BeautifulSoup
 
+from six import string_types
+
 misaka = Misaka()
 TP_COMPONENT_TAGS = ["text-input", "dropdown-input", "radio-group-input",
                      "checkbox-input", "multi-select-input", "input-text-area"]
@@ -1111,6 +1113,10 @@ def sign_task(task):
 def get_now_plus_delta_ts(**kwargs):
     return (datetime.utcnow() + timedelta(**kwargs))
 
+def get_time_plus_delta_ts(time, **kwargs):
+    if isinstance(time, string_types):
+        time = datetime.fromisoformat(time)
+    return (time + timedelta(**kwargs))
 
 def get_taskrun_date_range_sql_clause_params(start_date, end_date):
     """Generate date cause and sql params for queriying db."""

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -56,8 +56,6 @@ from pybossa.cloud_store_api.s3 import s3_upload_file_storage
 
 from bs4 import BeautifulSoup
 
-from six import string_types
-
 misaka = Misaka()
 TP_COMPONENT_TAGS = ["text-input", "dropdown-input", "radio-group-input",
                      "checkbox-input", "multi-select-input", "input-text-area"]
@@ -1111,7 +1109,7 @@ def sign_task(task):
 
 
 def get_time_plus_delta_ts(time, **kwargs):
-    if isinstance(time, string_types):
+    if isinstance(time, str):
         time = datetime.fromisoformat(time)
     return (time + timedelta(**kwargs))
 

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -1110,9 +1110,6 @@ def sign_task(task):
         task['signature'] = signature
 
 
-def get_now_plus_delta_ts(**kwargs):
-    return (datetime.utcnow() + timedelta(**kwargs))
-
 def get_time_plus_delta_ts(time, **kwargs):
     if isinstance(time, string_types):
         time = datetime.fromisoformat(time)

--- a/test/test_api/test_task_api.py
+++ b/test/test_api/test_task_api.py
@@ -770,8 +770,13 @@ class TestTaskAPI(TestAPI):
     def test_task_put_with_expiration_within_bound(self):
         admin = UserFactory.create()
         project = ProjectFactory.create(owner=admin)
-        task = TaskFactory.create(project=project, info=dict(x=1))
-        expiration = (datetime.datetime.utcnow() +  datetime.timedelta(30)).isoformat()
+        task = TaskFactory.create(
+            project=project,
+            info=dict(x=1),
+            created='2015-01-01T14:37:30.642119'
+        )
+        # 40 days after creation date
+        expiration = '2015-02-10T14:37:30.642119'
         datajson = json.dumps({'expiration': expiration})
 
         url = '/api/task/%s?api_key=%s' % (task.id, admin.api_key)
@@ -788,9 +793,15 @@ class TestTaskAPI(TestAPI):
     def test_task_put_with_expiration_out_of_bounds(self):
         admin = UserFactory.create()
         project = ProjectFactory.create(owner=admin)
-        task = TaskFactory.create(project=project, info=dict(x=1))
-        expiration = (datetime.datetime.utcnow() +  datetime.timedelta(1000)).isoformat()
-        max_expiration = (datetime.datetime.utcnow() +  datetime.timedelta(60)).isoformat()
+        task = TaskFactory.create(
+            project=project,
+            info=dict(x=1),
+            created='2015-01-01T14:37:30.642119'
+        )
+        # the task expires 60 days after creation date
+        max_expiration = '2015-03-02T14:37:30.642119'
+        # 365 days after creation date
+        expiration = '2016-01-01T14:37:30.642119'
         datajson = json.dumps({'expiration': expiration})
 
         url = '/api/task/%s?api_key=%s' % (task.id, admin.api_key)

--- a/test/test_task_creator_helpers.py
+++ b/test/test_task_creator_helpers.py
@@ -27,6 +27,12 @@ class TestGetTaskExpirationDatetime(object):
         exp = _get_task_expiration(current_exp, None, 60)
         assert are_almost_equal(exp, now + timedelta(days=60))
 
+    def test_create_date_is_set(self):
+        now = datetime.utcnow()
+        current_exp = now + timedelta(days=90)
+        exp = _get_task_expiration(current_exp, now, 60)
+        assert are_almost_equal(exp, now + timedelta(days=60))
+
     def test_current_expiration_is_none(self):
         now = datetime.utcnow()
         exp = _get_task_expiration(None, None, 60)
@@ -47,3 +53,9 @@ class TestGetTaskExpirationString(object):
         exp = _get_task_expiration(current_exp.isoformat(), None, 60)
         assert are_almost_equal(
             to_datetime(exp), now + timedelta(days=60))
+
+    def test_create_date_is_set(self):
+        now = datetime.utcnow()
+        current_exp = now + timedelta(days=30)
+        exp = _get_task_expiration(current_exp.isoformat(), now, 60)
+        assert to_datetime(exp) == current_exp

--- a/test/test_task_creator_helpers.py
+++ b/test/test_task_creator_helpers.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
-from pybossa.task_creator_helper import _get_task_expiration
+from pybossa.task_creator_helper import get_task_expiration
+from test import with_context
 
 
 def are_almost_equal(date1, date2):
@@ -15,47 +16,54 @@ def to_datetime(timestamp):
 
 class TestGetTaskExpirationDatetime(object):
 
+    @with_context
     def test_current_expiration_is_before(self):
         now = datetime.utcnow()
         current_exp = now + timedelta(days=30)
-        exp = _get_task_expiration(current_exp, None, 60)
+        exp = get_task_expiration(current_exp, now)
         assert exp == current_exp
 
+    @with_context
     def test_current_expiration_is_after(self):
         now = datetime.utcnow()
         current_exp = now + timedelta(days=90)
-        exp = _get_task_expiration(current_exp, None, 60)
+        exp = get_task_expiration(current_exp, now)
         assert are_almost_equal(exp, now + timedelta(days=60))
 
+    @with_context
     def test_create_date_is_set(self):
         now = datetime.utcnow()
         current_exp = now + timedelta(days=90)
-        exp = _get_task_expiration(current_exp, now, 60)
+        exp = get_task_expiration(current_exp, now)
         assert are_almost_equal(exp, now + timedelta(days=60))
 
+    @with_context
     def test_current_expiration_is_none(self):
         now = datetime.utcnow()
-        exp = _get_task_expiration(None, None, 60)
+        exp = get_task_expiration(None, now)
         assert are_almost_equal(exp, now + timedelta(days=60))
 
 
 class TestGetTaskExpirationString(object):
 
+    @with_context
     def test_current_expiration_is_before(self):
         now = datetime.utcnow()
         current_exp = now + timedelta(days=30)
-        exp = _get_task_expiration(current_exp.isoformat(), None, 60)
+        exp = get_task_expiration(current_exp.isoformat(), now)
         assert to_datetime(exp) == current_exp
 
+    @with_context
     def test_current_expiration_is_after(self):
         now = datetime.utcnow()
         current_exp = now + timedelta(days=90)
-        exp = _get_task_expiration(current_exp.isoformat(), None, 60)
+        exp = get_task_expiration(current_exp.isoformat(), now)
         assert are_almost_equal(
             to_datetime(exp), now + timedelta(days=60))
 
+    @with_context
     def test_create_date_is_set(self):
         now = datetime.utcnow()
         current_exp = now + timedelta(days=30)
-        exp = _get_task_expiration(current_exp.isoformat(), now, 60)
+        exp = get_task_expiration(current_exp.isoformat(), now)
         assert to_datetime(exp) == current_exp

--- a/test/test_task_creator_helpers.py
+++ b/test/test_task_creator_helpers.py
@@ -18,18 +18,18 @@ class TestGetTaskExpirationDatetime(object):
     def test_current_expiration_is_before(self):
         now = datetime.utcnow()
         current_exp = now + timedelta(days=30)
-        exp = _get_task_expiration(current_exp, 60)
+        exp = _get_task_expiration(current_exp, None, 60)
         assert exp == current_exp
 
     def test_current_expiration_is_after(self):
         now = datetime.utcnow()
         current_exp = now + timedelta(days=90)
-        exp = _get_task_expiration(current_exp, 60)
+        exp = _get_task_expiration(current_exp, None, 60)
         assert are_almost_equal(exp, now + timedelta(days=60))
 
     def test_current_expiration_is_none(self):
         now = datetime.utcnow()
-        exp = _get_task_expiration(None, 60)
+        exp = _get_task_expiration(None, None, 60)
         assert are_almost_equal(exp, now + timedelta(days=60))
 
 
@@ -38,12 +38,12 @@ class TestGetTaskExpirationString(object):
     def test_current_expiration_is_before(self):
         now = datetime.utcnow()
         current_exp = now + timedelta(days=30)
-        exp = _get_task_expiration(current_exp.isoformat(), 60)
+        exp = _get_task_expiration(current_exp.isoformat(), None, 60)
         assert to_datetime(exp) == current_exp
 
     def test_current_expiration_is_after(self):
         now = datetime.utcnow()
         current_exp = now + timedelta(days=90)
-        exp = _get_task_expiration(current_exp.isoformat(), 60)
+        exp = _get_task_expiration(current_exp.isoformat(), None, 60)
         assert are_almost_equal(
             to_datetime(exp), now + timedelta(days=60))


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-5852](https://jira.prod.bloomberg.com/browse/RDISCROWD-5852)*

### Describe your changes
**Previously**
In https://github.com/bloomberg/pybossa/pull/830, we limited the task expiration based on the current date. The task expiration limit was _n_ days from the current day. This allowed for the user to indefinitely extend their tasks' expirations, which we don't want.
**Now**
Task expiration limit is now _n_ days from the create date of the task, putting a hard cap on task expiration.

**Testing performed**
Tested locally

**Additional context**
https://github.com/bloomberg/pybossa/pull/830
