### PR TITLE
map_locations None edge case

### DIFF
--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -1418,8 +1418,16 @@ def delete_redis_keys(sentinel, pattern):
 
 
 def map_locations(locations):
+    if locations is None:
+        return {
+            'locations': None,
+            'country_codes': None,
+            'country_names': None
+        }
+
     country_codes_set = set()
     country_names_set = set()
+
     for location in locations:
         if len(location) == 2:
             country_codes_set.add(location)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1886,4 +1886,4 @@ class TestMapLocations(Test):
         expected_locations = None
         mapped_locations = util.map_locations(input_locations)
 
-        assert sorted(mapped_locations['locations']) == expected_locations
+        assert mapped_locations['locations'] == expected_locations

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1878,3 +1878,12 @@ class TestMapLocations(Test):
         mapped_locations = util.map_locations(input_locations)
 
         assert sorted(mapped_locations['locations']) == expected_locations
+
+    @with_context
+    def test_map_locations_none(self):
+
+        input_locations = None
+        expected_locations = None
+        mapped_locations = util.map_locations(input_locations)
+
+        assert sorted(mapped_locations['locations']) == expected_locations


### PR DESCRIPTION
*Issue number of the reported bug or feature request: DRQS 175540044*

**Describe your changes**
Add `None` check for `locations` array in `map_locations` function to prevent error when filtering by user preferences.

```
  File "/home/pybossa/pybossa/./pybossa/util.py", line 1426, in map_locations
    for location in locations:
TypeError: 'NoneType' object is not iterable
```

**Testing performed**
Tested locally
