### PR TITLE
RDISCROWD-6763 add LLM API token authentication

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ requirements = [
     "alembic==1.7.3",
     "arrow==1.1.1",
     "asn1crypto==1.4.0",
+    "bloomberg.mlp.auth_client",
     "Babel==2.9.1",
     "beautifulsoup4==4.10.0",
     "blinker==1.4",


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-6763](https://jira.prod.bloomberg.com/browse/RDISCROWD-6763)*

**Describe your changes**
 - use `bloomberg.mlp.auth_client` to authenticate requests to LLM API
 - Add error handling when LLM request fails

**Testing performed**
Tested locally.
