### PR TITLE
RDISCROWD-7554: Reset presented when configured

### DIFF
--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -140,8 +140,7 @@ class ProjectAPI(APIBase):
 
     def _update_attribute(self, new, old):
         for key, value in old.info.items():
-            if not new.info.get(key):
-                new.info[key] = value
+            new.info.setdefault(key, value)
 
     def _validate_instance(self, project):
         if project.short_name and is_reserved_name('project', project.short_name):

--- a/pybossa/contributions_guard.py
+++ b/pybossa/contributions_guard.py
@@ -22,6 +22,7 @@ class ContributionsGuard(object):
 
     KEY_PREFIX = 'pybossa:task_requested:user:{0}:task:{1}'
     PRESENTED_KEY_PREFIX = 'pybossa:task_presented:user:{0}:task:{1}'
+    CANCEL_TASK_KEY_PREFIX = 'pybossa:task_cancelled:user:{0}:task:{1}'
     STAMP_TTL = 60 * 60
 
     def __init__(self, redis_conn, timeout=None):
@@ -98,3 +99,33 @@ class ContributionsGuard(object):
             return self.conn.expire(key, self.STAMP_TTL)
         else:
             return self.conn.setEx(key, self.STAMP_TTL, make_timestamp())
+
+    def _create_cancelled_time_key(self, task, user):
+        """Create a Redis key for the time when task is
+        cancelled by a user. user must have a user_id.
+        """
+        user_id = user['user_id'] or None
+        return self.CANCEL_TASK_KEY_PREFIX.format(user_id, task.id)
+
+    def retrieve_cancelled_timestamp(self, task, user):
+        """Get the cached timestamp for a task cancelled by the user."""
+        key = self._create_cancelled_time_key(task, user)
+        timestamp = self.conn.get(key)
+        # If timestamp is not None, convert it to unicode string
+        return timestamp and timestamp.decode()
+
+    def stamp_cancelled_time(self, task, user):
+        """Cache the time that a task was cancelled by the user."""
+        key = self._create_cancelled_time_key(task, user)
+        self.conn.setex(key, self.STAMP_TTL, make_timestamp())
+
+    def check_task_cancelled_timestamp(self, task, user):
+        """Check if a task was cancelled by the user."""
+        key = self._create_cancelled_time_key(task, user)
+        task_cancelled = self.conn.get(key) is not None
+        return task_cancelled
+
+    def remove_cancelled_timestamp(self, task, user):
+        """Check if a task was cancelled by the user."""
+        key = self._create_cancelled_time_key(task, user)
+        return self.conn.delete(key)

--- a/pybossa/contributions_guard.py
+++ b/pybossa/contributions_guard.py
@@ -119,12 +119,6 @@ class ContributionsGuard(object):
         key = self._create_cancelled_time_key(task, user)
         self.conn.setex(key, self.STAMP_TTL, make_timestamp())
 
-    def check_task_cancelled_timestamp(self, task, user):
-        """Check if a task was cancelled by the user."""
-        key = self._create_cancelled_time_key(task, user)
-        task_cancelled = self.conn.get(key) is not None
-        return task_cancelled
-
     def remove_cancelled_timestamp(self, task, user):
         """Check if a task was cancelled by the user."""
         key = self._create_cancelled_time_key(task, user)

--- a/test/test_locked_sched.py
+++ b/test/test_locked_sched.py
@@ -609,3 +609,30 @@ class TestLockedSched(sched.Helper):
                         .format(project.id, user.api_key))
         task_served = json.loads(res.data)
         assert not task_served, "all expired tasks have expiration set. no task should be served."
+
+    @with_context
+    @patch('pybossa.api.ContributionsGuard')
+    def test_obtaining_task_again_reset_presented_time(self, guard):
+        owner = UserFactory.create(id=500)
+
+        project = ProjectFactory.create(owner=owner, info={"reset_presented_time": True})
+        project.info['sched'] = Schedulers.locked
+        project_repo.save(project)
+
+        task1 = TaskFactory.create(project=project, info='task 1', n_answers=1)
+        # making first call to task; mock cancel task not called
+        guard.return_value.retrieve_cancelled_timestamp.return_value = False
+        res = self.app.get('api/project/{}/newtask?api_key={}'
+                           .format(project.id, owner.api_key))
+        rec_task1 = json.loads(res.data)
+
+        # making second call to task upon cancel; mock cancel task
+        guard.return_value.retrieve_cancelled_timestamp.return_value = True
+        res = self.app.get('api/project/{}/newtask?api_key={}'
+                           .format(project.id, owner.api_key))
+        rec_task2 = json.loads(res.data)
+        # same task obtained again
+        assert rec_task1['id'] == task1.id
+        assert rec_task2['id'] == rec_task1['id']
+        assert guard.return_value.stamp_presented_time.called
+        assert guard.return_value.remove_cancelled_timestamp.called


### PR DESCRIPTION
* add a new project settings config `reset_presented_time`
* update cache with task cancel information adding new key `pybossa:task_cancelled:user:{0}:task:{1}`
* fix the bug with updating project setting attribute whose value to be updated is to be changed from `True` to `False`