### PR TITLE
RDISCROWD-7852 project routes redirect to 423 when user not allowed

### DIFF
--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1265,7 +1265,7 @@ def delete_autoimporter(short_name):
 @login_required
 def password_required(short_name):
     project, owner, ps = project_by_shortname(short_name)
-    ensure_authorized_to('read', project)
+    ensure_authorized_to('read', project, forbidden_code_override=423)
     form = PasswordForm(request.form)
 
     # if is_own_url_or_else returns None, use the default url.

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1324,7 +1324,7 @@ def task_presenter(short_name, task_id, task_submitter_id=None):
     """
     mode = request.args.get('mode')
     project, owner, ps = project_by_shortname(short_name)
-    ensure_authorized_to('read', project)
+    ensure_authorized_to('read', project, forbidden_code_override=423)
     task = task_repo.get_task(id=task_id)
     if task is None:
         raise abort(404)
@@ -1333,7 +1333,7 @@ def task_presenter(short_name, task_id, task_submitter_id=None):
         if redirect_to_password:
             return redirect_to_password
     else:
-        ensure_authorized_to('read', project)
+        ensure_authorized_to('read', project, forbidden_code_override=423)
 
     if current_user.is_anonymous:
         if not project.allow_anonymous_contributors:
@@ -1465,7 +1465,7 @@ def presenter(short_name):
     project, owner, ps = project_by_shortname(short_name)
     project.timeout = project.info.get('timeout', DEFAULT_TASK_TIMEOUT)
 
-    ensure_authorized_to('read', project)
+    ensure_authorized_to('read', project, forbidden_code_override=423)
 
     if project.needs_password():
         redirect_to_password = _check_if_redirect_to_password(project)
@@ -1532,7 +1532,7 @@ def presenter(short_name):
 @blueprint.route('/<short_name>/tutorial')
 def tutorial(short_name):
     project, owner, ps = project_by_shortname(short_name)
-    ensure_authorized_to('read', project)
+    ensure_authorized_to('read', project, forbidden_code_override=423)
     title = project_title(project, "Tutorial")
 
     if project.needs_password():
@@ -1631,7 +1631,7 @@ def _get_locks(project_id, task_id):
 @login_required
 def tasks(short_name):
     project, owner, ps = project_by_shortname(short_name)
-    ensure_authorized_to('read', project)
+    ensure_authorized_to('read', project, forbidden_code_override=423)
     title = project_title(project, "Tasks")
 
     if project.needs_password():
@@ -1671,7 +1671,7 @@ def tasks(short_name):
 @login_required
 def tasks_browse(short_name, page=1, records_per_page=None):
     project, owner, ps = project_by_shortname(short_name)
-    ensure_authorized_to('read', project)
+    ensure_authorized_to('read', project, forbidden_code_override=423)
 
     title = project_title(project, "Tasks")
     pro = pro_features()
@@ -2584,7 +2584,7 @@ def task_settings(short_name):
     """Settings page for tasks of the project"""
     project, owner, ps = project_by_shortname(short_name)
 
-    ensure_authorized_to('read', project)
+    ensure_authorized_to('read', project, forbidden_code_override=423)
     ensure_authorized_to('update', project)
     pro = pro_features()
     project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
@@ -2815,7 +2815,7 @@ def task_timeout(short_name):
     title = project_title(project, gettext('Timeout'))
     form = TaskTimeoutForm(request.body) if request.data else TaskTimeoutForm()
 
-    ensure_authorized_to('read', project)
+    ensure_authorized_to('read', project, forbidden_code_override=423)
     ensure_authorized_to('update', project)
     pro = pro_features()
     if request.method == 'GET':

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3586,7 +3586,7 @@ class TestWeb(web.Helper):
 
     @with_context
     def test_task_presenter_with_allow_taskrun_edit_raises_forbidden(self):
-        """Test WEB with taskrun edit permitted, task_submitter_id not passed raises 403"""
+        """Test WEB with taskrun edit permitted, task_submitter_id not passed raises 423"""
         self.register()
         self.signin()
         self.create()
@@ -3613,7 +3613,7 @@ class TestWeb(web.Helper):
         user_repo.save(regular_user)
         self.signin(email=regular_user.email_addr, password='1234')
         res = self.app.get('/project/%s/task/%s' % (project_short_name, task.id))
-        assert res.status_code == 403, res.status_code
+        assert res.status_code == 423, res.status_code
 
     @with_context
     @patch('pybossa.auth.project.ProjectAuth._read', return_value=True)
@@ -7762,7 +7762,7 @@ class TestWeb(web.Helper):
         self.signin(email="juan@example.com", password="p4ssw0rd")
         res = self.app.get(url, follow_redirects=True)
         err_msg = "User should not be allowed to access this page"
-        assert res.status_code == 403, err_msg
+        assert res.status_code == 423, err_msg
         self.signout()
 
         # As an anonymous user


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-7852](https://jira.prod.bloomberg.com/browse/RDISCROWD-7852)

**Describe your changes**
Redirect to 423 error page when common project API routes are accessed and user does not have access rights.

 - `/<short_name>/password`
 - `/<short_name>/task/<int:task_id>`
 - `/<short_name>/newtask`
 - `/<short_name>/tasks/`
 - `/<short_name>/tasks/browse`
 - `/<short_name>/tasks/settings`
 - `/<short_name>/tasks/timeout`

Upon improper credentials. , routes workers could have access to return 423, while routes only admins have access to still return 403 (like `/<short_name>/clone`, `/<short_name>/delete`, etc)