### PR TITLE
RDISCROWD-7866: Exclude reserved fields from duplicate task check

### DIFF
--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -99,9 +99,11 @@ class TaskAPI(APIBase):
             raise BadRequest(str(e))
         data["dup_checksum"] = dup_checksum
         completed_tasks = project.info.get("duplicate_task_check", {}).get("completed_tasks", False)
+        task_reserved_cols = current_app.config.get("TASK_RESERVED_COLS", [])
+        filtered_info = {k:v for k, v in info.items() if k not in task_reserved_cols} if isinstance(info, dict) else info
         duplicate = task_repo.find_duplicate(
             project_id=project_id,
-            info=info,
+            info=filtered_info,
             dup_checksum=dup_checksum,
             completed_tasks=completed_tasks
         )

--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -99,11 +99,9 @@ class TaskAPI(APIBase):
             raise BadRequest(str(e))
         data["dup_checksum"] = dup_checksum
         completed_tasks = project.info.get("duplicate_task_check", {}).get("completed_tasks", False)
-        task_reserved_cols = current_app.config.get("TASK_RESERVED_COLS", [])
-        filtered_info = {k:v for k, v in info.items() if k not in task_reserved_cols} if isinstance(info, dict) else info
         duplicate = task_repo.find_duplicate(
             project_id=project_id,
-            info=filtered_info,
+            info=info,
             dup_checksum=dup_checksum,
             completed_tasks=completed_tasks
         )

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -183,17 +183,15 @@ class Importer(object):
             current_app.logger.error(', '.join(fields_not_in_import))
             return msg + additional_msg
 
-        reserved_genids = []
+        reserved_cols = []
+        task_reserved_cols = current_app.config.get("TASK_RESERVED_COLS", [])
         if hasattr(import_fields, "__iter__"):
-            if "genid_big_datastore_id" in import_fields:
-                reserved_genids.append("genid_big_datastore_id")
-            if "genid_transaction_id" in import_fields:
-                reserved_genids.append("genid_transaction_id")
+            reserved_cols += [k for k in import_fields if k in task_reserved_cols]
 
         msg = ""
-        if reserved_genids:
-            reserved_genid_names = ", ".join(reserved_genids)
-            msg += f"Reserved columns {reserved_genid_names} not allowed. "
+        if reserved_cols:
+            reserved_cols_in_csv = ", ".join(reserved_cols)
+            msg += f"Reserved columns {reserved_cols_in_csv} not allowed. "
 
         msg += get_error_message()
 

--- a/pybossa/settings_local.py.tmpl
+++ b/pybossa/settings_local.py.tmpl
@@ -551,3 +551,5 @@ SWAGGER_TEMPLATE = {
 
 # perform task deletes in batches in absence of session_replication_role on db
 SESSION_REPLICATION_ROLE_DISABLED = True
+
+TASK_RESERVED_COLS = ["col_abc", "col_xyz"]

--- a/pybossa/task_creator_helper.py
+++ b/pybossa/task_creator_helper.py
@@ -198,12 +198,6 @@ def generate_checksum(project_id, task):
     # remaining fields when all fields are included for duplicate check
     task_reserved_cols = current_app.config.get("TASK_RESERVED_COLS", [])
     task_info = {k:v for k, v in task["info"].items() if k not in task_reserved_cols} if isinstance(task["info"], dict) else task["info"]
-    dup_task_config = project.info.get("duplicate_task_check")
-    if not dup_task_config:
-        return
-
-    dup_fields_configured = dup_task_config.get("duplicate_fields", [])
-    # include all task_info fields with no field configured under duplicate_fields
 
     task_contents = {}
     if current_app.config.get("PRIVATE_INSTANCE"):
@@ -264,6 +258,9 @@ def generate_checksum(project_id, task):
         # public instance has all task fields under task_info
         task_contents = task_info
 
+    # include all task_info fields with no field configured under duplicate_fields
+    dup_task_config = project.info.get("duplicate_task_check", {})
+    dup_fields_configured = dup_task_config.get("duplicate_fields", [])
     checksum_fields = task_contents.keys() if not dup_fields_configured else dup_fields_configured
     try:
         checksum_payload = {field:task_contents[field] for field in checksum_fields}

--- a/pybossa/task_creator_helper.py
+++ b/pybossa/task_creator_helper.py
@@ -199,6 +199,10 @@ def generate_checksum(project_id, task):
     task_reserved_cols = current_app.config.get("TASK_RESERVED_COLS", [])
     task_info = {k:v for k, v in task["info"].items() if k not in task_reserved_cols} if isinstance(task["info"], dict) else task["info"]
 
+    # with task payload not proper dict, dup checksum cannot be computed and will be set to null
+    if not isinstance(task["info"], dict):
+        return
+
     task_contents = {}
     if current_app.config.get("PRIVATE_INSTANCE"):
         # csv import under private instance, may contain private data under _priv cols

--- a/pybossa/task_creator_helper.py
+++ b/pybossa/task_creator_helper.py
@@ -193,7 +193,11 @@ def generate_checksum(project_id, task):
         current_app.logger.info("Duplicate task checksum may not be generated. Incorrect project id %d", project_id)
         return
 
-    task_info = task["info"]
+    # drop reserved columns that are always going to have unique values in
+    # certain scenarios as this could miss duplicate task check correctly on
+    # remaining fields when all fields are included for duplicate check
+    task_reserved_cols = current_app.config.get("TASK_RESERVED_COLS", [])
+    task_info = {k:v for k, v in task["info"].items() if k not in task_reserved_cols} if isinstance(task["info"], dict) else task["info"]
     dup_task_config = project.info.get("duplicate_task_check")
     if not dup_task_config:
         return

--- a/pybossa/task_creator_helper.py
+++ b/pybossa/task_creator_helper.py
@@ -193,15 +193,15 @@ def generate_checksum(project_id, task):
         current_app.logger.info("Duplicate task checksum may not be generated. Incorrect project id %d", project_id)
         return
 
+    # with task payload not proper dict, dup checksum cannot be computed and will be set to null
+    if not isinstance(task["info"], dict):
+        return
+
     # drop reserved columns that are always going to have unique values in
     # certain scenarios as this could miss duplicate task check correctly on
     # remaining fields when all fields are included for duplicate check
     task_reserved_cols = current_app.config.get("TASK_RESERVED_COLS", [])
-    task_info = {k:v for k, v in task["info"].items() if k not in task_reserved_cols} if isinstance(task["info"], dict) else task["info"]
-
-    # with task payload not proper dict, dup checksum cannot be computed and will be set to null
-    if not isinstance(task["info"], dict):
-        return
+    task_info = {k:v for k, v in task["info"].items() if k not in task_reserved_cols}
 
     task_contents = {}
     if current_app.config.get("PRIVATE_INSTANCE"):


### PR DESCRIPTION
Exclude reserved fields from duplicate task check. This is default behavior and applies irrespective of whether duplicate task check has been configured or not.
