### PR TITLE
RDISCROWD-7704: Update task with checksum value

### DIFF
--- a/pybossa/model/task.py
+++ b/pybossa/model/task.py
@@ -17,6 +17,7 @@
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 
 from sqlalchemy import Integer, Boolean, Float, UnicodeText, Text, DateTime
+from sqlalchemy import String
 import sqlalchemy
 from sqlalchemy.schema import Column, ForeignKey, Index
 from sqlalchemy.orm import relationship, backref
@@ -65,6 +66,8 @@ class Task(db.Model, DomainObject):
     gold_answers = Column(JSONB)
     #: Task.expiration field to determine when a task should no longer be scheduled. As UTC timestamp without timezone
     expiration = Column(DateTime, nullable=True)
+    #: Task.dup_checksum field to contain checksum for duplicate check
+    dup_checksum = Column(String(64), nullable=True)
 
     task_runs = relationship(TaskRun, cascade='all, delete, delete-orphan', backref='task')
 

--- a/pybossa/repositories/task_repository.py
+++ b/pybossa/repositories/task_repository.py
@@ -185,9 +185,7 @@ class TaskRepository(Repository):
             # set task default expiration
             if element.__class__.__name__ == "Task":
                 element.expiration = get_task_expiration(element.expiration, make_timestamp())
-                checksum = generate_checksum(element)
-                current_app.logger.info("Project %d duplicate checksum %s", element.project_id, checksum)
-                # element.checksum = generate_checksum(element)   TODO: upon task table updated
+                element.dup_checksum = generate_checksum(element)
             self.db.session.add(element)
             self.db.session.commit()
             if clean_project:

--- a/pybossa/task_creator_helper.py
+++ b/pybossa/task_creator_helper.py
@@ -231,4 +231,6 @@ def generate_checksum(task):
     current_app.logger.info("Project %d duplicate check fields %s", task.project_id, str(list(checksum_fields)))
     checksum = hashlib.sha256()
     checksum.update(json.dumps(checksum_payload, sort_keys=True).encode("utf-8"))
-    return checksum.hexdigest()
+    checksum_value = checksum.hexdigest()
+    current_app.logger.info("Project %d duplicate checksum %s", project.id, checksum_value)
+    return checksum_value

--- a/test/test_exporter/test_task_csv_exporter.py
+++ b/test/test_exporter/test_task_csv_exporter.py
@@ -154,7 +154,7 @@ class TestExporters(Test):
 
         expected_headers = ['info', 'fav_user_ids', 'user_pref', 'n_answers', 'quorum', 'calibration',
             'created', 'state', 'gold_answers_best_job', 'gold_answers_best_boss', 'exported',
-            'project_id', 'id', 'priority_0', 'expiration', 'worker_pref', 'worker_filter']
+            'project_id', 'id', 'priority_0', 'expiration', 'worker_pref', 'worker_filter', 'dup_checksum']
         obj_keys = list(task1_data.keys())
 
         self._compare_object_keys(obj_keys, expected_headers)
@@ -163,7 +163,7 @@ class TestExporters(Test):
 
         expected_headers = ['info', 'fav_user_ids', 'user_pref', 'n_answers', 'quorum', 'calibration',
             'created', 'state', 'gold_answers', 'exported', 'project_id', 'id', 'priority_0', 'expiration',
-            'worker_pref', 'worker_filter']
+            'worker_pref', 'worker_filter', 'dup_checksum']
         obj_keys = list(task2_data.keys())
 
         self._compare_object_keys(obj_keys, expected_headers)

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -10386,8 +10386,16 @@ class TestWeb(web.Helper):
             project=project,
             info={"a": 1, "b": 2, "c": 3}
         )
+        # confirm task payload populated with checksum generated
+        task.dup_checksum == expected_checksum
         checksum = generate_checksum(task)
         assert checksum == expected_checksum
+
+        # project w/o duplicate checksum configured gets
+        # tasks created with null checksum value
+        project2 = ProjectFactory.create(owner=subadmin, info={"x": 123}, short_name="xyz")
+        task2 = TaskFactory.create(project=project2, info={"a": 1, "b": 2, "c": 3})
+        assert task2.dup_checksum == None
 
     @with_context
     @patch("pybossa.task_creator_helper.get_encryption_key")


### PR DESCRIPTION
* Add column dup_checksum to task model class
* As SHA 256 will be always 64 hex characters, restrict task.dup_checksum to `String(64)`
* Upon generating checksum based on project configuration, set checksum value into task table.