### PR TITLE
RDISCROWD-5747: Color Code the Icons in GIGwork Internet Tabs

### DIFF
--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -689,7 +689,9 @@ def setup_hooks(app):
             plugins=plugins,
             ldap_enabled=ldap_enabled,
             get_wizard_steps=get_wizard_steps,
-            server_type=app.config['SERVER_TYPE'])
+            server_type=app.config['SERVER_TYPE'],
+            favicon_dir=app.config['FAVICONS'][app.config['SERVER_TYPE']]
+        )
 
     @app.errorhandler(CSRFError)
     def csrf_error_handler(err):

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -690,7 +690,7 @@ def setup_hooks(app):
             ldap_enabled=ldap_enabled,
             get_wizard_steps=get_wizard_steps,
             server_type=app.config['SERVER_TYPE'],
-            favicon_dir=app.config['FAVICONS'][app.config['SERVER_TYPE']]
+            favicon_dir=app.config['FAVICONS']
         )
 
     @app.errorhandler(CSRFError)

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -690,7 +690,7 @@ def setup_hooks(app):
             ldap_enabled=ldap_enabled,
             get_wizard_steps=get_wizard_steps,
             server_type=app.config['SERVER_TYPE'],
-            favicon_dir=app.config['FAVICONS']
+            favicon_dir=app.config['FAVICON']
         )
 
     @app.errorhandler(CSRFError)


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-5747*

**Describe your changes**
Checks the environment and sends the appropriate favicon directory name to the submodule.

**Testing performed**
Tested locally using Development testing environment variable.

**Additional context**
Supports changes made to [pybossa-default-theme](https://github.com/bloomberg/pybossa-default-theme/pull/413)

Re: https://github.com/bloomberg/pybossa-default-theme/pull/413#event-9038843088