### PR TITLE
RDISCROWD-7842 add project clone API endpoint

### DIFF
--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -1049,6 +1049,10 @@ def project_clone(project_id=None, short_name=None):
     # User must post a payload
     if not payload:
         return abort(400)
+    # check required fields
+    if not (payload.get('input_data_class') and payload.get('output_data_class') \
+        and payload.get('name') and payload.get('short_name')):
+        return abort(400)
 
     project.input_data_class = project.info.get('data_classification', {}).get('input_data')
     project.output_data_class = project.info.get('data_classification', {}).get('output_data')

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -1034,16 +1034,14 @@ def project_clone(project_id=None, short_name=None):
 
     if current_user.is_anonymous:
         return abort(401)
-    if not (project_id or short_name):
-        return abort(404)
     if short_name:
         project = project_repo.get_by_shortname(short_name)
-    elif project_id:
+    else:
         project = project_repo.get(project_id)
     if not project:
         return abort(404)
     if not (current_user.admin or (current_user.subadmin and current_user.id in project.owners_ids)):
-        return abort(401)
+        return abort(403)
 
     payload = json.loads(request.form['request_json']) if 'request_json' in request.form else request.json
 

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -1032,7 +1032,6 @@ def project_clone(project_id=None, short_name=None):
 
     if current_user.is_anonymous:
         return abort(401)
-
     if not (project_id or short_name):
         return abort(404)
     if short_name:
@@ -1041,16 +1040,13 @@ def project_clone(project_id=None, short_name=None):
         project = project_repo.get(project_id)
     if not project:
         return abort(404)
-
     if not (current_user.admin or (current_user.subadmin and current_user.id in project.owners_ids)):
         return abort(401)
 
     payload = json.loads(request.form['request_json']) if 'request_json' in request.form else request.json
-    # User must post a payload
-    if not payload:
-        return abort(400)
+
     # check required fields
-    if not (payload.get('input_data_class') and payload.get('output_data_class') \
+    if not (payload and payload.get('input_data_class') and payload.get('output_data_class') \
         and payload.get('name') and payload.get('short_name')):
         return abort(400)
 

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -1060,25 +1060,20 @@ def project_clone(project_id=None, short_name=None):
     try:
         new_project = clone_project(project, payload)
         current_app.logger.info(
-                            current_user,
-                            'clone',
-                            'project.clone',
-                            'old project id: %s'.format(project.id),
-                            'new project id: %s'.format(new_project.id)
-                            )
-
+                'project.clone: user: %s, old project id: %s, new project id: %s'.format(
+                    current_user.id,
+                    project.id,
+                    new_project.id
+                )
+            )
         return Response(json.dumps(new_project.dictize()), status=200, mimetype="application/json")
-    except DBIntegrityError as e:
-        current_app.logger.error(
-            'clone',
-            'project.clone',
-            e.message
-            )
-        raise abort(400, "Duplicate project keys.")
+
     except Exception as e:
+        msg = e.message if hasattr(e, 'message') else str(e)
         current_app.logger.error(
-            'clone',
-            'project.clone',
-            str(e)
+            'project.clone: user: %s, msg: %s'.format(
+            current_user.id,
+            msg
             )
-        raise abort(400, "Invalid project metadata.")
+        )
+        raise abort(400, f"Error cloning project - {e}")

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -1043,7 +1043,7 @@ def project_clone(project_id=None, short_name=None):
     if not (current_user.admin or (current_user.subadmin and current_user.id in project.owners_ids)):
         return abort(403)
 
-    payload = json.loads(request.form['request_json']) if 'request_json' in request.form else request.json
+    payload = request.json
 
     if not (payload and payload.get('input_data_class') and payload.get('output_data_class') \
         and payload.get('name') and payload.get('short_name')):

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -1049,13 +1049,10 @@ def project_clone(project_id=None, short_name=None):
 
     if not (payload and payload.get('input_data_class') and payload.get('output_data_class') \
         and payload.get('name') and payload.get('short_name')):
-        return abort(400)
+        return abort(400, 'Request is missing one or more of the required fields: name, short_name, input_data_class, output_data_class')
 
     if not payload.get('password'):
         payload['password'] = ""
-
-    project.input_data_class = project.info.get('data_classification', {}).get('input_data')
-    project.output_data_class = project.info.get('data_classification', {}).get('output_data')
 
     try:
         new_project = clone_project(project, payload)

--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -33,6 +33,7 @@ import jwt
 from flask import Blueprint, request, abort, Response, make_response
 from flask import current_app
 from flask_login import current_user, login_required
+from flasgger import swag_from
 from time import time
 from datetime import datetime, timedelta
 from werkzeug.exceptions import NotFound
@@ -1030,6 +1031,7 @@ def get_project_progress(project_id=None, short_name=None):
 @blueprint.route('/project/<int:project_id>/clone',  methods=['POST'])
 @blueprint.route('/project/<short_name>/clone',  methods=['POST'])
 @login_required
+@swag_from('docs/project/project_clone.yaml')
 def project_clone(project_id=None, short_name=None):
 
     if current_user.is_anonymous:

--- a/pybossa/api/docs/project/project_clone.yaml
+++ b/pybossa/api/docs/project/project_clone.yaml
@@ -26,6 +26,10 @@ definitions:
         type: string
         description: Password for the new project (optional)
         example: mypassword123
+      copy_users:
+        type: boolean
+        description: Keep same list of assigned users (optional, default=false)
+        example: false
     required:
       - input_data_class
       - output_data_class

--- a/pybossa/api/docs/project/project_clone.yaml
+++ b/pybossa/api/docs/project/project_clone.yaml
@@ -1,0 +1,69 @@
+Clone a project by project ID or short name
+---
+tags:
+  - name: project
+definitions:
+  CloneProjectRequestBody:
+    type: object
+    properties:
+      input_data_class:
+        type: string
+        description: Classification of input data
+        example: L4 - Public Internal Data
+      output_data_class:
+        type: string
+        description: Classification of output data
+        example: L4 - Public Internal Data
+      name:
+        type: string
+        description: Name of the new project
+        example: My Project Clone
+      short_name:
+        type: string
+        description: Short name of the new project
+        example: myprojectclone
+      password:
+        type: string
+        description: Password for the new project (optional)
+        example: mypassword123
+    required:
+      - input_data_class
+      - output_data_class
+      - name
+      - short_name
+parameters:
+  - name: project_id
+    in: path
+    type: integer
+    required: false
+    description: The project ID to clone
+  - name: short_name
+    in: path
+    type: string
+    required: false
+    description: The short name of the project to clone
+  - name: payload
+    in: body
+    required: true
+    description: Information required to clone the project
+    schema:
+      $ref: '#/definitions/CloneProjectRequestBody'
+      example:
+        input_data_class: L4 - Public Internal Data
+        output_data_class: L4 - Public Internal Data
+        name: My Project Clone
+        short_name: myprojectclone
+        password: mypassword
+responses:
+  200:
+    description: New cloned project information
+    schema:
+      $ref: '#definitions/Project'
+  400:
+    description: Bad request - Missing or invalid payload
+  401:
+    description: Unauthorized - User is not logged in
+  403:
+    description: Forbidden - User does not have permission to clone project
+  404:
+    description: Not found - Project does not exist

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -2576,32 +2576,38 @@ class TestProjectAPI(TestAPI):
         headers = [('Authorization', subadminowner.api_key)]
 
         # check 404 response when no project param
-        res = self.app.post('/api/project//clone', follow_redirects=True, headers=headers)
+        res = self.app.post('/api/project//clone', headers=headers)
         error_msg = "A valid project must be used"
         assert res.status_code == 404, error_msg
 
         # check 404 response when the project doesn't exist
-        res = self.app.post('/api/project/9999/clone', follow_redirects=True, headers=headers)
+        res = self.app.post('/api/project/9999/clone', headers=headers)
         error_msg = "A valid project must be used"
         assert res.status_code == 404, error_msg
 
         # check 404 response when the project doesn't exist
-        res = self.app.post('/api/project/xyz/clone', follow_redirects=True, headers=headers)
+        res = self.app.post('/api/project/xyz/clone', headers=headers)
         error_msg = "A valid project must be used"
         assert res.status_code == 404, error_msg
 
         # check 401 response when user not logged in
-        res = self.app.post('/api/project/xyz/clone', follow_redirects=True)
+        res = self.app.post(f'/api/project/{short_name}/clone')
         error_msg = "User must be logged in"
         assert res.status_code == 401, error_msg
 
         # check 400 response when user does not post a payload
-        res = self.app.post(f'/api/project/{short_name}/clone', follow_redirects=True)
+        res = self.app.post(f'/api/project/{short_name}/clone', headers=headers)
+        error_msg = "User must post valid payload"
+        assert res.status_code == 400, error_msg
+
+        # check 400 response when user posts payload missed req fields
+        data = { "name": "Test Project Clone"}
+        res = self.app.post(f'/api/project/{short_name}/clone', headers=headers, data=json.dumps(data))
         error_msg = "User must post valid payload"
         assert res.status_code == 400, error_msg
 
         # check 401 response when use is not authorized
         headers = [('Authorization', reguser.api_key)]
-        res = self.app.post('/api/project/xyz/clone', follow_redirects=True)
+        res = self.app.post('/api/project/xyz/clone', headers=headers)
         error_msg = "User must have permissions"
         assert res.status_code == 401, error_msg

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -2561,6 +2561,18 @@ class TestProjectAPI(TestAPI):
         assert res.json == dict(n_completed_tasks=3, n_tasks=3)
 
 
+    def _setup_project(self, short_name, owner):
+        task_presenter = 'test; url="project/oldname/" pybossa.run("oldname"); test;'
+        return ProjectFactory.create(id=40,
+                                        short_name=short_name,
+                                        info={'task_presenter': task_presenter,
+                                              'quiz': {'test': 123},
+                                              'enrichments': [{'test': 123}],
+                                              'passwd_hash': 'testpass',
+                                              'ext_config': {'test': 123}
+                                            },
+                                        owner=owner)
+
     @with_context
     def test_clone_project_access(self):
         """Test API clone project access control"""
@@ -2570,8 +2582,7 @@ class TestProjectAPI(TestAPI):
         make_subadmin(subadmin)
 
         short_name = "testproject"
-
-        project = ProjectFactory.create(owner=subadminowner, short_name=short_name)
+        self._setup_project(short_name, subadminowner)
         headers = [('Authorization', subadminowner.api_key)]
 
         # check 404 response when no project param
@@ -2610,8 +2621,7 @@ class TestProjectAPI(TestAPI):
         make_subadmin(subadminowner)
 
         short_name = "testproject"
-
-        project = ProjectFactory.create(owner=subadminowner, short_name=short_name)
+        self._setup_project(short_name, subadminowner)
         headers = [('Authorization', subadminowner.api_key)]
 
         # check 400 response when user does not post a payload
@@ -2650,18 +2660,7 @@ class TestProjectAPI(TestAPI):
         make_subadmin(subadminowner)
 
         short_name = "testproject"
-
-        task_presenter = 'test; url="project/oldname/" pybossa.run("oldname"); test;'
-        project = ProjectFactory.create(id=40,
-                                        short_name=short_name,
-                                        info={'task_presenter': task_presenter,
-                                              'quiz': {'test': 123},
-                                              'enrichments': [{'test': 123}],
-                                              'passwd_hash': 'testpass',
-                                              'ext_config': {'test': 123}
-                                            },
-                                        owner=subadminowner)
-
+        self._setup_project(short_name, subadminowner)
         headers = [('Authorization', subadminowner.api_key)]
 
         data = {'short_name': 'newname', 'name': 'newname', 'password': 'Test123', 'input_data_class': 'L4 - public','output_data_class': 'L4 - public'}
@@ -2681,16 +2680,7 @@ class TestProjectAPI(TestAPI):
         make_subadmin(subadminowner)
 
         short_name = "testproject"
-
-        task_presenter = 'test; url="project/oldname/" pybossa.run("oldname"); test;'
-        project = ProjectFactory.create(id=40,
-                                        short_name=short_name,
-                                        info={'task_presenter': task_presenter,
-                                              'quiz': {'test': 123},
-                                              'enrichments': [{'test': 123}],
-                                              'ext_config': {'test': 123}
-                                            },
-                                        owner=subadminowner)
+        self._setup_project(short_name, subadminowner)
 
         headers = [('Authorization', subadminowner.api_key)]
 

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -2559,3 +2559,31 @@ class TestProjectAPI(TestAPI):
         res = self.app.get('/api/project/testproject/projectprogress', follow_redirects=True, headers=headers)
         assert res.status_code == 200
         assert res.json == dict(n_completed_tasks=3, n_tasks=3)
+
+
+    @with_context
+    def test_clone_project(self):
+        """Test API clone project works"""
+        [admin, subadminowner, subadmin, reguser] = UserFactory.create_batch(4)
+        make_admin(admin)
+        make_subadmin(subadminowner)
+        make_subadmin(subadmin)
+
+        project = ProjectFactory.create(owner=subadminowner, short_name="testproject")
+        tasks = TaskFactory.create_batch(3, project=project)
+        headers = [('Authorization', subadminowner.api_key)]
+
+        # check 404 response when no project param
+        res = self.app.post('/api/project//clone', follow_redirects=True, headers=headers)
+        error_msg = "A valid project must be used"
+        assert res.status_code == 404, error_msg
+
+        # check 404 response when the project doesn't exist
+        res = self.app.post('/api/project/9999/clone', follow_redirects=True, headers=headers)
+        error_msg = "A valid project must be used"
+        assert res.status_code == 404, error_msg
+
+        # check 404 response when the project doesn't exist
+        res = self.app.post('/api/project/xyz/clone', follow_redirects=True, headers=headers)
+        error_msg = "A valid project must be used"
+        assert res.status_code == 404, error_msg

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -2654,7 +2654,7 @@ class TestProjectAPI(TestAPI):
 
 
     @with_context
-    def test_clone_project(self):
+    def test_clone_project_success(self):
         """Test API clone project success state"""
         from pybossa.view.projects import data_access_levels
 
@@ -2676,7 +2676,7 @@ class TestProjectAPI(TestAPI):
     @with_context
     @patch('pybossa.api.clone_project')
     def test_clone_project_error(self, clone_project):
-        """Test API clone project success state"""
+        """Test API clone project error when cloning project"""
         from pybossa.view.projects import data_access_levels
 
         clone_project.side_effect = Exception("Project clone error!")
@@ -2696,7 +2696,7 @@ class TestProjectAPI(TestAPI):
 
 
     @with_context
-    def test_clone_project_by_id(self):
+    def test_clone_project_by_id_success(self):
         """Test API clone project by id success state"""
         from pybossa.view.projects import data_access_levels
 

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -2590,11 +2590,6 @@ class TestProjectAPI(TestAPI):
         error_msg = "A valid project must be used"
         assert res.status_code == 404, error_msg
 
-        # check 401 response when user not logged in
-        res = self.app.post(f'/api/project/{short_name}/clone')
-        error_msg = "User must be logged in"
-        assert res.status_code == 401, error_msg
-
         # check 400 response when user does not post a payload
         res = self.app.post(f'/api/project/{short_name}/clone', headers=headers)
         error_msg = "User must post valid payload"
@@ -2608,6 +2603,6 @@ class TestProjectAPI(TestAPI):
 
         # check 401 response when use is not authorized
         headers = [('Authorization', reguser.api_key)]
-        res = self.app.post('/api/project/xyz/clone', headers=headers)
+        res = self.app.post(f'/api/project/{short_name}/clone', headers=headers)
         error_msg = "User must have permissions"
         assert res.status_code == 401, error_msg


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-7842](https://jira.prod.bloomberg.com/browse/RDISCROWD-7842)*

**Describe your changes**
 add routes for cloning a project, with the same functionality as the UI at `/project/<short_name>clone`
1.  POST `/api/project/<short_name>/clone`
2. POST `/api/project/<project_id>/clone`

body:
```
{
copy_users: bool (default= false),
name: str,
short_name: str,
input_data_class: str,
output_data_class: str
password: str
}
```
`name`, `short_name`, `input_data_class`, and `output_data_class` are all required fields.