### PR TITLE
RDISCROWD-7875 - fix bug where config is overwritten

### DIFF
--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -24,6 +24,7 @@ import math
 import requests
 from io import StringIO
 import six
+import copy
 from pybossa.cache.helpers import n_unexpired_gold_tasks, n_priority_x_tasks
 from flask import Blueprint, request, url_for, flash, redirect, abort, Response, current_app
 from flask import render_template, render_template_string, make_response, session
@@ -3705,7 +3706,7 @@ def project_config(short_name):
                                                             owner,
                                                             current_user,
                                                             ps)
-    forms = current_app.config.get('EXTERNAL_CONFIGURATIONS_VUE', {})
+    forms = copy.deepcopy(current_app.config.get('EXTERNAL_CONFIGURATIONS_VUE', {}))
     remove_restricted_keys(forms)
 
     def generate_input_forms_and_external_config_dict():


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-7875*

## Bug:
The authorized services form was randomly appearing and disappearing between page refreshes.

## Cause:
This [line](https://github.com/bloomberg/pybossa/blob/094984e46b05fd94ae155c1bff4e179872748c54/pybossa/view/projects.py#L3694) was overwriting `EXTERNAL_CONFIGURATIONS_VUE` and removing the `authorized_services` key when the user was not an admin. And when another user who was an admin loaded the config, the app would read from the same app context and `EXTERNAL_CONFIGURATIONS_VUE` would not have that key anymore.

## Solution
Deep copy the config before mutating it.