### PR TITLE
RDISCROWD-6709 update llm call

### DIFF
--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -866,8 +866,7 @@ def large_language_model(model_name):
                 "context": "Identify the company name: Microsoft will release Windows 20 next year.",
                 "temperature": 1.0,
                 "seed": 12345,
-                "repetition_penalty": 1.05,
-                "num_beams": 1,
+                "repetition_penalty": 1.05
             }
         ]
     }
@@ -909,8 +908,7 @@ def large_language_model(model_name):
                     "context": prompts + ' ',
                     "temperature": 1.0,
                     "seed": 12345,
-                    "repetition_penalty": 1.05,
-                    "num_beams": 1,
+                    "repetition_penalty": 1.05
                 }
             ]
         }

--- a/test/test_api/__init__.py
+++ b/test/test_api/__init__.py
@@ -109,7 +109,6 @@ class TestLargeLanguageModel(unittest.TestCase):
                     "temperature": 1.0,
                     "seed": 12345,
                     "repetition_penalty": 1.05,
-                    "num_beams": 1,
                 }
             ]
         }):
@@ -151,7 +150,6 @@ class TestLargeLanguageModel(unittest.TestCase):
                     "temperature": 1.0,
                     "seed": 12345,
                     "repetition_penalty": 1.05,
-                    "num_beams": 1,
                 }
             ]
         }):


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-6709](https://jira.prod.bloomberg.com/browse/RDISCROWD-6709)*

**Describe your changes**
`num_beams` is not a supported argument for `flan-ul2`. Calling LLM endpoint with it yields a 500 error and the following error:
```
{'error': "ValueError : TGI doesn't support num_beams"}
```

This PR removes `num_beans` argument from llm call.

**Testing performed**
Tested locally.

