### PR TITLE
DISABLE_TASK_PRESENTER_EDITOR_PAYLOAD

### DIFF
--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -994,7 +994,7 @@ def setup_profiler(app):
 
 
 def setup_task_presenter_editor(app):
-    if app.config.get('DISABLE_TASK_PRESENTER_EDITOR'):
+    if app.config.get('DISABLE_TASK_PRESENTER_EDITOR_PAYLOAD'):
         from pybossa.api.project import ProjectAPI
         ProjectAPI.restricted_keys.add('info::task_presenter')
 

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -1149,8 +1149,8 @@ def add_metadata(name):
                                input_form=True,
                                can_update=can_update,
                                upref_mdata_enabled=bool(app_settings.upref_mdata),
-                               country_name_to_country_code=app_settings.upref_mdata.country_name_to_country_code(),
-                               country_code_to_country_name=app_settings.upref_mdata.country_code_to_country_name())
+                               country_name_to_country_code=app_settings.upref_mdata.country_name_to_country_code,
+                               country_code_to_country_name=app_settings.upref_mdata.country_code_to_country_name)
 
     user_pref, metadata = get_user_pref_and_metadata(name, form)
     user.info['metadata'] = metadata

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -895,7 +895,7 @@ class TestProjectAPI(TestAPI):
         from flask import current_app
         from pybossa.core import setup_task_presenter_editor
 
-        current_app.config['DISABLE_TASK_PRESENTER_EDITOR'] = True
+        current_app.config['DISABLE_TASK_PRESENTER_EDITOR_PAYLOAD'] = True
         setup_task_presenter_editor(current_app)
 
         [admin, subadmin] = UserFactory.create_batch(2)


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-7414](https://jira.prod.bloomberg.com/browse/RDISCROWD-7414)*

**Describe your changes**
separate `DISABLE_TASK_PRESENTER_EDITOR` into 2 flags:
1. `DISABLE_TASK_PRESENTER_EDITOR`: Disable editing the task presenter in the GIGwork UI
2. `DISABLE_TASK_PRESENTER_EDITOR_PAYLOAD`: Disable editing the task presenter through an API request