### PR TITLE
RDISCROWD-7089 Usage stats to include project ids and project names

### DIFF
--- a/pybossa/cache/site_stats.py
+++ b/pybossa/cache/site_stats.py
@@ -434,8 +434,7 @@ def n_projects_using_component(days='all', component=None):
                 string_agg("user".id::text, ', ') AS owner_ids,
                 string_agg("user".name::text, ', ') AS owner_names,
                 string_agg("user".email_addr::text, ', ') AS owner_emails
-            FROM project
-            LEFT JOIN "user" ON project.owner_id = "user".id
+            FROM project, "user"
             WHERE project.info->>'task_presenter' like :component
         '''
     if days != 'all':

--- a/pybossa/cache/site_stats.py
+++ b/pybossa/cache/site_stats.py
@@ -430,7 +430,10 @@ def n_projects_using_component(days='all', component=None):
             SELECT
                 count(project.id) AS n_projects,
                 string_agg(project.id::text, ', ') AS project_ids,
-                string_agg(project.short_name, ', ') AS project_names
+                string_agg(project.short_name, ', ') AS project_names,
+                string_agg("user".id::text, ', ') AS owner_ids,
+                string_agg("user".name::text, ', ') AS owner_names,
+                string_agg("user".email_addr::text, ', ') AS owner_emails
             FROM project
             LEFT JOIN "user" ON project.owner_id = "user".id
             WHERE project.info->>'task_presenter' like :component
@@ -438,6 +441,9 @@ def n_projects_using_component(days='all', component=None):
     if days != 'all':
         sql += '''
             AND to_timestamp(project.updated, 'YYYY-MM-DD"T"HH24:MI:SS.US') > current_timestamp - interval ':days days'
+        '''
+    sql += '''
+            GROUP BY "user".id, "user".name, "user".email_addr
         '''
     data = {'days' : days, 'component' : component}
 

--- a/pybossa/cache/site_stats.py
+++ b/pybossa/cache/site_stats.py
@@ -434,7 +434,8 @@ def n_projects_using_component(days='all', component=None):
                 string_agg("user".id::text, ', ') AS owner_ids,
                 string_agg("user".name::text, ', ') AS owner_names,
                 string_agg("user".email_addr::text, ', ') AS owner_emails
-            FROM project, "user"
+            FROM project
+            LEFT JOIN "user" ON project.owner_id = "user".id
             WHERE project.info->>'task_presenter' like :component
         '''
     if days != 'all':
@@ -442,7 +443,7 @@ def n_projects_using_component(days='all', component=None):
             AND to_timestamp(project.updated, 'YYYY-MM-DD"T"HH24:MI:SS.US') > current_timestamp - interval ':days days'
         '''
     sql += '''
-            GROUP BY "user".id, "user".name, "user".email_addr
+            GROUP BY "user".id
         '''
     data = {'days' : days, 'component' : component}
 

--- a/pybossa/cache/site_stats.py
+++ b/pybossa/cache/site_stats.py
@@ -427,7 +427,10 @@ def n_projects_using_component(days='all', component=None):
     """
     component = '%' + component + '%'
     sql = '''
-            SELECT count(project.id) AS n_projects
+            SELECT
+                count(project.id) AS n_projects,
+                string_agg(project.id::text, ', ') AS project_ids,
+                string_agg(project.short_name, ', ') AS project_names
             FROM project
             LEFT JOIN "user" ON project.owner_id = "user".id
             WHERE project.info->>'task_presenter' like :component
@@ -437,7 +440,8 @@ def n_projects_using_component(days='all', component=None):
             AND to_timestamp(project.updated, 'YYYY-MM-DD"T"HH24:MI:SS.US') > current_timestamp - interval ':days days'
         '''
     data = {'days' : days, 'component' : component}
-    return session.execute(text(sql), data).scalar()
+
+    return session.execute(text(sql), data).fetchall()
 
 
 def management_dashboard_stats_cached():

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -1367,9 +1367,6 @@ def load_usage_dashboard_data(days):
     for func, title in timed_stats_funcs:
         stats[title] = [(func(days), None, None)]
 
-    #from pybossa.cache import delete_memoized
-    #delete_memoized(site_stats.n_projects_using_component)
-
     # component usage
     for name, tag in current_app.config.get("USAGE_DASHBOARD_COMPONENTS", {}).items():
         stats[name] = site_stats.n_projects_using_component(days=days, component=tag)

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -1365,7 +1365,10 @@ def load_usage_dashboard_data(days):
     # total tasks, taskruns, projects over a specified amount of time.
     stats = OrderedDict()
     for func, title in timed_stats_funcs:
-        stats[title] = func(days)
+        stats[title] = [(func(days), None, None)]
+
+    #from pybossa.cache import delete_memoized
+    #delete_memoized(site_stats.n_projects_using_component)
 
     # component usage
     for name, tag in current_app.config.get("USAGE_DASHBOARD_COMPONENTS", {}).items():

--- a/test/test_cache/test_site_stats.py
+++ b/test/test_cache/test_site_stats.py
@@ -569,7 +569,7 @@ class TestSiteStatsCache(Test):
         ProjectFactory.create(created=date_12_mo, updated=date_12_mo, info=project_info)
 
         res = stats.n_projects_using_component(days=183, component='text-tagging')
-        assert res == 1, "Expected 1 project in last 6 months using text-tagging"
+        assert len(res) == 1, "Expected 1 project in last 6 months using text-tagging"
 
         res = stats.n_projects_using_component(days='all', component='text-tagging')
-        assert res == 2, "Expected 2 projects in all time using text-tagging"
+        assert len(res) == 2, "Expected 2 projects in all time using text-tagging"


### PR DESCRIPTION
- Updated admin project stats usage dashboard to include project_ids and project_names, along with counts.

Re: https://github.com/bloomberg/pybossa-default-theme/pull/449

## Screenshots

### The Usage Dashboard with clickable counts

![cap-1](https://github.com/bloomberg/pybossa-default-theme/assets/50708624/571df1ce-2376-4305-8fe4-2dd9b0e931d3)

### Project details for the statistic

![cap-2](https://github.com/bloomberg/pybossa-default-theme/assets/50708624/5dab10c1-9f0d-47dc-b3b6-d247a402c7fc)
