### PR TITLE
RDISCROWD-5998 support alternate turkey spelling

### DIFF
--- a/pybossa/cache/task_browse_helpers.py
+++ b/pybossa/cache/task_browse_helpers.py
@@ -350,6 +350,9 @@ def validate_user_preferences(user_pref):
     valid_languages = valid_user_preferences.get('languages')
     valid_locations = valid_user_preferences.get('locations')
 
+    # Support old spelling of Türkiye
+    if valid_locations:
+        valid_locations.append('Turkey')
 
     lang = user_pref.get('languages')
     loc = user_pref.get('locations')


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-5998](https://jira.prod.bloomberg.com/browse/RDISCROWD-5998)*

**Describe your changes**
Show new spelling of Türkiye in location pickers. Support both spellings on backend.

**Testing performed**
Tested locally.

