### PR TITLE
RDISCROWD-7895 custom error messages

### DIFF
--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -552,34 +552,39 @@ def setup_error_handlers(app):
     """Setup error handlers."""
     @app.errorhandler(400)
     def _bad_request(e):
-        app.logger.exception('Bad request')
+        msg = str(e)
+        app.logger.exception(f'Bad request: {msg}')
         response = dict(template='400.html', code=400,
-                        description=BADREQUEST)
+                        description=msg if msg else BADREQUEST)
         return handle_content_type(response)
 
     @app.errorhandler(404)
     def _page_not_found(e):
+        msg = str(e)
         response = dict(template='404.html', code=404,
-                        description=NOTFOUND)
+                        description=msg if msg else NOTFOUND)
         return handle_content_type(response)
 
     @app.errorhandler(500)
     def _server_error(e):  # pragma: no cover
-        app.logger.exception('An error occurred')
+        msg = str(e)
+        app.logger.exception(f'An error occurred: {msg}')
         response = dict(template='500.html', code=500,
-                        description=INTERNALSERVERERROR)
+                        description=msg if msg else INTERNALSERVERERROR)
         return handle_content_type(response)
 
     @app.errorhandler(403)
     def _forbidden(e):
+        msg = str(e)
         response = dict(template='403.html', code=403,
-                        description=FORBIDDEN)
+                        description=msg if msg else FORBIDDEN)
         return handle_content_type(response)
 
     @app.errorhandler(401)
     def _unauthorized(e):
+        msg = str(e)
         response = dict(template='401.html', code=401,
-                        description=UNAUTHORIZED)
+                        description=msg if msg else UNAUTHORIZED)
         return handle_content_type(response)
 
     @app.errorhandler(423)

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -678,9 +678,10 @@ class TestWeb(web.Helper):
 
             res = self.app_post_json(url, data="{stringoftext")
             data = json.loads(res.data)
-            err_msg = "The browser (or proxy) sent a request that this server could not understand."
+            err_msg = "400 Bad Request: The browser (or proxy) sent a request that this server could not understand."
             assert res.status_code == 400, data
             assert data.get('code') == 400, data
+            assert data.get('description') == err_msg, data
 
             data = json.dumps(userdict)
             data += "}"
@@ -690,6 +691,7 @@ class TestWeb(web.Helper):
             data = json.loads(res.data)
             assert res.status_code == 400, data
             assert data.get('code') == 400, data
+            assert data.get('description') == err_msg, data
 
     @with_context
     def test_register_csrf_missing(self):
@@ -1687,6 +1689,7 @@ class TestWeb(web.Helper):
         data = json.loads(res.data)
         assert res.status_code == 403
         assert data.get('code') == 403
+        assert FORBIDDEN in data.get('description'), data
 
 
     @with_context

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -681,7 +681,6 @@ class TestWeb(web.Helper):
             err_msg = "The browser (or proxy) sent a request that this server could not understand."
             assert res.status_code == 400, data
             assert data.get('code') == 400, data
-            assert data.get('description') == err_msg, data
 
             data = json.dumps(userdict)
             data += "}"
@@ -691,7 +690,6 @@ class TestWeb(web.Helper):
             data = json.loads(res.data)
             assert res.status_code == 400, data
             assert data.get('code') == 400, data
-            assert data.get('description') == err_msg, data
 
     @with_context
     def test_register_csrf_missing(self):
@@ -1689,7 +1687,6 @@ class TestWeb(web.Helper):
         data = json.loads(res.data)
         assert res.status_code == 403
         assert data.get('code') == 403
-        assert data.get('description') == FORBIDDEN, data
 
 
     @with_context


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-7895](https://jira.prod.bloomberg.com/browse/RDISCROWD-7895)*

**Describe your changes**
 - support custom error messages in `abort()` calls
 - Many methods already assume that this works and pass strings to abort, like `abort(400, "my custom message")`. Now these will actually get sent to the user and will be helpful when they are working with our API.

Some usage examples:

1. https://github.com/bloomberg/pybossa/blob/main/pybossa/api/__init__.py#L795
2. https://github.com/bloomberg/pybossa/blob/main/pybossa/api/__init__.py#L733
3. https://github.com/bloomberg/pybossa/blob/main/pybossa/api/__init__.py#L772

**Testing performed**
Tested locally

**Additional context**
Add any other context about your contribution here.
