### PR TITLE
RDISCROWD-7682 Logging for get_user

### DIFF
--- a/pybossa/cache/users.py
+++ b/pybossa/cache/users.py
@@ -119,7 +119,7 @@ def get_user_summary(name, current_user=None):
                 return None
         else:
             return user
-    else:  # pragma: no cover
+    else:
         current_app.logger.info("Method get_user_summary(): user is None for user name %s, current user id %s, current user name %s",
             name, current_user.id if current_user else None, current_user.name if current_user else None)
         return None

--- a/pybossa/cache/users.py
+++ b/pybossa/cache/users.py
@@ -109,10 +109,19 @@ def get_user_summary(name, current_user=None):
                (current_user.id == user['id'])):
                 return user
             else:
+                current_app.logger.info("""
+                    Method get_user_summary(): User restricted. Returning None as user is not current_user
+                    for user name %s, user id %s, user restrict %s, current user id %s, current user name %s,
+                    current user authenticated %s, is_current_user == user %s""",
+                    name, user.get('id'), user.get('restrict'), current_user.id if current_user else None,
+                    current_user.name if current_user else None, current_user.is_authenticated if current_user else False,
+                    current_user.id == user.get('id') if current_user else False)
                 return None
         else:
             return user
     else:  # pragma: no cover
+        current_app.logger.info("Method get_user_summary(): user is None for user name %s, current user id %s, current user name %s",
+            name, current_user.id if current_user else None, current_user.name if current_user else None)
         return None
 
 
@@ -124,6 +133,9 @@ def public_get_user_summary(name):
     if private_user is not None:
         u = User()
         public_user = u.to_public_json(data=private_user)
+    if not public_user:
+        current_app.logger.info("Method public_get_user_summary(): public_user is None for user name %s. private_user None = %s",
+            name, private_user == None)
     return public_user
 
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -169,9 +169,10 @@ def sanitize_project_owner(project, owner, current_user, ps=None):
     project_sanitized = deepcopy(project_sanitized)
 
     if not owner_sanitized:
-        current_app.logger.info("owner_sanitized is None. \
-                            project id %s, project name %s, owner id %s, owner name %s, current user id %s, \
-                            current user name %s, current user authenticated %s, is_current_user == owner %s",
+        current_app.logger.info("""owner_sanitized is None after %sget_user_summary().
+                            project id %s, project name %s, owner id %s, owner name %s, current user id %s,
+                            current user name %s, current user authenticated %s, is_current_user == owner %s""",
+                            "public_" if not is_current_user_owner else "",
                             project.id, project.name, owner.id, owner.name, current_user.id, current_user.name,
                             current_user.is_authenticated, is_current_user_owner)
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -146,7 +146,8 @@ def project_id_route_converter(projectid, path):
 
 def sanitize_project_owner(project, owner, current_user, ps=None):
     """Sanitize project and owner data."""
-    if current_user.is_authenticated and owner.id == current_user.id:
+    is_current_user_owner = current_user.is_authenticated and owner.id == current_user.id
+    if is_current_user_owner:
         if isinstance(project, Project):
             project_sanitized = project.dictize()   # Project object
         else:
@@ -166,6 +167,13 @@ def sanitize_project_owner(project, owner, current_user, ps=None):
                 project_sanitized = project             # dict object
         owner_sanitized = cached_users.public_get_user_summary(owner.name)
     project_sanitized = deepcopy(project_sanitized)
+
+    if not owner_sanitized:
+        current_app.logger.info("owner_sanitized is None. \
+                            project id %s, project name %s, owner id %s, owner name %s, current user id %s, \
+                            current user name %s, current user authenticated %s, is_current_user == owner %s",
+                            project.id, project.name, owner.id, owner.name, current_user.id, current_user.name,
+                            current_user.is_authenticated, is_current_user_owner)
 
     # remove project, owner creds so that they're unavailable under json response
     project_sanitized['info'].pop('passwd_hash', None)

--- a/test/test_cache/test_cache_users.py
+++ b/test/test_cache/test_cache_users.py
@@ -55,6 +55,17 @@ class TestUsersCache(Test):
         assert zizou != None, zizou
 
     @with_context
+    def test_get_user_summary_user_exists_restrict(self):
+        """Test CACHE USERS get_user_summary returns a dict with the user data
+        if the user exists restricted"""
+        UserFactory.create(name='zidane', restrict=True)
+        UserFactory.create(name='figo')
+
+        zizou = cached_users.get_user_summary('zidane')
+
+        assert zizou is None, zizou
+
+    @with_context
     def test_public_get_user_summary_user_exists(self):
         """Test public CACHE USERS get_user_summary returns a dict with the user data
         if the user exists"""

--- a/test/test_view/test_project_contact.py
+++ b/test/test_view/test_project_contact.py
@@ -205,4 +205,4 @@ class TestProjectContact(Helper):
 
         # Verify error is raised from owner_sanitized.pop().
         with assert_raises(AttributeError) as ex:
-            sanitize_project_owner(project, owner, user)
+            sanitize_project_owner(project, owner, owner)

--- a/test/test_view/test_project_contact.py
+++ b/test/test_view/test_project_contact.py
@@ -183,7 +183,7 @@ class TestProjectContact(Helper):
     @with_request_context
     @patch('pybossa.cache.users.public_get_user_summary')
     def test_project_sanitize_project_no_owner_not_project_owner(self, public_get_user_summary):
-        """Test Project sanitize_project_owner when no onwer returned and current user not owner."""
+        """Test Project sanitize_project_owner when no owner returned and current user not owner."""
         admin, owner, user = UserFactory.create_batch(3)
         project = ProjectFactory.create(owner=owner, short_name='test-app', name='My New Project')
 
@@ -197,7 +197,7 @@ class TestProjectContact(Helper):
     @with_request_context
     @patch('pybossa.cache.users.get_user_summary')
     def test_project_sanitize_project_no_owner_is_project_owner(self, get_user_summary):
-        """Test Project sanitize_project_owner when no onwer returned and current user is owner."""
+        """Test Project sanitize_project_owner when no owner returned and current user is owner."""
         admin, owner, user = UserFactory.create_batch(3)
         project = ProjectFactory.create(owner=owner, short_name='test-app', name='My New Project')
 

--- a/test/test_view/test_project_contact.py
+++ b/test/test_view/test_project_contact.py
@@ -16,11 +16,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 import json
-from test import with_context
+from test import with_context, with_request_context
 from test.helper.web import Helper
 from test.factories import ProjectFactory, UserFactory
 from unittest.mock import patch
-
+from nose.tools import assert_raises
+from pybossa.view.projects import sanitize_project_owner
 
 class TestProjectContact(Helper):
 
@@ -178,3 +179,30 @@ class TestProjectContact(Helper):
 
         # Verify status code from response.
         assert res.status_code == 405
+
+    @with_request_context
+    @patch('pybossa.cache.users.public_get_user_summary')
+    def test_project_sanitize_project_no_owner_not_project_owner(self, public_get_user_summary):
+        """Test Project sanitize_project_owner when no onwer returned and current user not owner."""
+        admin, owner, user = UserFactory.create_batch(3)
+        project = ProjectFactory.create(owner=owner, short_name='test-app', name='My New Project')
+
+        # Simulate no returned user.
+        public_get_user_summary.return_value = None
+
+        # Verify error is raised from owner_sanitized.pop().
+        with assert_raises(AttributeError) as ex:
+            sanitize_project_owner(project, owner, user)
+
+    @with_request_context
+    @patch('pybossa.cache.users.get_user_summary')
+    def test_project_sanitize_project_no_owner_is_project_owner(self, get_user_summary):
+        """Test Project sanitize_project_owner when no onwer returned and current user is owner."""
+        admin, owner, user = UserFactory.create_batch(3)
+        project = ProjectFactory.create(owner=owner, short_name='test-app', name='My New Project')
+
+        get_user_summary.return_value = None
+
+        # Verify error is raised from owner_sanitized.pop().
+        with assert_raises(AttributeError) as ex:
+            sanitize_project_owner(project, owner, user)


### PR DESCRIPTION
- Added logging for get_user.

```
Test Project sanitize_project_owner when no onwer returned and current user is owner. ... 
pybossa:INFO:[2024-10-02 11:27:19,664] owner_sanitized is None after get_user_summary().
                            project id 1, project name My New Project, owner id 2, owner name user2, current user id 2,
                            current user name user2, current user authenticated True, is_current_user == owner True [in /mnt/c/Projects/gigwork/pybossa/pybossa/view/projects.py:172]
passed


Test Project sanitize_project_owner when no onwer returned and current user not owner. ... 
pybossa:INFO:[2024-10-02 11:28:14,876] owner_sanitized is None after public_get_user_summary().
                            project id 1, project name My New Project, owner id 2, owner name user2, current user id 3,
                            current user name user3, current user authenticated True, is_current_user == owner False [in /mnt/c/Projects/gigwork/pybossa/pybossa/view/projects.py:172]
passed


Test CACHE USERS get_user_summary returns a dict with the user data ... 
pybossa:INFO:[2024-10-02 11:29:31,107]
                    Method get_user_summary(): User restricted. Returning None as user is not current_user
                    for user name zidane, user id 1, user restrict True, current user id None, current user name None,
                    current user authenticated False, is_current_user == user False [in /mnt/c/Projects/gigwork/pybossa/pybossa/cache/users.py:112]
passed
```