### PR TITLE
RDISCROWD-7813 - file size limit

### DIFF
--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -964,7 +964,8 @@ def export_tasks(current_user_email_addr, short_name,
             max_s3_upload_size = current_app.config.get('EXPORT_MAX_UPLOAD_SIZE', float('Inf'))
 
             if len(content) > max_s3_upload_size:
-                current_app.logger.info("task export exceeded max size. Project ID: %s, Size: %d", project.id, len(content))
+                current_app.logger.info("Task export project id %s: Task export exceeded max size %d, actual size: %d",
+                                        project.id, max_s3_upload_size, len(content))
                 mail_dict['subject'] = 'Data export exceeded max file size: {0}'.format(project.name)
                 msg = '<p>Your export exceeded the maximum file upload size. ' + \
                     'Please try again with a smaller subset of tasks'
@@ -978,14 +979,15 @@ def export_tasks(current_user_email_addr, short_name,
                 key.set_contents_from_string(content)
                 expires_in = current_app.config.get('EXPORT_EXPIRY', 12 * 3600)
                 url = key.generate_url(expires_in)
-                current_app.logger.info("uploading to s3 done for project %s", project.id)
+                current_app.logger.info("Task export project id %s: Exported file uploaded to s3 %s",
+                                        project.id, url)
                 msg = '<p>You can download your file <a href="{}">here</a>.</p>'.format(url)
             else:
                 msg = '<p>Your exported data is attached.</p>'
                 mail_dict['attachments'] = [Attachment(filename, "application/zip", content)]
+                current_app.logger.info("Task export project id %s. Exported file attached to email to send",
+                                        project.id)
 
-            current_app.logger.info(
-                'Tasks export completed - Project: %s', project.name)
         else:
             # Failure email
             mail_dict['subject'] = 'Data export failed for your project: {0}'.format(project.name)

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -969,7 +969,7 @@ def export_tasks(current_user_email_addr, short_name,
                 msg = '<p>Your export exceeded the maximum file upload size. ' + \
                     'Please try again with a smaller subset of tasks'
             elif len(content) > max_email_size and bucket_name:
-                current_app.logger.info(f"uploading exporting tasks to s3 for project {project.id}")
+                current_app.logger.info("uploading exporting tasks to s3 for project, %s", project.id)
                 conn_kwargs = current_app.config.get('S3_EXPORT_CONN', {})
                 conn = create_connection(**conn_kwargs)
                 bucket = conn.get_bucket(bucket_name, validate=False)
@@ -978,14 +978,14 @@ def export_tasks(current_user_email_addr, short_name,
                 key.set_contents_from_string(content)
                 expires_in = current_app.config.get('EXPORT_EXPIRY', 12 * 3600)
                 url = key.generate_url(expires_in)
-                current_app.logger.info(f"uploading to s3 done for project {project.id}")
+                current_app.logger.info("uploading to s3 done for project %s", project.id)
                 msg = '<p>You can download your file <a href="{}">here</a>.</p>'.format(url)
             else:
                 msg = '<p>Your exported data is attached.</p>'
                 mail_dict['attachments'] = [Attachment(filename, "application/zip", content)]
 
             current_app.logger.info(
-                'Tasks export completed - Project: {0}'.format(project.name))
+                'Tasks export completed - Project: %s', project.name)
         else:
             # Failure email
             mail_dict['subject'] = 'Data export failed for your project: {0}'.format(project.name)
@@ -1000,14 +1000,14 @@ def export_tasks(current_user_email_addr, short_name,
         message = Message(**mail_dict)
         mail.send(message)
         current_app.logger.info(
-            'Email sent successfully - Project: {0}'.format(project.name))
+            'Email sent successfully - Project: %s', project.name)
         job_response = '{0} {1} file was successfully exported for: {2}'
         return job_response.format(
                 ty.capitalize(), filetype.upper(), project.name)
     except Exception as e:
         current_app.logger.exception(
-                'Export email failed - Project: {0}, exception: {1}'
-                .format(project.name, str(e)))
+                'Export email failed - Project: %s, exception: %s',
+                project.name, str(e))
         subject = 'Email delivery failed for your project: {0}'.format(project.name)
         msg = 'There was an error when attempting to deliver your data export via email.'
         body = 'Hello,\n\n' + msg + '\n\nThe {0} team.'

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -964,12 +964,10 @@ def export_tasks(current_user_email_addr, short_name,
             max_s3_upload_size = current_app.config.get('EXPORT_MAX_UPLOAD_SIZE', float('Inf'))
 
             if len(content) > max_s3_upload_size:
-                current_app.logger.info(f"task export exceeded max size. Project ID: {project.id}, Size: {len(content)}")
+                current_app.logger.info("task export exceeded max size. Project ID: %s, Size: %d", project.id, len(content))
                 mail_dict['subject'] = 'Data export exceeded max file size: {0}'.format(project.name)
                 msg = '<p>Your export exceeded the maximum file upload size. ' + \
-                    'Please try again with a smaller subset of tasks or ' + \
-                    'reach out to a {0} administrator for help.</p>'
-                msg = msg.format(current_app.config.get('BRAND'))
+                    'Please try again with a smaller subset of tasks'
             elif len(content) > max_email_size and bucket_name:
                 current_app.logger.info(f"uploading exporting tasks to s3 for project {project.id}")
                 conn_kwargs = current_app.config.get('S3_EXPORT_CONN', {})

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -963,7 +963,7 @@ def export_tasks(current_user_email_addr, short_name,
             max_email_size = current_app.config.get('EXPORT_MAX_EMAIL_SIZE', float('Inf'))
             max_s3_upload_size = current_app.config.get('EXPORT_MAX_UPLOAD_SIZE', float('Inf'))
 
-            if len(content) > max_s3_upload_size:
+            if len(content) > max_s3_upload_size and bucket_name:
                 current_app.logger.info("Task export project id %s: Task export exceeded max size %d, actual size: %d",
                                         project.id, max_s3_upload_size, len(content))
                 mail_dict['subject'] = 'Data export exceeded max file size: {0}'.format(project.name)

--- a/pybossa/settings_local.py.tmpl
+++ b/pybossa/settings_local.py.tmpl
@@ -365,6 +365,12 @@ TASK_REQUIRED_FIELDS = {
 # TASK_RUN_CSV_EXPORT_INFO_KEY = 'key2'
 # RESULT_CSV_EXPORT_INFO_KEY = 'key3'
 
+# Specify export max content sizes (json or csv)
+# max size of email attachment
+EXPORT_MAX_EMAIL_SIZE = 6 * 1024 * 1024 # 6 MB
+# max size of s3 upload
+EXPORT_MAX_UPLOAD_SIZE = 1024 * 1024 * 1024 # 1 GB
+
 # A 32 char string for AES encryption of public IPs.
 # NOTE: this is really important, don't use the following one
 # as anyone with the source code of pybossa will be able to reverse


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-7813](https://jira.prod.bloomberg.com/browse/RDISCROWD-7813)*

**Describe your changes**
change behavior for task exports:
  - if content size larger than `EXPORT_MAX_UPLOAD_SIZE`, don't upload and send error email
  - else if larger than `EXPORT_MAX_EMAIL_SIZE`, upload file and send link in email
  - else, file is small, so send as email attachment
