### PR TITLE
Rdiscrowd 5851 taskbrowse bookmarks dates

### DIFF
--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -58,6 +58,7 @@ from pybossa.jobs import send_mail, export_userdata, delete_account
 from pybossa.core import user_repo, ldap
 from pybossa.feed import get_update_feed
 from pybossa.messages import *
+from pybossa.model import make_timestamp
 
 from pybossa.forms.forms import UserPrefMetadataForm, RegisterFormWithUserPrefMetadata
 from pybossa.forms.account_view_forms import *
@@ -1155,11 +1156,6 @@ def add_metadata(name):
     return redirect(url_for('account.profile', name=name))
 
 
-def make_timestamp():
-    now = datetime.now()
-    return now.isoformat()
-
-
 def _get_bookmarks(user_name, short_name):
     taskbrowse_bookmarks = cached_users.get_taskbrowse_bookmarks(user_name)
     proj_bookmarks = taskbrowse_bookmarks.get(short_name, {})
@@ -1180,14 +1176,14 @@ def _add_bookmark(user_name, short_name, bookmark_name, bookmark_url):
     if old_bookmark is not None:
         created_date = old_bookmark['created']
     else:
-        created_date = make_timestamp()
-    updated_date = make_timestamp()
-    bookmark_payload = {
+        created_date = model.make_timestamp()
+    updated_date = model.make_timestamp()
+    bookmark_data = {
         'url': bookmark_url,
         'created': created_date,
         'updated': updated_date
     }
-    proj_bookmarks[bookmark_name] =  bookmark_payload
+    proj_bookmarks[bookmark_name] =  bookmark_data
     taskbrowse_bookmarks[short_name] = proj_bookmarks
     user.info['taskbrowse_bookmarks'] = taskbrowse_bookmarks
 

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -1199,7 +1199,6 @@ def _add_bookmark(user_name, short_name, bookmark_name, bookmark_url):
 def _delete_bookmark(user_name, short_name, bookmark_name):
     user = user_repo.get_by_name(name=user_name)
     taskbrowse_bookmarks = user.info.get('taskbrowse_bookmarks', {})
-    print(taskbrowse_bookmarks)
     proj_bookmarks = taskbrowse_bookmarks.get(short_name, {})
 
     if bookmark_name not in proj_bookmarks:

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -49,7 +49,6 @@ from pybossa.model.auditlog import Auditlog
 from pybossa.model.project_stats import ProjectStats
 from pybossa.model.webhook import Webhook
 from pybossa.model.blogpost import Blogpost
-from pybossa.view.account import _get_bookmarks
 from pybossa.util import (Pagination, admin_required, get_user_id_or_ip, rank,
                           handle_content_type, redirect_content_type,
                           get_avatar_url, admin_or_subadmin_required,
@@ -1788,8 +1787,6 @@ def tasks_browse(short_name, page=1, records_per_page=None):
         location_options = valid_user_preferences.get('locations')
         rdancy_upd_exp = current_app.config.get('TASK_EXPIRATION', 60)
 
-        taskbrowse_bookmarks = _get_bookmarks(current_user.name, project['short_name'])
-
         data = dict(template='/projects/tasks_browse.html',
                     users=[],
                     project=project_sanitized,
@@ -1815,7 +1812,6 @@ def tasks_browse(short_name, page=1, records_per_page=None):
                     can_know_task_is_gold=can_know_task_is_gold,
                     allow_taskrun_edit=allow_taskrun_edit,
                     regular_user=regular_user,
-                    taskbrowse_bookmarks=taskbrowse_bookmarks,
                     admin_subadmin_coowner=admin_subadmin_coowner)
 
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -10721,8 +10721,8 @@ class TestWebUserMetadataUpdate(web.Helper):
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
         assert data[name1]['url'] == url1
-        assert 'created' in data
-        assert 'updated' in data
+        assert 'created' in data[name1]
+        assert 'updated' in data[name1]
 
         # test if new url is appended correctly
         res = self.app.post(url, json={"name":name2, "url":url2})

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -10657,13 +10657,13 @@ class TestWebUserMetadataUpdate(web.Helper):
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
 
-        assert data['bookmark 1']['url'] == bookmark_1_data['url']
-        assert data['bookmark 1']['created'] == bookmark_1_data['created']
-        assert data['bookmark 1']['updated'] == bookmark_1_data['updated']
+        assert data[0]['url'] == bookmark_1_data['url']
+        assert data[0]['created'] == bookmark_1_data['created']
+        assert data[0]['updated'] == bookmark_1_data['updated']
 
-        assert data['bookmark 2']['url'] == bookmark_2_data['url']
-        assert data['bookmark 2']['created'] == bookmark_2_data['created']
-        assert data['bookmark 2']['updated'] == bookmark_2_data['updated']
+        assert data[1]['url'] == bookmark_2_data['url']
+        assert data[1]['created'] == bookmark_2_data['created']
+        assert data[1]['updated'] == bookmark_2_data['updated']
 
 
     @with_context
@@ -10679,7 +10679,7 @@ class TestWebUserMetadataUpdate(web.Helper):
 
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert str(data) == str({})
+        assert len(data) == 0
 
 
     @with_context
@@ -10698,7 +10698,7 @@ class TestWebUserMetadataUpdate(web.Helper):
 
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert str(data) == str({})
+        assert len(data) == 0
 
 
     @with_context
@@ -10720,37 +10720,37 @@ class TestWebUserMetadataUpdate(web.Helper):
         res = self.app.post(url, json={"name":name1, "url":url1})
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert data[name1]['url'] == url1
-        assert 'created' in data[name1]
-        assert 'updated' in data[name1]
+        assert data[0]['url'] == url1
+        assert 'created' in data[0]
+        assert 'updated' in data[0]
 
-        # test if new url is appended correctly
+        # test second insertion
         res = self.app.post(url, json={"name":name2, "url":url2})
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert data[name1]['url'] == url1
-        assert data[name2]['url'] == url2
+        assert data[0]['url'] == url1
+        assert data[1]['url'] == url2
 
         # test if data is saved in db
         res = self.app.get(url)
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert data[name1]['url'] == url1
-        assert data[name2]['url'] == url2
+        assert data[0]['url'] == url1
+        assert data[1]['url'] == url2
 
         # test adding bookmark for a different project
         new_url = f"/account/{user.name}/taskbrowse_bookmarks/project2"
         res = self.app.post(new_url, json={"name":name2, "url":url1})
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert data[name2]['url'] == url1
+        assert data[0]['url'] == url1
 
         # test new post does not affect old data
         res = self.app.get(url)
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert data[name1]['url'] == url1
-        assert data[name2]['url'] == url2
+        assert data[0]['url'] == url1
+        assert data[1]['url'] == url2
 
     @with_context
     def test_update_taskbrowse_bookmark(self):
@@ -10769,9 +10769,9 @@ class TestWebUserMetadataUpdate(web.Helper):
         res = self.app.post(url, json={"name":"bookmark 1", "url":"www.google.com"})
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert data["bookmark 1"]["updated"] != bookmark_1_data["updated"]
-        assert data["bookmark 1"]["created"] == bookmark_1_data["created"]
-        assert data["bookmark 1"]["url"] == "www.google.com"
+        assert data[0]["updated"] != bookmark_1_data["updated"]
+        assert data[0]["created"] == bookmark_1_data["created"]
+        assert data[0]["url"] == "www.google.com"
 
 
     @with_context
@@ -10815,10 +10815,11 @@ class TestWebUserMetadataUpdate(web.Helper):
         expected_res = {"bookmark 2" : "https://gigwork.net/project/testproject66/tasks/browse"}
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
+        print(data)
         assert len(data) == 1
-        assert data['bookmark 2']['url'] == bookmark_2_data['url']
-        assert data['bookmark 2']['created'] == bookmark_2_data['created']
-        assert data['bookmark 2']['updated'] == bookmark_2_data['updated']
+        assert data[0]['url'] == bookmark_2_data['url']
+        assert data[0]['created'] == bookmark_2_data['created']
+        assert data[0]['updated'] == bookmark_2_data['updated']
 
         # ensure deleting last bookmark does not result in error
         url = f"/account/{user.name}/taskbrowse_bookmarks/{target_project}"

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -10753,6 +10753,28 @@ class TestWebUserMetadataUpdate(web.Helper):
         assert data[name2]['url'] == url2
 
     @with_context
+    def test_update_taskbrowse_bookmark(self):
+        """Test update taskbrowse_bookmark via POST works"""
+        data = self.original
+        target_project = "project1"
+        bookmark_1_data, _, _, bookmarks = self.generate_sample_bookmarks(target_project)
+        info = {
+                'taskbrowse_bookmarks' : bookmarks
+        }
+        user = UserFactory.create(info=info)
+        self.signin_user(user)
+        url = f"/account/{user.name}/taskbrowse_bookmarks/{target_project}"
+
+        # update a bookmark that already exists
+        res = self.app.post(url, json={"name":"bookmark 1", "url":"www.google.com"})
+        assert res.status_code == 200, res.status_code
+        data = json.loads(res.data)
+        assert data["bookmark 1"]["updated"] != bookmark_1_data["updated"]
+        assert data["bookmark 1"]["created"] == bookmark_1_data["created"]
+        assert data["bookmark 1"]["url"] == "www.google.com"
+
+
+    @with_context
     def test_post_taskbrowse_bookmarks_missing_arguments(self):
         """Test error not thrown when POST endpoint is called with bad message body"""
         data = self.original

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -10612,25 +10612,43 @@ class TestWebUserMetadataUpdate(web.Helper):
         resp = self.app_get_json(url)
         assert resp.status_code == 401, resp
 
+    def generate_sample_bookmarks(self, target_project="project1"):
+        bookmark_1_data = {
+                    "created": "2019-01-01T14:37:30.642119",
+                    "updated": "2019-01-01T14:37:30.642119",
+                    "url": "https://gigwork.net/project/testproject66/tasks/browse/1/10?changed=true&display_columns=%5B%22task_id%22%2C%22priority%22%2C%22pcomplete%22%2C%22created%22%2C%22finish_time%22%2C%22gold_task%22%2C%22actions%22%2C%22lock_status%22%5D&order_by=task_id+asc&pcomplete_from=46&pcomplete_to=100&priority_from=0.45&priority_to=1.00&display_info_columns=%5B%5D"
+                }
+        bookmark_2_data = {
+                    "created": "2019-01-01T14:37:30.642119",
+                    "updated": "2023-01-01T14:37:30.642119",
+                    "url": "https://gigwork.net/project/testproject66/tasks/browse"
+                }
+        bookmark_3_data = {
+                    "created": "2022-01-01T14:37:30.642119",
+                    "updated": "2022-01-01T14:37:30.642119",
+                    "url": "https://gigwork.net/project/project2/tasks/browse"
+                }
+        bookmarks = {
+            target_project : {
+                "bookmark 1" : bookmark_1_data,
+                "bookmark 2" : bookmark_2_data
+            },
+            "project2" : {
+                "bookmark 3" : bookmark_3_data
+            }
+        }
+        return (bookmark_1_data, bookmark_2_data, bookmark_3_data, bookmarks)
+
 
     @with_context
     def test_get_taskbrowse_bookmarks(self):
         """Test get taskbrowse_bookmark works"""
         data = self.original
         target_project = "project1"
-        bookmarks = {
-                    target_project : {
-                                "bookmark 1" : "https://gigwork.net/project/testproject66/tasks/browse/1/10?changed=true&display_columns=%5B%22task_id%22%2C%22priority%22%2C%22pcomplete%22%2C%22created%22%2C%22finish_time%22%2C%22gold_task%22%2C%22actions%22%2C%22lock_status%22%5D&order_by=task_id+asc&pcomplete_from=46&pcomplete_to=100&priority_from=0.45&priority_to=1.00&display_info_columns=%5B%5D",
-                                "bookmark 2" : "https://gigwork.net/project/testproject66/tasks/browse"
-                                },
-                    "project2" : {
-                        "bookmark 3" : "https://gigwork.net/project/project2/tasks/browse"
-                    }
-
-        }
+        bookmark_1_data, bookmark_2_data, bookmark_3_data, bookmarks = self.generate_sample_bookmarks(target_project)
         info = {
                 'taskbrowse_bookmarks' : bookmarks
-            }
+        }
         user = UserFactory.create(info=info)
         self.signin_user(user)
         url = f"/account/{user.name}/taskbrowse_bookmarks/{target_project}"
@@ -10638,7 +10656,14 @@ class TestWebUserMetadataUpdate(web.Helper):
 
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert str(data) == str(bookmarks[target_project])
+
+        assert data['bookmark 1']['url'] == bookmark_1_data['url']
+        assert data['bookmark 1']['created'] == bookmark_1_data['created']
+        assert data['bookmark 1']['updated'] == bookmark_1_data['updated']
+
+        assert data['bookmark 2']['url'] == bookmark_2_data['url']
+        assert data['bookmark 2']['created'] == bookmark_2_data['created']
+        assert data['bookmark 2']['updated'] == bookmark_2_data['updated']
 
 
     @with_context
@@ -10661,17 +10686,8 @@ class TestWebUserMetadataUpdate(web.Helper):
     def test_get_taskbrowse_bookmarks_no_saved_bookmarks_for_project(self):
         """Test get taskbrowse_bookmark works when no saved bookmarks for project"""
         data = self.original
-        target_project = "project1"
-        bookmarks = {
-                    "project600" : {
-                                "bookmark 1" : "https://gigwork.net/project/testproject66/tasks/browse/1/10?changed=true&display_columns=%5B%22task_id%22%2C%22priority%22%2C%22pcomplete%22%2C%22created%22%2C%22finish_time%22%2C%22gold_task%22%2C%22actions%22%2C%22lock_status%22%5D&order_by=task_id+asc&pcomplete_from=46&pcomplete_to=100&priority_from=0.45&priority_to=1.00&display_info_columns=%5B%5D",
-                                "bookmark 2" : "https://gigwork.net/project/testproject66/tasks/browse"
-                                },
-                    "project2" : {
-                        "bookmark 3" : "https://gigwork.net/project/project2/tasks/browse"
-                    }
-
-        }
+        target_project = "project_with_no_bookmarks"
+        _, _, _, bookmarks = self.generate_sample_bookmarks()
         info = {
                 'taskbrowse_bookmarks' : bookmarks
             }
@@ -10692,9 +10708,9 @@ class TestWebUserMetadataUpdate(web.Helper):
         target_project = "project1"
 
         url1 = "https://gigwork.net/project/testproject66/tasks/browse"
-        url2 = "https://gigwork.net/project/testproject66/tasks/browse/1/10?changed=true&display_columns=%5B%22task_id%22%2C%22priority%22%2C%22pcomplete%22%2C%22created%22%2C%22finish_time%22%2C%22gold_task%22%2C%22actions%22%2C%22lock_status%22%5D&order_by=task_id+asc&pcomplete_from=46&pcomplete_to=100&priority_from=0.45&priority_to=1.00&display_info_columns=%5B%5D"
-        name1 = "bookmark1"
-        name2 = "bookmark2"
+        url2 = "https://gigwork.net/project/testproject66/tasks/browse/1/10?changed=true&display_columns=%5B%22task_id%22%2C%22priority%22%2C%22pcomplete%22%2C%22created%22%2C%22finish_time&order_by=task_id"
+        name1 = "bookmark 1"
+        name2 = "bookmark 2"
 
         user = UserFactory.create()
         self.signin_user(user)
@@ -10704,32 +10720,37 @@ class TestWebUserMetadataUpdate(web.Helper):
         res = self.app.post(url, json={"name":name1, "url":url1})
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert str(data) == str({name1:url1})
+        assert data[name1]['url'] == url1
+        assert 'created' in data
+        assert 'updated' in data
 
         # test if new url is appended correctly
         res = self.app.post(url, json={"name":name2, "url":url2})
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert str(data) == str({name1:url1, name2:url2})
+        assert data[name1]['url'] == url1
+        assert data[name2]['url'] == url2
 
         # test if data is saved in db
         res = self.app.get(url)
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert str(data) == str({name1:url1, name2:url2})
+        assert data[name1]['url'] == url1
+        assert data[name2]['url'] == url2
 
         # test adding bookmark for a different project
         new_url = f"/account/{user.name}/taskbrowse_bookmarks/project2"
-        res = self.app.post(new_url, json={"name":name2, "url":url2})
+        res = self.app.post(new_url, json={"name":name2, "url":url1})
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert str(data) == str({name2:url2})
+        assert data[name2]['url'] == url1
 
         # test new post does not affect old data
         res = self.app.get(url)
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert str(data) == str({name1:url1, name2:url2})
+        assert data[name1]['url'] == url1
+        assert data[name2]['url'] == url2
 
     @with_context
     def test_post_taskbrowse_bookmarks_missing_arguments(self):
@@ -10758,16 +10779,7 @@ class TestWebUserMetadataUpdate(web.Helper):
         """Test deleting taskbrowse bookmarks"""
         data = self.original
         target_project = "project1"
-        bookmarks = {
-                    target_project : {
-                        "bookmark1" : "https://gigwork.net/project/testproject66/tasks/browse/1/10?changed=true&display_columns=%5B%22task_id%22%2C%22priority%22%2C%22pcomplete%22%2C%22created%22%2C%22finish_time%22%2C%22gold_task%22%2C%22actions%22%2C%22lock_status%22%5D&order_by=task_id+asc&pcomplete_from=46&pcomplete_to=100&priority_from=0.45&priority_to=1.00&display_info_columns=%5B%5D",
-                        "bookmark2" : "https://gigwork.net/project/testproject66/tasks/browse"
-                                },
-                    "project2" : {
-                        "bookmark3" : "https://gigwork.net/project/project2/tasks/browse"
-                    }
-
-        }
+        bookmark_1_data, bookmark_2_data ,_, bookmarks = self.generate_sample_bookmarks(target_project)
         info = {
                 'taskbrowse_bookmarks' : bookmarks
             }
@@ -10775,39 +10787,33 @@ class TestWebUserMetadataUpdate(web.Helper):
         user = UserFactory.create(info=info)
         self.signin_user(user)
         url = f"/account/{user.name}/taskbrowse_bookmarks/{target_project}"
-        data = {"name": "bookmark1"}
+        data = {"name": "bookmark 1"}
         res = self.app.delete(url, json=data)
 
-        expected_res = {"bookmark2" : "https://gigwork.net/project/testproject66/tasks/browse"}
+        expected_res = {"bookmark 2" : "https://gigwork.net/project/testproject66/tasks/browse"}
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert str(data) == str(expected_res)
+        assert len(data) == 1
+        assert data['bookmark 2']['url'] == bookmark_2_data['url']
+        assert data['bookmark 2']['created'] == bookmark_2_data['created']
+        assert data['bookmark 2']['updated'] == bookmark_2_data['updated']
 
         # ensure deleting last bookmark does not result in error
         url = f"/account/{user.name}/taskbrowse_bookmarks/{target_project}"
-        data = {"name" : "bookmark2"}
+        data = {"name" : "bookmark 2"}
         res = self.app.delete(url, json=data)
 
         expected_res = {}
         assert res.status_code == 200, res.status_code
         data = json.loads(res.data)
-        assert str(data) == str(expected_res)
+        assert len(data) == 0
 
     @with_context
-    def test_delete_taskbrowse_bookmarks_invalid_bookmark_name(self):
+    def test_delete_taskbrowse_bookmarks_bookmark_not_found(self):
         """Test calling delete taskbrowse bookmarks with an invalid bookmark name"""
         data = self.original
         target_project = "project1"
-        bookmarks = {
-                    target_project : {
-                                "bookmark1" : "https://gigwork.net/project/testproject66/tasks/browse/1/10?changed=true&display_columns=%5B%22task_id%22%2C%22priority%22%2C%22pcomplete%22%2C%22created%22%2C%22finish_time%22%2C%22gold_task%22%2C%22actions%22%2C%22lock_status%22%5D&order_by=task_id+asc&pcomplete_from=46&pcomplete_to=100&priority_from=0.45&priority_to=1.00&display_info_columns=%5B%5D",
-                                "bookmark2" : "https://gigwork.net/project/testproject66/tasks/browse"
-                                },
-                    "project2" : {
-                        "bookmark3" : "https://gigwork.net/project/project2/tasks/browse"
-                    }
-
-        }
+        _,_,_, bookmarks = self.generate_sample_bookmarks(target_project)
         info = {
                 'taskbrowse_bookmarks' : bookmarks
             }
@@ -10820,7 +10826,7 @@ class TestWebUserMetadataUpdate(web.Helper):
 
 
     @with_context
-    def test_get_taskbrowse_bookmarks_user_errors(self):
+    def test_get_taskbrowse_bookmarks_user_auth_errors(self):
         """Test retrive taskbrowse bookmarks returns errors"""
         data = self.original
         target_project = "project1"


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-5851](https://jira.prod.bloomberg.com/browse/RDISCROWD-5851)*

**Describe your changes**
Adds `created` and `updated` fields for each bookmark. New data structure in DB:
```
user.info = { 
             metadata...,
             taskbrowse_bookmarks : {
	                            project_name : {
			                         bookmark_name : {
                                                                   url: http://localhost:5000/project/proj/...
                                                                   created: 2023-04-05T17:59:28.516927
                                                                   updated: 2023-04-05T17:59:28.516927
			                         }
                                                 ....
		                    },
	                            project_name : {
			                         bookmark_name : {...,
                                                 bookmark_name : {...,
                                                 bookmark_name : {...
                                                 ....
		                    }
                                    ...
                  }
}
```

Example endpoint JSON response structure:
```
[
   {
      "created": "2023-04-26T18:17:29.745312",
      "name": "apple",
      "updated": "2023-04-26T18:17:29.745320",
      "url": "http://localhost:5000/project/testproject2/tasks/browse"
   },
{
      "created": "2023-04-06T18:17:29.745312",
      "name": "banana",
      "updated": "2023-04-06T18:17:29.745320",
      "url": "http://localhost:5000/project/testproject2/tasks/browse"
   },
]

```

**Testing performed**
Tested locally

**Additional context**
 - https://github.com/bloomberg/pybossa/pull/832