### PR TITLE
RDISCROWD-7338 default user access level

### DIFF
--- a/pybossa/data_access.py
+++ b/pybossa/data_access.py
@@ -71,7 +71,7 @@ def can_assign_user(levels, user_levels):
     """check if user be assigned to a project based on
     whether user_levels matches project levels """
 
-    if len(user_levels) == 0 and app_settings.config.get('DEFAULT_USER_ACCESS_LEVELS'):
+    if len(user_levels) == 0 and default_user_access_levels:
         user_levels = default_user_access_levels
 
     if not (valid_user_access_levels(levels) and valid_user_access_levels(user_levels)):

--- a/pybossa/data_access.py
+++ b/pybossa/data_access.py
@@ -34,7 +34,7 @@ if app_settings.config.get('ENABLE_ACCESS_CONTROL'):
         valid_access_levels_for_user_types = app_settings.config['VALID_ACCESS_LEVELS_FOR_USER_TYPES'],
         valid_user_access_levels=app_settings.config['VALID_USER_ACCESS_LEVELS']
     )
-
+default_user_access_levels = app_settings.config.get('DEFAULT_USER_ACCESS_LEVELS')
 
 def execute_if(this_is_true, otherwise_return=None):
     def decorator(otherwise_return=otherwise_return):
@@ -70,6 +70,10 @@ def valid_user_access_levels(levels):
 def can_assign_user(levels, user_levels):
     """check if user be assigned to a project based on
     whether user_levels matches project levels """
+
+    if len(user_levels) == 0 and app_settings.config.get('DEFAULT_USER_ACCESS_LEVELS'):
+        user_levels = default_user_access_levels
+
     if not (valid_user_access_levels(levels) and valid_user_access_levels(user_levels)):
         return False
 

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -606,7 +606,7 @@ def _show_public_profile(user, form, can_update):
                     percentage_tasks_completed=percentage_tasks_completed,
                     form=form,
                     can_update=can_update,
-                    private_instance=bool(data_access_levels),
+                    private_instance=bool(current_app.config.get('PRIVATE_INSTANCE')),
                     upref_mdata_enabled=bool(app_settings.upref_mdata),
                     country_name_to_country_code=app_settings.upref_mdata.country_name_to_country_code,
                     country_code_to_country_name=app_settings.upref_mdata.country_code_to_country_name)
@@ -632,7 +632,7 @@ def _show_own_profile(user, form, current_user, can_update):
                     user=user_dict,
                     form=form,
                     can_update=can_update,
-                    private_instance=bool(data_access_levels),
+                    private_instance=bool(current_app.config.get('PRIVATE_INSTANCE')),
                     upref_mdata_enabled=bool(app_settings.upref_mdata),
                     country_name_to_country_code=app_settings.upref_mdata.country_name_to_country_code,
                     country_code_to_country_name=app_settings.upref_mdata.country_code_to_country_name)

--- a/pybossa/view/bloomberg.py
+++ b/pybossa/view/bloomberg.py
@@ -89,7 +89,7 @@ def handle_bloomberg_response():
             try:
                 firm_id_to_type = current_app.config.get('FIRM_TO_TYPE', "")
                 firm_id = int(attributes.get('firmId', [0])[0])
-                data_access = ["L2"] if bool(data_access_levels) else ["L4"]
+                data_access = ["L2"] if bool(current_app.config.get('PRIVATE_INSTANCE')) else ["L4"]
                 user_type = firm_id_to_type.get(firm_id, "")
                 user_data['fullname']    = attributes['firstName'][0] + " " + attributes['lastName'][0]
                 user_data['email_addr']  = attributes['emailAddress'][0]

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -454,7 +454,7 @@ def clone_project(project, form):
     proj_dict['info'].pop('data_classification', None)
     proj_dict['info'].pop('data_access', None)
 
-    if  bool(data_access_levels) and not form.get('copy_users', False):
+    if  bool(current_app.config.get('PRIVATE_INSTANCE')) and not form.get('copy_users', False):
         proj_dict['info'].pop('project_users', None)
 
     if current_user.id not in project.owners_ids:
@@ -945,7 +945,7 @@ def update(short_name):
                     title=title,
                     pro_features=pro,
                     sync_enabled=sync_enabled,
-                    private_instance=bool(data_access_levels),
+                    private_instance=bool(current_app.config.get('PRIVATE_INSTANCE')),
                     prodsubprods=prodsubprods)
     return handle_content_type(response)
 
@@ -1087,7 +1087,7 @@ def settings(short_name):
                     n_volunteers=ps.n_volunteers,
                     title=title,
                     pro_features=pro,
-                    private_instance=bool(data_access_levels))
+                    private_instance=bool(current_app.config.get('PRIVATE_INSTANCE')))
     return handle_content_type(response)
 
 
@@ -2020,7 +2020,7 @@ def bulk_update_assign_worker(short_name):
         response['assign_users'] = assign_users
 
         # get a list of all users can be assigned to task
-        if bool(data_access_levels):
+        if bool(current_app.config.get('PRIVATE_INSTANCE')):
             all_users = user_repo.get_users(project.get_project_users())
         else:
             all_users = user_repo.get_all()
@@ -3739,7 +3739,7 @@ def project_config(short_name):
         try:
             data = json.loads(request.data)
             project.info['ext_config'] = integrate_ext_config(data.get('config'))
-            if bool(data_access_levels):
+            if bool(current_app.config.get('PRIVATE_INSTANCE')):
                 # for private gigwork
                 project.info['data_access'] = data.get('data_access')
             project.info['completed_tasks_cleanup_days'] = data.get('completed_tasks_cleanup_days')

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -954,10 +954,17 @@ def update(short_name):
 @login_required
 @csrf.exempt
 def remove_password(short_name):
+    # password required
     if current_app.config.get('PROJECT_PASSWORD_REQUIRED'):
         flash(gettext('Project password required'), 'error')
         return redirect_content_type(url_for('.update', short_name=short_name))
     project, owner, ps = project_by_shortname(short_name)
+    access_levels = project.info.get('data_access', None)
+    # access levels not set
+    if not data_access_levels or not access_levels:
+        flash('Cannot remove password from a project without data access levels', 'warning')
+        return redirect_content_type(url_for('.update', short_name=short_name))
+    # remove password
     project.set_password("")
     project_repo.update(project)
     flash(gettext('Project password has been removed!'), 'success')

--- a/test/test_data_access.py
+++ b/test/test_data_access.py
@@ -67,6 +67,19 @@ class TestAccessLevels(Test):
             assign_users = data_access.can_assign_user(proj_levels, user_levels)
             assert assign_users, "user with level L1 can work on project with level L2; user should be assigned"
 
+    def test_can_assign_user_default_access_level(self):
+        with patch.dict(data_access.data_access_levels, self.patched_levels()), \
+            patch('data_access.default_user_access_levels', new=["L3", "L4"]):
+            proj_levels = ["L3", "L4"]
+            user_levels = []
+            assign_users = data_access.can_assign_user(proj_levels, user_levels)
+            assert assign_users
+
+            proj_levels = ["L1", "L2"]
+            user_levels = []
+            assign_users = data_access.can_assign_user(proj_levels, user_levels)
+            assert not assign_users
+
     @with_context
     def test_user_type_based_access_levels(self):
         data = [dict(user_type='Researcher', access_levels=["L1"]),

--- a/test/test_data_access.py
+++ b/test/test_data_access.py
@@ -69,7 +69,7 @@ class TestAccessLevels(Test):
 
     def test_can_assign_user_default_access_level(self):
         with patch.dict(data_access.data_access_levels, self.patched_levels()), \
-            patch('data_access.default_user_access_levels', new=["L3", "L4"]):
+            patch('pybossa.data_access.default_user_access_levels', new=["L3", "L4"]):
             proj_levels = ["L3", "L4"]
             user_levels = []
             assign_users = data_access.can_assign_user(proj_levels, user_levels)

--- a/test/test_json/test_project.py
+++ b/test/test_json/test_project.py
@@ -437,6 +437,6 @@ class TestJsonProject(web.Helper):
                 patch('pybossa.view.projects.data_access_levels', new=["L3", "L4"]):
                 short_name = 'testproject'
                 url = f'project/{short_name}/remove-password'
-                res = self.app.post(url)
+                res = self.app.post(url, follow_redirects=True)
+                assert res.status_code == 200, res.status_code
                 project_mock.set_password.assert_not_called()
-                assert res.stats_code == 200

--- a/test/test_json/test_project.py
+++ b/test/test_json/test_project.py
@@ -385,12 +385,14 @@ class TestJsonProject(web.Helper):
         with patch.dict(self.flask_app.config, configs):
 
             project_mock = MagicMock()
+            project_mock.info.get.return_value = ["L3", "L4"]
             owner_mock = MagicMock()
             ps_mock = MagicMock()
 
             with patch('pybossa.view.projects.project_by_shortname', return_value=(project_mock, owner_mock, ps_mock)), \
                 patch('pybossa.view.projects.redirect_content_type', return_value='/project/update/testproject'), \
-                patch('pybossa.view.projects.project_repo.update', return_value=True):
+                patch('pybossa.view.projects.project_repo.update', return_value=True), \
+                patch('pybossa.view.projects.data_access_levels', new=["L3", "L4"]):
                 short_name = 'testproject'
                 url = f'project/{short_name}/remove-password'
                 res = self.app.post(url)

--- a/test/test_view/test_project_clone.py
+++ b/test/test_view/test_project_clone.py
@@ -145,8 +145,3 @@ class TestProjectClone(Helper):
                 assert new_project.info.get('ext_config', None) == None, new_project.info.get('ext_config', None)
                 assert new_project.owner_id == admin.id, new_project.owner_id
                 assert new_project.owners_ids == [admin.id], new_project.owners_ids
-
-
-
-
-

--- a/test/test_view/test_project_clone.py
+++ b/test/test_view/test_project_clone.py
@@ -109,38 +109,42 @@ class TestProjectClone(Helper):
     @with_context
     def test_clone_project_not_copy_assigned_users(self):
 
-        from pybossa.view.projects import data_access_levels
+        configs = {
+            'PRIVATE_INSTANCE': True
+        }
+        with patch.dict(self.flask_app.config, configs):
+            from pybossa.view.projects import data_access_levels
 
-        admin = UserFactory.create(admin=False, subadmin=True)
-        user2 = UserFactory.create()
-        assign_users = [user2.id]
-        task_presenter = 'test"; url="project/oldname/" pybossa.run("oldname"); test;'
-        project = ProjectFactory.create(id=40,
-                                        short_name='oldname',
-                                        info={'task_presenter': task_presenter,
-                                              'quiz': {'test': 123},
-                                              'enrichments': [{'test': 123}],
-                                              'project_users': assign_users,
-                                              'passwd_hash': 'testpass',
-                                              'ext_config': {'test': 123}},
-                                        owner=user2)
+            admin = UserFactory.create(admin=False, subadmin=True)
+            user2 = UserFactory.create()
+            assign_users = [user2.id]
+            task_presenter = 'test"; url="project/oldname/" pybossa.run("oldname"); test;'
+            project = ProjectFactory.create(id=40,
+                                            short_name='oldname',
+                                            info={'task_presenter': task_presenter,
+                                                'quiz': {'test': 123},
+                                                'enrichments': [{'test': 123}],
+                                                'project_users': assign_users,
+                                                'passwd_hash': 'testpass',
+                                                'ext_config': {'test': 123}},
+                                            owner=user2)
 
-        with patch.dict(data_access_levels, self.patch_data_access_levels):
-            data = {'short_name': 'newproj', 'name': 'newproj', 'password': 'Test123', 'input_data_class': 'L4 - public','output_data_class': 'L4 - public'}
-            url = '/project/%s/clone?api_key=%s' % (project.short_name, admin.api_key)
-            res = self.app.post(url, data=data)
-            new_project = project_repo.get(1)
-            old_project = project_repo.get(40)
-            task_presenter_expected = 'test"; url="project/newproj/" pybossa.run("newproj"); test;'
-            assert old_project.owner_id == user2.id, old_project.owner_id
-            assert old_project.info['passwd_hash'] == 'testpass', old_project.info['passwd_hash']
-            assert new_project.info['task_presenter'] == task_presenter_expected, new_project.info['task_presenter']
-            assert new_project.get_project_users() == [], new_project.get_project_users()
-            assert new_project.info.get('enrichments') == None, new_project.info.get('enrichments')
-            assert new_project.info.get('quiz') == None, new_project.info.get('quiz')
-            assert new_project.info.get('ext_config', None) == None, new_project.info.get('ext_config', None)
-            assert new_project.owner_id == admin.id, new_project.owner_id
-            assert new_project.owners_ids == [admin.id], new_project.owners_ids
+            with patch.dict(data_access_levels, self.patch_data_access_levels):
+                data = {'short_name': 'newproj', 'name': 'newproj', 'password': 'Test123', 'input_data_class': 'L4 - public','output_data_class': 'L4 - public'}
+                url = '/project/%s/clone?api_key=%s' % (project.short_name, admin.api_key)
+                res = self.app.post(url, data=data)
+                new_project = project_repo.get(1)
+                old_project = project_repo.get(40)
+                task_presenter_expected = 'test"; url="project/newproj/" pybossa.run("newproj"); test;'
+                assert old_project.owner_id == user2.id, old_project.owner_id
+                assert old_project.info['passwd_hash'] == 'testpass', old_project.info['passwd_hash']
+                assert new_project.info['task_presenter'] == task_presenter_expected, new_project.info['task_presenter']
+                assert new_project.get_project_users() == [], new_project.get_project_users()
+                assert new_project.info.get('enrichments') == None, new_project.info.get('enrichments')
+                assert new_project.info.get('quiz') == None, new_project.info.get('quiz')
+                assert new_project.info.get('ext_config', None) == None, new_project.info.get('ext_config', None)
+                assert new_project.owner_id == admin.id, new_project.owner_id
+                assert new_project.owners_ids == [admin.id], new_project.owners_ids
 
 
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-7338](https://jira.prod.bloomberg.com/browse/RDISCROWD-7338)*

**Describe your changes**
 - set default access level for users in config var `DEFAULT_USER_ACCESS_LEVELS`
 - Only allow removing project password if assigning users to the project is possible
 - `bool(data_access_levels)` was used to check if we are in private gigwork. Replace this with `bool(current_app.config.get('PRIVATE_INSTANCE'))` , since now both private and public will have data access levels

**Testing performed**
Tested Locally
