### PR TITLE
RDISCROWD-7364 custom task export fields

### DIFF
--- a/pybossa/exporter/export_helpers.py
+++ b/pybossa/exporter/export_helpers.py
@@ -223,7 +223,6 @@ def filter_table_headers(headers, accepted_fields):
                     pass
                 elif header.startswith('task__info__'):
                     masked_header = header[12:  ]
-                    print("masked header: ", masked_header)
                     if masked_header in accepted_fields_set:
                         new_headers.append(header)
                 else:

--- a/pybossa/exporter/export_helpers.py
+++ b/pybossa/exporter/export_helpers.py
@@ -223,12 +223,15 @@ def filter_task_info_headers(headers, accepted_task_info_fields=[]):
   task_info_header_len = len(task_info_header) + 2
 
   for header in headers:
+    # skip task__info_header
     if header == task_info_header:
       pass
+    # check task info headers for accepted fields
     elif header.startswith(task_info_header):
       masked_header = header[task_info_header_len:]
       if masked_header in accepted_task_info_fields_set:
         new_headers.append(header)
+    # add all headers unrelated to task info
     else:
         new_headers.append(header)
   return new_headers

--- a/pybossa/exporter/export_helpers.py
+++ b/pybossa/exporter/export_helpers.py
@@ -213,3 +213,19 @@ def browse_tasks_export_count(obj, project_id, expanded, filters):
         return
     return session.execute(
             sql, dict(project_id=project_id, **filter_params)).scalar()
+
+
+def filter_table_headers(headers, accepted_fields):
+            new_headers = []
+            accepted_fields_set = set(accepted_fields)
+            for header in headers:
+                if header == 'task__info':
+                    pass
+                elif header.startswith('task__info__'):
+                    masked_header = header[12:  ]
+                    print("masked header: ", masked_header)
+                    if masked_header in accepted_fields_set:
+                        new_headers.append(header)
+                else:
+                    new_headers.append(header)
+            return new_headers

--- a/pybossa/exporter/export_helpers.py
+++ b/pybossa/exporter/export_helpers.py
@@ -223,7 +223,7 @@ def filter_task_info_headers(headers, accepted_task_info_fields=[]):
   task_info_header_len = len(task_info_header) + 2
 
   for header in headers:
-    # skip task__info_header
+    # skip task info_header
     if header != task_info_header:
       if header.startswith(task_info_header):
         masked_header = header[task_info_header_len:]

--- a/pybossa/exporter/export_helpers.py
+++ b/pybossa/exporter/export_helpers.py
@@ -215,16 +215,20 @@ def browse_tasks_export_count(obj, project_id, expanded, filters):
             sql, dict(project_id=project_id, **filter_params)).scalar()
 
 
-def filter_table_headers(headers, accepted_task_info_fields):
-            new_headers = []
-            accepted_task_info_fields_set = set(accepted_task_info_fields)
-            for header in headers:
-                if header == 'task__info':
-                    pass
-                elif header.startswith('task__info__'):
-                    masked_header = header[12:  ]
-                    if masked_header in accepted_task_info_fields_set:
-                        new_headers.append(header)
-                else:
-                    new_headers.append(header)
-            return new_headers
+def filter_task_info_headers(headers, accepted_task_info_fields=[]):
+  new_headers = []
+  accepted_task_info_fields_set = set(accepted_task_info_fields)
+  task_info_header = "task__info"
+  # account for the double underscore after task__info in headers
+  task_info_header_len = len(task_info_header) + 2
+
+  for header in headers:
+    if header == task_info_header:
+      pass
+    elif header.startswith(task_info_header):
+      masked_header = header[task_info_header_len:]
+      if masked_header in accepted_task_info_fields_set:
+        new_headers.append(header)
+    else:
+        new_headers.append(header)
+  return new_headers

--- a/pybossa/exporter/export_helpers.py
+++ b/pybossa/exporter/export_helpers.py
@@ -215,15 +215,15 @@ def browse_tasks_export_count(obj, project_id, expanded, filters):
             sql, dict(project_id=project_id, **filter_params)).scalar()
 
 
-def filter_table_headers(headers, accepted_fields):
+def filter_table_headers(headers, accepted_task_info_fields):
             new_headers = []
-            accepted_fields_set = set(accepted_fields)
+            accepted_task_info_fields_set = set(accepted_task_info_fields)
             for header in headers:
                 if header == 'task__info':
                     pass
                 elif header.startswith('task__info__'):
                     masked_header = header[12:  ]
-                    if masked_header in accepted_fields_set:
+                    if masked_header in accepted_task_info_fields_set:
                         new_headers.append(header)
                 else:
                     new_headers.append(header)

--- a/pybossa/exporter/export_helpers.py
+++ b/pybossa/exporter/export_helpers.py
@@ -224,14 +224,12 @@ def filter_task_info_headers(headers, accepted_task_info_fields=[]):
 
   for header in headers:
     # skip task__info_header
-    if header == task_info_header:
-      pass
-    # check task info headers for accepted fields
-    elif header.startswith(task_info_header):
-      masked_header = header[task_info_header_len:]
-      if masked_header in accepted_task_info_fields_set:
-        new_headers.append(header)
-    # add all headers unrelated to task info
-    else:
-        new_headers.append(header)
+    if header != task_info_header:
+      if header.startswith(task_info_header):
+        masked_header = header[task_info_header_len:]
+        if masked_header in accepted_task_info_fields_set:
+          new_headers.append(header)
+      # add all headers unrelated to task info
+      else:
+          new_headers.append(header)
   return new_headers

--- a/pybossa/exporter/task_csv_export.py
+++ b/pybossa/exporter/task_csv_export.py
@@ -30,7 +30,7 @@ from werkzeug.utils import safe_join, secure_filename
 from pybossa.core import uploader
 from pybossa.exporter.csv_export import CsvExporter
 from pybossa.uploader import local
-from .export_helpers import browse_tasks_export, filter_table_headers
+from .export_helpers import browse_tasks_export, filter_task_info_headers
 
 
 class TaskCsvExporter(CsvExporter):
@@ -169,7 +169,7 @@ class TaskCsvExporter(CsvExporter):
         headers = self._get_all_headers(objs=rows, expanded=expanded, table=ty)
         if (filters and 'display_info_columns' in filters and \
             len(filters['display_info_columns']) > 0):
-            headers = filter_table_headers(headers, filters['display_info_columns'])
+            headers = filter_task_info_headers(headers, filters['display_info_columns'])
 
         formatted_rows = []
         for row in rows:

--- a/pybossa/exporter/task_csv_export.py
+++ b/pybossa/exporter/task_csv_export.py
@@ -30,7 +30,7 @@ from werkzeug.utils import safe_join, secure_filename
 from pybossa.core import uploader
 from pybossa.exporter.csv_export import CsvExporter
 from pybossa.uploader import local
-from .export_helpers import browse_tasks_export
+from .export_helpers import browse_tasks_export, filter_table_headers
 
 
 class TaskCsvExporter(CsvExporter):
@@ -141,7 +141,7 @@ class TaskCsvExporter(CsvExporter):
             for kk, vv, in iterator:
                 yield kk, vv
 
-    def _get_all_headers(self, objs, expanded, table=None):
+    def _get_all_headers(self, objs, expanded, table=None, filters=None):
         """Construct headers to **guarantee** that all headers
         for all tasks are included, regardless of whether
         or not all tasks were imported with the same headers.
@@ -167,6 +167,8 @@ class TaskCsvExporter(CsvExporter):
         objs = browse_tasks_export(ty, project_id, expanded, filters, disclose_gold)
         rows = [obj for obj in objs]
         headers = self._get_all_headers(objs=rows, expanded=expanded, table=ty)
+        if ('display_info_columns' in filters and len(filters['display_info_columns']) > 0):
+            headers = filter_table_headers(headers, filters['display_info_columns'])
 
         formatted_rows = []
         for row in rows:

--- a/pybossa/exporter/task_csv_export.py
+++ b/pybossa/exporter/task_csv_export.py
@@ -141,7 +141,7 @@ class TaskCsvExporter(CsvExporter):
             for kk, vv, in iterator:
                 yield kk, vv
 
-    def _get_all_headers(self, objs, expanded, table=None, filters=None):
+    def _get_all_headers(self, objs, expanded, table=None):
         """Construct headers to **guarantee** that all headers
         for all tasks are included, regardless of whether
         or not all tasks were imported with the same headers.
@@ -167,7 +167,8 @@ class TaskCsvExporter(CsvExporter):
         objs = browse_tasks_export(ty, project_id, expanded, filters, disclose_gold)
         rows = [obj for obj in objs]
         headers = self._get_all_headers(objs=rows, expanded=expanded, table=ty)
-        if ('display_info_columns' in filters and len(filters['display_info_columns']) > 0):
+        if (filters and 'display_info_columns' in filters and \
+            len(filters['display_info_columns']) > 0):
             headers = filter_table_headers(headers, filters['display_info_columns'])
 
         formatted_rows = []

--- a/test/test_jobs/test_export.py
+++ b/test/test_jobs/test_export.py
@@ -18,6 +18,7 @@
 from test import Test, with_context, flask_app
 from test.factories import ProjectFactory, UserFactory, TaskFactory, TaskRunFactory
 from pybossa.jobs import get_export_task_jobs, project_export, export_tasks, export_all_users
+from pybossa.exporter.export_helpers import filter_table_headers
 from unittest.mock import patch
 from nose.tools import assert_raises
 
@@ -130,3 +131,18 @@ class TestExport(Test):
         """Test export_all_users exception handled."""
         with assert_raises(KeyError) as exec:
             export_all_users(None, 'test@test.com')
+
+    @with_context
+    def test_filter_table_headers(self):
+        """Test filter_table_headers filters task__info fields"""
+        input_headers = ['task__calibration', 'task__created', 'task__exported', 'task__id', 'task__info', 'task__info__batch_id', 'task__info__class', 'task__info__document_type', 'task__info__notes', 'task__n_answers', 'task__priority_0', 'task__project_id', 'task__quorum', 'task__state', 'task__user_pref']
+
+        # only task__info__batch_id and task__info__document_type should be present in output headers
+        accepted_task_info_fields = ['batch_id,', 'document_type']
+        output_headers = filter_table_headers(input_headers, accepted_task_info_fields)
+        assert len(output_headers) == 10
+
+        # no task info fields should be present in output headers
+        accepted_task_info_fields = []
+        output_headers = filter_table_headers(input_headers, accepted_task_info_fields)
+        assert len(output_headers) == 8

--- a/test/test_jobs/test_export.py
+++ b/test/test_jobs/test_export.py
@@ -138,11 +138,11 @@ class TestExport(Test):
         input_headers = ['task__calibration', 'task__created', 'task__exported', 'task__id', 'task__info', 'task__info__batch_id', 'task__info__class', 'task__info__document_type', 'task__info__notes', 'task__n_answers', 'task__priority_0', 'task__project_id', 'task__quorum', 'task__state', 'task__user_pref']
 
         # only task__info__batch_id and task__info__document_type should be present in output headers
-        accepted_task_info_fields = ['batch_id,', 'document_type']
+        accepted_task_info_fields = ['batch_id', 'document_type']
         output_headers = filter_table_headers(input_headers, accepted_task_info_fields)
-        assert len(output_headers) == 10
+        assert len(output_headers) == 12
 
         # no task info fields should be present in output headers
         accepted_task_info_fields = []
         output_headers = filter_table_headers(input_headers, accepted_task_info_fields)
-        assert len(output_headers) == 8
+        assert len(output_headers) == 10

--- a/test/test_jobs/test_export.py
+++ b/test/test_jobs/test_export.py
@@ -18,7 +18,7 @@
 from test import Test, with_context, flask_app
 from test.factories import ProjectFactory, UserFactory, TaskFactory, TaskRunFactory
 from pybossa.jobs import get_export_task_jobs, project_export, export_tasks, export_all_users
-from pybossa.exporter.export_helpers import filter_table_headers
+from pybossa.exporter.export_helpers import filter_task_info_headers
 from unittest.mock import patch
 from nose.tools import assert_raises
 
@@ -133,16 +133,16 @@ class TestExport(Test):
             export_all_users(None, 'test@test.com')
 
     @with_context
-    def test_filter_table_headers(self):
-        """Test filter_table_headers filters task__info fields"""
+    def test_filter_task_info_headers(self):
+        """Test filter_task_info_headers filters task__info fields"""
         input_headers = ['task__calibration', 'task__created', 'task__exported', 'task__id', 'task__info', 'task__info__batch_id', 'task__info__class', 'task__info__document_type', 'task__info__notes', 'task__n_answers', 'task__priority_0', 'task__project_id', 'task__quorum', 'task__state', 'task__user_pref']
 
         # only task__info__batch_id and task__info__document_type should be present in output headers
         accepted_task_info_fields = ['batch_id', 'document_type']
-        output_headers = filter_table_headers(input_headers, accepted_task_info_fields)
+        output_headers = filter_task_info_headers(input_headers, accepted_task_info_fields)
         assert len(output_headers) == 12
 
         # no task info fields should be present in output headers
         accepted_task_info_fields = []
-        output_headers = filter_table_headers(input_headers, accepted_task_info_fields)
+        output_headers = filter_task_info_headers(input_headers, accepted_task_info_fields)
         assert len(output_headers) == 10


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-7364](https://jira.prod.bloomberg.com/browse/RDISCROWD-7364)*

**Describe your changes**
 - Update task csv export: when `display_info_columns` is in the request body, filter the `task__info` fields to only contain fields in `display_info_columns`.

**Testing performed**
tested locally

