### PR TITLE
RDISCROWD-6316 Browse TasksList No Tasks Forbidden Error

### DIFF
--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1737,6 +1737,10 @@ def tasks_browse(short_name, page=1, records_per_page=None):
             args["regular_user"] = regular_user
             # default page size for worker view is 100
             per_page = records_per_page if records_per_page in allowed_records_per_page else task_list_default_records_per_page
+        elif view_type == 'tasklist' and n_available_tasks_for_user(project, current_user.id) == 0:
+            # When no tasks are available, redirect to browse all tasks view.
+            new_path = '/project/{}/tasks/browse'.format(project.short_name)
+            return redirect_content_type(new_path)
         else:
             abort(403)
     except (ValueError, TypeError) as err:

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1739,6 +1739,7 @@ def tasks_browse(short_name, page=1, records_per_page=None):
             per_page = records_per_page if records_per_page in allowed_records_per_page else task_list_default_records_per_page
         elif view_type == 'tasklist' and n_available_tasks_for_user(project, current_user.id) == 0:
             # When no tasks are available, redirect to browse all tasks view.
+            flash("No new tasks available")
             new_path = '/project/{}/tasks/browse'.format(project.short_name)
             return redirect_content_type(new_path)
         else:

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -10146,6 +10146,51 @@ class TestWeb(web.Helper):
         assert "class=\" sort-asc sortable\" data-sort=\"completed_by\"" not in str(res.data), "Unexpected sorted column (sort-asc) indicator on Completed By."
         assert "class=\" sort-asc sortable\" data-sort=\"priority\"" not in str(res.data), "Missing sorted column indicator (sort-asc) on Priority."
 
+
+    @with_context
+    @patch('pybossa.view.projects.n_available_tasks_for_user')
+    def test_browse_task_view_tasklist_no_tasks_admin(self, n_available_tasks_for_user):
+        """Test browse task with view=tasklist and no available tasks redirects to tasks/browse."""
+        n_available_tasks_for_user.return_value = 0
+
+        # Initialize a project.
+        self.create()
+        self.delete_task_runs()
+
+        # Set the user password and admin.
+        user = db.session.query(User).get(2)
+        user.set_password('1234')
+        user.admin = True
+        user_repo.save(user)
+
+        # Create a project and task.
+        project = db.session.query(Project).first()
+        project.allow_anonymous_contributors = True
+        db.session.add(project)
+        db.session.commit()
+
+        # Retrieve the first task.
+        task = db.session.query(Task).filter(Project.id == project.id).first()
+
+        # Add task results.
+        for i in range(10):
+            task_run = TaskRun(project_id=project.id, task_id=task.id,
+                               user_id=user.id,
+                               info={'answer': i})
+            db.session.add(task_run)
+            db.session.commit()
+            res = self.app.get('api/project/%s/newtask' % project.id)
+
+        # Sign-in as an admin user.
+        csrf = self.get_csrf('/account/signin')
+        res = self.signin(email=user.email_addr, password='1234', csrf=csrf)
+
+        # Load the task browse page using the tasklist view.
+        res = self.app.get('project/%s/tasks/browse?view=tasklist' % (project.short_name), follow_redirects=True)
+        # Confirm a 200 response for /tasks/browse is returned.
+        assert res.status_code == 200
+
+
     @with_context
     def test_gold_annotations_anonymous_access_fails(self):
         """Test gold_annotations without login"""


### PR DESCRIPTION
- Bug fix for case where Browse Tasks view=tasklist and no tasks available to no longer show 403 error, redirect to Browse Tasks view.

## Screenshot

![no-tasks-avail-2](https://github.com/user-attachments/assets/e50f800b-f35b-459d-a2f4-28ead654cf14)
