### PR TITLE
RDISCROWD-7088 add ownership_id to project ownership page

### DIFF
--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -242,7 +242,6 @@ class TaskDefaultRedundancyForm(Form):
                                         task_repo.MAX_REDUNDANCY
                                     )))])
 
-
 class TaskRedundancyForm(Form):
     n_answers = IntegerField(lazy_gettext('Redundancy'),
                              [validators.Required(),
@@ -255,7 +254,6 @@ class TaskRedundancyForm(Form):
                                           task_repo.MIN_REDUNDANCY,
                                           task_repo.MAX_REDUNDANCY
                                       )))])
-
 
 class TaskPriorityForm(Form):
     task_ids = TextField(lazy_gettext('Task IDs'),
@@ -289,6 +287,7 @@ class TaskTimeoutForm(Form):
 class TaskNotificationForm(Form):
     remaining = IntegerField(lazy_gettext('Notify when the number of remaining tasks is less than or equal to'))
     webhook = TextField(lazy_gettext('Webhook URL'))
+
 
 class TaskSchedulerForm(Form):
     _translate_names = lambda variant: (variant[0], lazy_gettext(variant[1]))

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -368,6 +368,11 @@ def datetime_filter(source, fmt):
     return source.strftime(fmt)
 
 
+def validate_ownership_id(ownership_id):
+    if ownership_id == None or len(ownership_id) == 0:
+        return True
+    return ownership_id.isnumeric() and len(ownership_id) <= 20
+
 class Pagination(object):
 
     """Class to paginate domain objects."""

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -3528,9 +3528,8 @@ def ownership_id(short_name):
                 old_ownership_id, new_ownership_id)
             project.info['ownership_id'] = new_ownership_id
             project_repo.save(project)
-            response['ownership_id'] = new_ownership_id
-
-            flash(gettext('Ownership ID updated successfully'), 'success')
+        response['ownership_id'] = new_ownership_id
+        flash(gettext('Ownership ID updated successfully'), 'success')
 
     return handle_content_type(response)
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -107,7 +107,7 @@ import pybossa.app_settings as app_settings
 from copy import deepcopy
 from pybossa.cache import delete_memoized
 from sqlalchemy.orm.attributes import flag_modified
-from pybossa.util import admin_or_project_owner
+from pybossa.util import admin_or_project_owner, validate_ownership_id
 
 cors_headers = ['Content-Type', 'Authorization']
 
@@ -3503,6 +3503,36 @@ def del_coowner(short_name, user_name=None):
         return redirect_content_type(url_for('.coowners', short_name=short_name))
     return abort(404)
 
+
+@blueprint.route('/<short_name>/ownership_id', methods=['GET', 'PUT'])
+@login_required
+def ownership_id(short_name):
+    """Manage project project ownership identifer."""
+    project, owner, ps = project_by_shortname(short_name)
+    response = {'title': current_app.config.get('OWNERSHIP_ID_TITLE', 'Ownership ID')}
+
+    if request.method == 'GET':
+        ensure_authorized_to('read', project)
+        response['ownership_id'] = project.info.get('ownership_id', None)
+
+    if request.method == 'PUT':
+        ensure_authorized_to('update', project)
+        data = request.get_json()
+        new_ownership_id = data.get("ownership_id")
+        if not validate_ownership_id(new_ownership_id):
+            flash(gettext('Ownership ID must be numeric and less than 20 characters!'), 'error')
+            handle_content_type(response)
+        old_ownership_id = project.info.get('ownership_id', None)
+        if new_ownership_id != old_ownership_id:
+            auditlogger.log_event(project, current_user, 'update', 'project.ownership_id',
+                old_ownership_id, new_ownership_id)
+            project.info['ownership_id'] = new_ownership_id
+            project_repo.save(project)
+            response['ownership_id'] = new_ownership_id
+
+            flash(gettext('Ownership ID updated successfully'), 'success')
+
+    return handle_content_type(response)
 
 @blueprint.route('/<short_name>/projectreport/export', methods=['GET', 'POST'])
 @login_required

--- a/test/test_ownership_id.py
+++ b/test/test_ownership_id.py
@@ -21,7 +21,7 @@ class TestOwnershipId(web.Helper):
         self.signin()
         self.new_project()
 
-        res = self.app.get('/project/sampleapp/ownership_id', follow_redirects=True)
+        res = self.app.get('/project/sampleapp/ownership_id', content_type='application/json', follow_redirects=True)
         assert "ownership_id" in str(res.data), res.data
 
         self.signout()
@@ -32,15 +32,21 @@ class TestOwnershipId(web.Helper):
     def test_01_edit_ownership_id(self):
         """Test admin and owner can edit ownership id"""
         self.register()
+        csrf = self.get_csrf('/account/signin')
         self.signin()
-
         self.new_project()
-        payload = {'ownership_id': '12345'}
-        res = self.app.put('/project/sampleapp/ownership_id', data=json.dumps(payload))
-        assert "12345" in str(res.data), res.data
 
+        # test add id
+        payload = {'ownership_id': '12345'}
+        res = self.app.put('/project/sampleapp/ownership_id', headers={'X-CSRFToken': csrf}, content_type='application/json', data=json.dumps(payload))
+        assert "12345" in str(res.data), res.data
+        # test same id as saved
+        payload = {'ownership_id': '12345'}
+        res = self.app.put('/project/sampleapp/ownership_id', headers={'X-CSRFToken': csrf}, content_type='application/json', data=json.dumps(payload))
+        assert "12345" in str(res.data), res.data
+        # test remove id
         payload = {'ownership_id': ''}
-        res = self.app.put('/project/sampleapp/ownership_id', data=json.dumps(payload))
+        res = self.app.put('/project/sampleapp/ownership_id', headers={'X-CSRFToken': csrf}, content_type='application/json', data=json.dumps(payload))
         assert "12345" not in str(res.data), res.data
 
         self.signout()
@@ -51,19 +57,20 @@ class TestOwnershipId(web.Helper):
     def test_02_invalid_ownership_ids(self):
         """Test ownership id validation"""
         self.register()
+        csrf = self.get_csrf('/account/signin')
         self.signin()
-
         self.new_project()
+
         payload = {'ownership_id': 'abcd123'}
-        res = self.app.put('/project/sampleapp/ownership_id', data=json.dumps(payload))
+        res = self.app.put('/project/sampleapp/ownership_id', headers={'X-CSRFToken': csrf}, content_type='application/json', data=json.dumps(payload))
         assert "Ownership ID must be numeric and less than 20 characters!" in str(res.data), res.data
 
         payload = {'ownership_id': '123!!!abc'}
-        res = self.app.put('/project/sampleapp/ownership_id', data=json.dumps(payload))
+        res = self.app.put('/project/sampleapp/ownership_id', headers={'X-CSRFToken': csrf}, content_type='application/json', data=json.dumps(payload))
         assert "Ownership ID must be numeric and less than 20 characters!" in str(res.data), res.data
 
         payload = {'ownership_id': '1111111111111111111111'}
-        res = self.app.put('/project/sampleapp/ownership_id', data=json.dumps(payload))
+        res = self.app.put('/project/sampleapp/ownership_id', headers={'X-CSRFToken': csrf}, content_type='application/json', data=json.dumps(payload))
         assert "Ownership ID must be numeric and less than 20 characters!" in str(res.data), res.data
 
         self.signout()

--- a/test/test_ownership_id.py
+++ b/test/test_ownership_id.py
@@ -1,0 +1,70 @@
+import json
+from unittest.mock import patch
+from test.helper import web
+from test import with_context
+from test import db, Fixtures
+from test.factories import ProjectFactory, UserFactory
+from pybossa.core import user_repo
+from pybossa.repositories import ProjectRepository
+
+
+class TestOwnershipId(web.Helper):
+
+    def setup(self):
+        super(TestOwnershipId, self).setUp()
+        self.project_repo = ProjectRepository(db)
+
+    @with_context
+    def test_00_access_ownership_id(self):
+        """Test admin and owner can access coowners page"""
+        self.register()
+        self.signin()
+        self.new_project()
+
+        res = self.app.get('/project/sampleapp/ownership_id', follow_redirects=True)
+        assert "ownership_id" in str(res.data), res.data
+
+        self.signout()
+        self.signin()
+
+
+    @with_context
+    def test_01_edit_ownership_id(self):
+        """Test admin and owner can edit ownership id"""
+        self.register()
+        self.signin()
+
+        self.new_project()
+        payload = {'ownership_id': '12345'}
+        res = self.app.put('/project/sampleapp/ownership_id', data=json.dumps(payload))
+        assert "12345" in str(res.data), res.data
+
+        payload = {'ownership_id': ''}
+        res = self.app.put('/project/sampleapp/ownership_id', data=json.dumps(payload))
+        assert "12345" not in str(res.data), res.data
+
+        self.signout()
+        self.signin()
+
+
+    @with_context
+    def test_02_invalid_ownership_ids(self):
+        """Test ownership id validation"""
+        self.register()
+        self.signin()
+
+        self.new_project()
+        payload = {'ownership_id': 'abcd123'}
+        res = self.app.put('/project/sampleapp/ownership_id', data=json.dumps(payload))
+        assert "Ownership ID must be numeric and less than 20 characters!" in str(res.data), res.data
+
+        payload = {'ownership_id': '123!!!abc'}
+        res = self.app.put('/project/sampleapp/ownership_id', data=json.dumps(payload))
+        assert "Ownership ID must be numeric and less than 20 characters!" in str(res.data), res.data
+
+        payload = {'ownership_id': '1111111111111111111111'}
+        res = self.app.put('/project/sampleapp/ownership_id', data=json.dumps(payload))
+        assert "Ownership ID must be numeric and less than 20 characters!" in str(res.data), res.data
+
+        self.signout()
+        self.signin()


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-7088](https://jira.prod.bloomberg.com/browse/RDISCROWD-7088)*

**Describe your changes**
- Add endpoint `/<short_name>/ownership_id` to handle project ownership id
- Field name from config
![image](https://github.com/user-attachments/assets/6f88927b-064e-4cbb-ac1c-3a96936cfb40)

**Testing performed**
Tested Localy

**Additional context**
https://github.com/bloomberg/pybossa-default-theme/pull/469
