### PR TITLE
RDISCROWD-7701: Add dup_checksum col and associated index to task table

### DIFF
--- a/alembic/versions/d4363025a58c_add_dup_checksum_col_to_task.py
+++ b/alembic/versions/d4363025a58c_add_dup_checksum_col_to_task.py
@@ -1,0 +1,23 @@
+"""add dup_checksum_col to task
+
+Revision ID: d4363025a58c
+Revises: c7d7de1f09f6
+Create Date: 2024-11-27 20:22:48.450611
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd4363025a58c'
+down_revision = 'c7d7de1f09f6'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('task', sa.Column('dup_checksum', sa.String, nullable=True))
+    op.create_index('task_project_id_dup_checksum', 'task', ['project_id', 'dup_checksum'])
+
+def downgrade():
+    op.drop_column('task', 'dup_checksum')
+    op.drop_index('task_project_id_dup_checksum', table_name='task')

--- a/alembic/versions/d4363025a58c_add_dup_checksum_col_to_task.py
+++ b/alembic/versions/d4363025a58c_add_dup_checksum_col_to_task.py
@@ -16,8 +16,10 @@ import sqlalchemy as sa
 
 def upgrade():
     op.add_column('task', sa.Column('dup_checksum', sa.String, nullable=True))
-    op.create_index('task_project_id_dup_checksum', 'task', ['project_id', 'dup_checksum'])
+    op.execute('COMMIT')
+    op.execute('CREATE INDEX CONCURRENTLY IF NOT EXISTS task_project_id_dup_checksum ON task (project_id, dup_checksum);')
 
 def downgrade():
     op.drop_column('task', 'dup_checksum')
-    op.drop_index('task_project_id_dup_checksum', table_name='task')
+    op.execute('COMMIT')
+    op.execute('DROP INDEX CONCURRENTLY IF EXISTS task_project_id_dup_checksum;')


### PR DESCRIPTION
Upgrade brings in new column and indexes
```
$ alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade c7d7de1f09f6 -> d4363025a58c, add dup_checksum_col to task
```
Downgrade removes new column and indexes
```
$ alembic downgrade c7d7de1f09f6
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade d4363025a58c -> c7d7de1f09f6, add dup_checksum_col to task
```