### PR TITLE
RDISCROWD-6283 - API to obtain projects for user being co-owner.

### DIFF
--- a/pybossa/api/api_base.py
+++ b/pybossa/api/api_base.py
@@ -263,7 +263,7 @@ class APIBase(MethodView):
                 if self.__class__ == Task and k == 'external_uid':
                     pass
                 else:
-                    getattr(self.__class__, k)
+                    self._has_filterable_attribute(k)
                 filters[k] = request.args[k]
 
         repo = repo_info['repo']
@@ -513,6 +513,11 @@ class APIBase(MethodView):
         specific filtering criteria.
         """
         return query
+
+    def _has_filterable_attribute(self, attribute):
+        """Method to be overridden by inheriting classes that want
+        to have custom filterable attributes"""
+        getattr(self.__class__, attribute)
 
     def _validate_instance(self, instance):
         """Method to be overriden in inheriting classes which may need to

--- a/pybossa/repositories/__init__.py
+++ b/pybossa/repositories/__init__.py
@@ -60,13 +60,17 @@ class Repository(object):
                                      **kwargs):
         clauses = [_entity_descriptor(model, key) == value
                        for key, value in kwargs.items()
-                       if (key != 'info' and key != 'fav_user_ids'
+                       if (key != 'custom_query_filters' and key != 'info' and key != 'fav_user_ids'
                             and key != 'created' and key != 'project_id'
                             and key != 'created_from' and key != 'created_to')]
+
         queries = []
         headlines = []
         order_by_ranks = []
         or_clauses = []
+
+        if 'custom_query_filters' in kwargs.keys():
+            clauses = clauses + kwargs.get('custom_query_filters')
 
         if 'info' in kwargs.keys():
             queries, headlines, order_by_ranks = self.handle_info_json(model, kwargs['info'],
@@ -232,6 +236,7 @@ class Repository(object):
             filters.pop('finish_time', None)
         to_finish_time = filters.pop('to_finish_time', None)
         query = self.create_context(filters, fulltextsearch, model)
+
         if hasattr(model, 'finish_time'):
             if from_finish_time:
                 if not to_finish_time:


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-6283*

**Describe your changes**
Add a new query parameter to support querying projects by co-owner.

**Testing performed**
Unit tests pass. Changes also verified manually on localhost.

**Additional context**
A project owner is also considered a co-owner because `Project.owners_ids` contains ids for all owners. This means it is sufficient to query `?coowner_id=123` to get all projects where the user is either owner or co-owner.
