### PR TITLE
RDISCROWD-6284 Block database details from API response

### DIFF
--- a/pybossa/error/__init__.py
+++ b/pybossa/error/__init__.py
@@ -27,6 +27,7 @@ This package adds GET, POST, PUT and DELETE errors for the API:
 import json
 from flask import Response
 from flask import current_app, request
+from flask_babel import gettext
 
 
 class ErrorStatus(object):
@@ -69,6 +70,9 @@ class ErrorStatus(object):
                              'Conflict'):
             if message is None:
                 message = e.description
+        elif exception_cls in ('DataError'):
+            if message is None:
+                message = gettext('Your request was invalid. Please check your arguments.')
         else:
             if message is None:
                 message = str(e)

--- a/pybossa/messages.py
+++ b/pybossa/messages.py
@@ -34,7 +34,7 @@ from werkzeug.exceptions import Forbidden, Unauthorized, InternalServerError
 from werkzeug.exceptions import NotFound, BadRequest
 
 __all__ = ['SUCCESS', 'ERROR', 'WARNING', 'FORBIDDEN', 'NOTFOUND', 'BADREQUEST',
-           'INFO', 'NOTFOUND', 'INTERNALSERVERERROR', 'UNAUTHORIZED']
+           'INFO', 'FAILED', 'NOTFOUND', 'INTERNALSERVERERROR', 'UNAUTHORIZED']
 
 SUCCESS = "success"
 
@@ -43,6 +43,8 @@ ERROR = "error"
 WARNING = "warning"
 
 INFO = "info"
+
+FAILED = "failed"
 
 FORBIDDEN = Forbidden.description
 

--- a/test/test_api/test_api_common.py
+++ b/test/test_api/test_api_common.py
@@ -20,6 +20,7 @@ import datetime
 from test import db, with_context
 from test.test_api import TestAPI
 from pybossa.core import project_repo
+from pybossa.messages import *
 
 from test.factories import ProjectFactory, TaskFactory, TaskRunFactory, UserFactory
 
@@ -475,3 +476,16 @@ class TestApiCommon(TestAPI):
             assert "Statistics" in res.data.decode()
             assert 'id="percent-completed"' in res.data.decode()
             assert "<div>100%</div>" in res.data.decode()
+
+    @with_context
+    def test_request_with_invalid_filter_query(self):
+        """Test API response status code upon invalid request with filter query"""
+
+        user = UserFactory.create()
+        # owners_ids is missing curly braces
+        bad_url_query = '/api/project?owners_ids=9999&api_key=' + user.api_key
+        res = self.app_get_json(bad_url_query)
+        data = json.loads(res.data)
+        assert data.get('status') == FAILED
+        assert data.get('status_code') == 415
+        assert data.get('exception_msg') == 'Your request was invalid. Please check your arguments.'


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-6284*

**Describe your changes**
This fixes a bug when passing unsupported or invalid parameters to the API results in displaying database/backend details to the client.

**Testing performed**
Unit tests

**Additional context**
The underlying exception thrown for an invalid query string is:
`sqlalchemy.exc.DataError: (psycopg2.errors.InvalidTextRepresentation)`
So, instead of returning the `DataError` exception message, we print out a more general message.
