### PR TITLE
RDISCROWD-7968 add n_gold_tasks to projectprogress API

### DIFF
--- a/pybossa/repositories/project_repository.py
+++ b/pybossa/repositories/project_repository.py
@@ -446,12 +446,11 @@ class ProjectRepository(Repository):
         sql = text(
                     '''
                         SELECT
-                            (SELECT COUNT(*) FROM task
-                            WHERE task.project_id=:project_id AND task.state='completed') as n_completed,
-                            (SELECT COUNT(task.id) AS n_tasks FROM task
-                            WHERE task.project_id=:project_id AND calibration != 1) as n_tasks,
-                            (SELECT COUNT(task.id) AS n_gold_tasks FROM task
-                            WHERE task.project_id=:project_id AND calibration = 1) as n_gold_tasks;
+                            SUM(CASE WHEN task.state = 'completed' THEN 1 ELSE 0 END) AS n_completed,
+                            SUM(CASE WHEN calibration != 1 THEN 1 ELSE 0 END) AS n_tasks,
+                            SUM(CASE WHEN calibration = 1 THEN 1 ELSE 0 END) AS n_gold_tasks
+                        FROM task
+                        WHERE task.project_id = :project_id;
                     '''
                     )
         response = self.db.session.execute(sql, dict(project_id=project_id)).fetchall()

--- a/pybossa/repositories/project_repository.py
+++ b/pybossa/repositories/project_repository.py
@@ -449,10 +449,12 @@ class ProjectRepository(Repository):
                             (SELECT COUNT(*) FROM task
                             WHERE task.project_id=:project_id AND task.state='completed') as n_completed,
                             (SELECT COUNT(task.id) AS n_tasks FROM task
-                            WHERE task.project_id=:project_id AND calibration != 1) as n_tasks;
+                            WHERE task.project_id=:project_id AND calibration != 1) as n_tasks,
+                            (SELECT COUNT(task.id) AS n_gold_tasks FROM task
+                            WHERE task.project_id=:project_id AND calibration = 1) as n_gold_tasks;
                     '''
                     )
         response = self.db.session.execute(sql, dict(project_id=project_id)).fetchall()
-        n_completed, n_tasks = response[0]
-        result = dict(n_completed_tasks=n_completed, n_tasks=n_tasks)
+        n_completed, n_tasks, n_gold_tasks = response[0]
+        result = dict(n_completed_tasks=n_completed, n_tasks=n_tasks, n_gold_tasks=n_gold_tasks)
         return result

--- a/test/test_api/test_project_api.py
+++ b/test/test_api/test_project_api.py
@@ -2513,7 +2513,7 @@ class TestProjectAPI(TestAPI):
         # query for the count of all tasks in the propject
         res = self.app.get('/api/project/1/projectprogress', follow_redirects=True, headers=headers)
         assert res.status_code == 200
-        assert res.json == dict(n_completed_tasks=0, n_tasks=3)
+        assert res.json == dict(n_completed_tasks=0, n_tasks=3, n_gold_tasks=0)
 
         # mark 2 out of total 3 tasks as complete
         for i in range(n_answers):
@@ -2523,7 +2523,7 @@ class TestProjectAPI(TestAPI):
         # query for the count of all tasks in the propject
         res = self.app.get('/api/project/1/projectprogress', follow_redirects=True, headers=headers)
         assert res.status_code == 200
-        assert res.json == dict(n_completed_tasks=2, n_tasks=3)
+        assert res.json == dict(n_completed_tasks=2, n_tasks=3, n_gold_tasks=0)
 
         # mark third task also complete
         for i in range(n_answers):
@@ -2531,7 +2531,7 @@ class TestProjectAPI(TestAPI):
         # query for the count of all tasks in the propject
         res = self.app.get('/api/project/1/projectprogress', follow_redirects=True, headers=headers)
         assert res.status_code == 200
-        assert res.json == dict(n_completed_tasks=3, n_tasks=3)
+        assert res.json == dict(n_completed_tasks=3, n_tasks=3, n_gold_tasks=0), res.json
 
         # accessing api with subadmin user who's not owner fails
         headers = [('Authorization', subadmin.api_key)]
@@ -2554,12 +2554,15 @@ class TestProjectAPI(TestAPI):
         # query for the count of total tasks and completed tasks in the propject
         res = self.app.get('/api/project/1/projectprogress', follow_redirects=True, headers=headers)
         assert res.status_code == 200
-        assert res.json == dict(n_completed_tasks=3, n_tasks=3)
+        assert res.json == dict(n_completed_tasks=3, n_tasks=3, n_gold_tasks=0)
+
+        # create gold tasks
+        tasks = TaskFactory.create_batch(2, project=project, calibration = 1)
 
         # accessing api using project short_name pass
         res = self.app.get('/api/project/testproject/projectprogress', follow_redirects=True, headers=headers)
         assert res.status_code == 200
-        assert res.json == dict(n_completed_tasks=3, n_tasks=3)
+        assert res.json == dict(n_completed_tasks=3, n_tasks=3, n_gold_tasks=2)
 
 
     def _setup_project(self, short_name, owner):


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-7968*

**Describe your changes**
Add `n_gold_tasks` to `/project/<id>/projectprogress` API response
No changes to existing fields `n_completed_tasks` and `n_tasks`

**Example:**

**Request:**
GET `/api/project/50/projectprogress`

**Response:**
```
{
    "n_completed_tasks": 1,
    "n_tasks": 149,
    "n_gold_tasks": 2
}
```



**Testing performed**
Tested locally
