### PR TITLE
allow empty password in validator

### DIFF
--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -99,9 +99,6 @@ class ProjectCommonForm(Form):
 
     password = PasswordField(
                     lazy_gettext('Password'),
-                    [pb_validator.CheckPasswordStrength(
-                                        min_len=PROJECT_PWD_MIN_LEN,
-                                        special=False)],
                     render_kw={'placeholder': 'Minimum length {} characters, 1 uppercase, 1 lowercase and 1 numeric.'.format(PROJECT_PWD_MIN_LEN)})
     input_data_class = SelectFieldWithProps(lazy_gettext('Input Data Classification'),
                                             validators=[validators.Required()], choices=[], default='')
@@ -116,10 +113,16 @@ class ProjectForm(ProjectCommonForm):
         super(ProjectForm, self).__init__(*args, **kwargs)
         if current_app.config.get('PROJECT_PASSWORD_REQUIRED'):
             self.password_required = True
-            self.password.validators.append(validators.Required())
+            self.password.validators = [pb_validator.CheckPasswordStrength(
+                                        min_len=PROJECT_PWD_MIN_LEN,
+                                        special=False,
+                                        password_required=True), validators.Required()]
         else:
             self.password_required = False
-            self.password.validators.append(validators.Optional())
+            self.password.validators = [pb_validator.CheckPasswordStrength(
+                                        min_len=PROJECT_PWD_MIN_LEN,
+                                        special=False,
+                                        password_required=False), validators.Optional()]
 
     long_description = TextAreaField(lazy_gettext('Long Description'),
                                      [validators.Required()])

--- a/pybossa/forms/validator.py
+++ b/pybossa/forms/validator.py
@@ -145,13 +145,14 @@ class CheckPasswordStrength(object):
             self, message=None, min_len=8,
             max_len=None, uppercase=True,
             lowercase=True, numeric=True,
-            special=True):
+            special=True, password_required=True):
         self.min_len = min_len
         self.max_len = max_len
         self.uppercase = uppercase
         self.lowercase = lowercase
         self.numeric = numeric
         self.special = special
+        self.password_required = password_required
 
         if message:
             self.message = message
@@ -162,6 +163,8 @@ class CheckPasswordStrength(object):
 
     def __call__(self, form, field):
         pwd = field.data
+        if not self.password_required and len(pwd) == 0:
+            return
         valid, message = check_password_strength(
                             pwd, self.min_len, self.max_len,
                             self.uppercase, self.lowercase,


### PR DESCRIPTION
**Describe your changes**
Cloning projects without a password is blocked due to password validation on the frontend. This PR allows empty password strings in the `CheckPasswordStrength` validator when `password_required` is `False`.

**Testing performed**
Tested Locally

**Additional context**
![image](https://github.com/user-attachments/assets/a8e6dae7-2f19-4cdc-9c31-7dbb1e008943)
