### PR TITLE
RDISCROWD-7501 increase bookmark url length limit

### DIFF
--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -1182,7 +1182,7 @@ def add_bookmark(user_name, short_name, bookmark_name, bookmark_url, order_by, d
     if bookmark_name is None or len(bookmark_name) > MAX_BOOKMARK_NAME_LEN:
         raise ValueError(f'Bookmark name must be between 1-{MAX_BOOKMARK_NAME_LEN} characters.')
     if bookmark_url is None or len(bookmark_url) > MAX_BOOKMARK_URL_LEN:
-        raise ValueError('Bookmark URL must be between 1-100 characters.')
+        raise ValueError(f'Bookmark URL must be between 1-{MAX_BOOKMARK_URL_LEN} characters.')
     bookmark_name = str(bookmark_name)
 
     user = user_repo.get_by_name(name=user_name)

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -79,7 +79,7 @@ export_queue = Queue('high', connection=sentinel.master)
 super_queue = Queue('super', connection=sentinel.master)
 
 MAX_BOOKMARK_NAME_LEN = 100
-MAX_BOOKMARK_URL_LEN = 500
+MAX_BOOKMARK_URL_LEN = 2000
 
 @blueprint.route('/')
 @blueprint.route('/page/<int:page>')


### PR DESCRIPTION
*Issue number of the reported bug or feature request: DRQS 176080286*

 - set taskbrowse bookmark url length limit to 2000