### PR TITLE
RDISCROWD-7379: Delete task records in batches

### DIFF
--- a/pybossa/run.py
+++ b/pybossa/run.py
@@ -16,10 +16,24 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA. If not, see <http://www.gnu.org/licenses/>.
 from pybossa.core import create_app
+from pybossa.jobs import delete_bulk_tasks_in_batches
 
 if __name__ == "__main__":  # pragma: no cover
     app = create_app()
     # logging.basicConfig(level=logging.NOTSET)
+
+    data = dict(
+        project_id = 2,
+        project_name = "test bulk del",
+        curr_user = "usera",
+        coowners = [],
+        current_user_fullname = "usera",
+        force_reset = True,
+        url = "https://testbulkdel"
+    )
+    # with app.app_context():
+    #     delete_bulk_tasks_in_batches(data)
+
     app.run(host=app.config['HOST'], port=app.config['PORT'],
             debug=app.config.get('DEBUG', True))
 else:

--- a/pybossa/run.py
+++ b/pybossa/run.py
@@ -16,24 +16,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA. If not, see <http://www.gnu.org/licenses/>.
 from pybossa.core import create_app
-from pybossa.jobs import delete_bulk_tasks_in_batches
 
 if __name__ == "__main__":  # pragma: no cover
     app = create_app()
     # logging.basicConfig(level=logging.NOTSET)
-
-    data = dict(
-        project_id = 2,
-        project_name = "test bulk del",
-        curr_user = "usera",
-        coowners = [],
-        current_user_fullname = "usera",
-        force_reset = True,
-        url = "https://testbulkdel"
-    )
-    # with app.app_context():
-    #     delete_bulk_tasks_in_batches(data)
-
     app.run(host=app.config['HOST'], port=app.config['PORT'],
             debug=app.config.get('DEBUG', True))
 else:

--- a/pybossa/settings_local.py.tmpl
+++ b/pybossa/settings_local.py.tmpl
@@ -540,3 +540,6 @@ SWAGGER_TEMPLATE = {
     'favicon': '/static/img/favicon/favicon.ico',
     'title': 'GIGwork - Local API',
 }
+
+# perform bulk task deletes in batches in absence of session_replication_role on db
+DELETE_BULK_TASKS_IN_BATCHES = True

--- a/test/test_jobs/test_delete_tasks.py
+++ b/test/test_jobs/test_delete_tasks.py
@@ -77,7 +77,10 @@ class TestDeleteTasks(Test):
         data = {'project_id': 123, 'project_name': "xyz", 'curr_user': "user@a.com",
             'force_reset': 'true', 'coowners': [], 'current_user_fullname': "usera", 'url': "https://a.com"
         }
-        delete_bulk_tasks_in_batches(data)
+
+        with patch.dict(self.flask_app.config, {"DELETE_BULK_TASKS_IN_BATCHES": True}):
+            delete_bulk_tasks(data) #delete_bulk_tasks_in_batches(data)
+
         assert mock_cleanup_task_records.call_count == 2
         mock_sleep.assert_called_with(2)
 

--- a/test/test_jobs/test_delete_tasks.py
+++ b/test/test_jobs/test_delete_tasks.py
@@ -99,7 +99,7 @@ class TestDeleteTasks(Test):
         project_id = 123
         limit = 100
         mock_db.return_value.fetchall.side_effect = [[(1,), (2,), (3,), (4,)]]
-        cleanup_task_records(project_id, limit, force_reset=True)
+        cleanup_task_records(project_id, limit, force_reset=True, task_filter_args={})
         mock_db.call_count = 5
 
 
@@ -110,5 +110,5 @@ class TestDeleteTasks(Test):
         project_id = 123
         limit = 100
         mock_db.return_value.fetchall.side_effect = [[(1,), (2,), (3,), (4,)]]
-        cleanup_task_records(project_id, limit, force_reset=False)
+        cleanup_task_records(project_id, limit, force_reset=False, task_filter_args={})
         mock_db.call_count = 2

--- a/test/test_jobs/test_delete_tasks.py
+++ b/test/test_jobs/test_delete_tasks.py
@@ -17,7 +17,7 @@
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 from test import Test, with_context, flask_app, db
 from test.factories import ProjectFactory, UserFactory, TaskFactory
-from pybossa.jobs import delete_bulk_tasks
+from pybossa.jobs import delete_bulk_tasks, delete_bulk_tasks_in_batches, cleanup_task_records
 from pybossa.repositories import TaskRepository
 from unittest.mock import patch
 
@@ -54,3 +54,47 @@ class TestDeleteTasks(Test):
                                        )
         expected = dict(recipients=[user.email_addr], subject=expected_subject, body=expected_body)
         mock_send_mail.assert_called_once_with(expected)
+
+    @with_context
+    @patch('time.sleep')
+    @patch('pybossa.jobs.cleanup_task_records')
+    @patch('pybossa.core.db.session.execute')
+    @patch('pybossa.jobs.send_mail')
+    def test_delete_bulk_tasks_in_batches(self, mock_send_mail, mock_db, mock_cleanup_task_records, mock_sleep):
+        """Test delete_bulk_tasks_in_batches deletes tasks and sends email"""
+        user = UserFactory.create(admin=True)
+        project = ProjectFactory.create(name='test_project')
+        TaskFactory.create_batch(5, project=project)
+        tasks = task_repo.filter_tasks_by(project_id=project.id)
+        assert len(tasks) == 5
+
+        data = {'project_id': 123, 'project_name': project.name,
+        'curr_user': user.email_addr, 'force_reset': 'true',
+        'coowners': [], 'current_user_fullname': user.fullname,
+        'url': flask_app.config.get('SERVER_URL')}
+
+        mock_db.return_value.scalar.side_effect = [102, 3, 0, 105]
+        data = {'project_id': 123, 'project_name': "xyz", 'curr_user': "user@a.com",
+            'force_reset': 'true', 'coowners': [], 'current_user_fullname': "usera", 'url': "https://a.com"
+        }
+        delete_bulk_tasks_in_batches(data)
+        assert mock_cleanup_task_records.call_count == 2
+        mock_sleep.assert_called_with(2)
+
+        expected_subject = "Tasks deletion from {0}".format(data["project_name"])
+        msg_str = "Hello,\n\nTasks, taskruns and results associated have been deleted from project {0} on {1} as requested by {2}\n\nThe {3} team."
+        expected_body = msg_str.format(data["project_name"], data["url"], data["current_user_fullname"], flask_app.config.get("BRAND"))
+        expected = dict(recipients=[data["curr_user"]], subject=expected_subject, body=expected_body)
+        mock_send_mail.assert_called_once_with(expected)
+
+
+    @with_context
+    @patch('pybossa.core.db.session.execute')
+    def test_cleanup_task_records(self, mock_db):
+        """"Test cleanup task pick records to delete and perform cleanup from all tables"""
+
+        project_id = 123
+        limit = 100
+        mock_db.return_value.fetchall.side_effect = [[(1,), (2,), (3,), (4,)]]
+        cleanup_task_records(project_id, limit)
+        mock_db.call_count = 5

--- a/test/test_jobs/test_delete_tasks.py
+++ b/test/test_jobs/test_delete_tasks.py
@@ -75,7 +75,7 @@ class TestDeleteTasks(Test):
 
         mock_db.return_value.scalar.side_effect = [102, 3, 0, 105]
         data = {'project_id': 123, 'project_name': "xyz", 'curr_user': "user@a.com",
-            'force_reset': 'true', 'coowners': [], 'current_user_fullname': "usera", 'url': "https://a.com"
+            'force_reset': True, 'coowners': [], 'current_user_fullname': "usera", 'url': "https://a.com"
         }
 
         with patch.dict(self.flask_app.config, {"DELETE_BULK_TASKS_IN_BATCHES": True}):
@@ -99,5 +99,16 @@ class TestDeleteTasks(Test):
         project_id = 123
         limit = 100
         mock_db.return_value.fetchall.side_effect = [[(1,), (2,), (3,), (4,)]]
-        cleanup_task_records(project_id, limit)
+        cleanup_task_records(project_id, limit, force_reset=True)
         mock_db.call_count = 5
+
+
+    @with_context
+    @patch('pybossa.core.db.session.execute')
+    def test_cleanup_task_records_without_force_reset(self, mock_db):
+        """"Test cleanup task pick records to delete and perform cleanup from task table"""
+        project_id = 123
+        limit = 100
+        mock_db.return_value.fetchall.side_effect = [[(1,), (2,), (3,), (4,)]]
+        cleanup_task_records(project_id, limit, force_reset=False)
+        mock_db.call_count = 2


### PR DESCRIPTION
This is an alternative option to delete tasks in bulk. The existing solution is to enable `session_replication_role` that disables triggers on tables having referential integrity defined resulting faster deletes. The new solution under this PR is to  break down large chunk of deletes into smaller batches, introduce delays between batch of deletes to perform bulk delete of tasks. 