### PR TITLE
RDISCROWD-6680 update swagger header

### DIFF
--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -96,7 +96,7 @@ def create_app(run_as_server=True):
     anonymizer.init_app(app)
     setup_task_presenter_editor(app)
     setup_schedulers(app)
-    Swagger(app, template=app.config.get('SWAGGER_TEMPLATE'))
+    setup_swagger(app)
     return app
 
 # construct rq_dashboard config
@@ -1011,3 +1011,12 @@ def setup_http_signer(app):
     from pybossa.http_signer import HttpSigner
     secret = app.config.get('SIGNATURE_SECRET')
     http_signer = HttpSigner(secret, 'X-Pybossa-Signature')
+
+
+def setup_swagger(app):
+    script_path = 'pybossa/themes/default/templates/flasgger_custom_head.html'
+    with open(script_path, 'r') as file:
+        html_as_string = file.read()
+        app.config.get('SWAGGER_TEMPLATE')['head_text'] = html_as_string
+    Swagger.DEFAULT_CONFIG.update(app.config.get('SWAGGER_TEMPLATE'))
+    Swagger(app, template=app.config.get('SWAGGER_TEMPLATE'))

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -1015,8 +1015,12 @@ def setup_http_signer(app):
 
 def setup_swagger(app):
     script_path = 'pybossa/themes/default/templates/flasgger_custom_head.html'
-    with open(script_path, 'r') as file:
-        html_as_string = file.read()
-        app.config.get('SWAGGER_TEMPLATE')['head_text'] = html_as_string
+    try:
+        with open(script_path, 'r') as file:
+            html_as_string = file.read()
+            app.config.get('SWAGGER_TEMPLATE')['head_text'] = html_as_string
+    except FileNotFoundError:
+        msg = "WARNING: Swagger custom header file not found."
+        app.logger.warning(msg)
     Swagger.DEFAULT_CONFIG.update(app.config.get('SWAGGER_TEMPLATE'))
     Swagger(app, template=app.config.get('SWAGGER_TEMPLATE'))

--- a/pybossa/settings_local.py.tmpl
+++ b/pybossa/settings_local.py.tmpl
@@ -530,7 +530,9 @@ USAGE_DASHBOARD_COMPONENTS = {
 
 SWAGGER_TEMPLATE = {
     'info': {
-        'title': 'Local GIGwork API',
+        'title': 'GIGwork - Local API',
         'description': 'Explore and experiment with Gigwork\'s REST APIs.\nUseful Links:\n- [Pybossa Docs](https://docs.pybossa.com/)',
     },
+    'favicon': '/static/img/favicon/favicon.ico',
+    'title': 'GIGwork - Local API',
 }


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-6680](https://jira.prod.bloomberg.com/browse/RDISCROWD-6680)*

**Describe your changes**
On the gigwork swagger page `/apidocs`:
1. Set favicon to match environment
2. Set page title
3. Set top left logo to GIGwork logo
4. Add link on logo to GIGwork home page
![screenshot-1](https://github.com/bloomberg/pybossa/assets/17805819/7be758f6-f74c-4244-acbb-0d66f1b8c251)

**Testing performed**
Tested locally

**Additional Context**
https://github.com/bloomberg/pybossa-default-theme/pull/444