### PR TITLE
RDISCROWD-7728 ownership id on project create page

### DIFF
--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -30,7 +30,7 @@ from flask_login import current_user
 from .api_base import APIBase
 from pybossa.model.project import Project
 from pybossa.cache.categories import get_all as get_categories
-from pybossa.util import is_reserved_name, description_from_long_description, validate_ownership_id
+from pybossa.util import is_reserved_name, description_from_long_description, valid_ownership_id
 from pybossa.core import auditlog_repo, result_repo, http_signer
 from pybossa.auditlogger import AuditLogger
 from pybossa.data_access import ensure_user_assignment_to_project, set_default_amp_store
@@ -149,7 +149,9 @@ class ProjectAPI(APIBase):
             msg = "Project short_name is not valid, as it's used by the system."
             raise ValueError(msg)
         ensure_user_assignment_to_project(project)
-        validate_ownership_id(project.info.get('ownership_id'))
+        if not valid_ownership_id(project.info.get('ownership_id')):
+            ownership_id_title = current_app.config.get('OWNERSHIP_ID_TITLE', 'Ownership ID')
+            raise ValueError(f"{ownership_id_title} must be numeric and less than 20 characters.")
 
     def _log_changes(self, old_project, new_project):
         auditlogger.add_log_entry(old_project, new_project, current_user)

--- a/pybossa/api/project.py
+++ b/pybossa/api/project.py
@@ -30,7 +30,7 @@ from flask_login import current_user
 from .api_base import APIBase
 from pybossa.model.project import Project
 from pybossa.cache.categories import get_all as get_categories
-from pybossa.util import is_reserved_name, description_from_long_description, valid_ownership_id
+from pybossa.util import is_reserved_name, description_from_long_description
 from pybossa.core import auditlog_repo, result_repo, http_signer
 from pybossa.auditlogger import AuditLogger
 from pybossa.data_access import ensure_user_assignment_to_project, set_default_amp_store
@@ -149,9 +149,6 @@ class ProjectAPI(APIBase):
             msg = "Project short_name is not valid, as it's used by the system."
             raise ValueError(msg)
         ensure_user_assignment_to_project(project)
-        if not valid_ownership_id(project.info.get('ownership_id')):
-            ownership_id_title = current_app.config.get('OWNERSHIP_ID_TITLE', 'Ownership ID')
-            raise ValueError(f"{ownership_id_title} must be numeric and less than 20 characters.")
 
     def _log_changes(self, old_project, new_project):
         auditlogger.add_log_entry(old_project, new_project, current_user)

--- a/pybossa/forms/dynamic_forms.py
+++ b/pybossa/forms/dynamic_forms.py
@@ -1,8 +1,9 @@
+from flask import current_app
 from flask_babel import lazy_gettext
 from flask_wtf import FlaskForm as Form
 from wtforms import SelectField, validators, TextField, BooleanField
 from pybossa.forms.fields.select_two import Select2Field
-from .validator import AmpPvfValidator
+from .validator import AmpPvfValidator, OwnershipIdValidator
 
 import wtforms
 
@@ -37,6 +38,10 @@ def dynamic_project_form(class_type, form_data, data_access_levels, products=Non
         ProjectFormExtraInputs.amp_pvf = TextField(
             lazy_gettext('Annotation Store PVF'),
             [AmpPvfValidator()])
+
+    ProjectFormExtraInputs.ownership_id = TextField(
+        lazy_gettext(current_app.config.get('OWNERSHIP_ID_TITLE', 'Ownership ID')),
+        [OwnershipIdValidator()])
 
     generate_form = ProjectFormExtraInputs(form_data, obj=obj)
     if data_access_levels and not form_data:

--- a/pybossa/forms/validator.py
+++ b/pybossa/forms/validator.py
@@ -23,7 +23,7 @@ from wtforms.validators import ValidationError
 import re
 import requests
 
-from pybossa.util import is_reserved_name, check_password_strength
+from pybossa.util import is_reserved_name, check_password_strength, valid_ownership_id
 from pybossa.data_access import valid_user_type_based_data_access
 
 
@@ -254,3 +254,17 @@ class AmpPvfValidator(object):
         amp_store = form.amp_store.data
         if amp_store and not(amp_pvf and self.pvf_format.match(amp_pvf)):
             raise ValidationError("Invalid PVF format. Must contain <PVF name> <PVF val>.")
+
+
+class OwnershipIdValidator(object):
+    """Ensure Ownership ID is valid."""
+    def __init__(self, message=None):
+        self.ownership_id_title = current_app.config.get('OWNERSHIP_ID_TITLE', 'Ownership ID')
+        if not message:
+            message = lazy_gettext(f"Invalid {self.ownership_id_title}.")
+        self.message = message
+
+    def __call__(self, form, field):
+        o_id = form.ownership_id.data
+        if not valid_ownership_id(o_id):
+            raise ValidationError(f"{self.ownership_id_title} must be numeric and less than 20 characters. Got: {o_id}")

--- a/pybossa/forms/validator.py
+++ b/pybossa/forms/validator.py
@@ -267,4 +267,4 @@ class OwnershipIdValidator(object):
     def __call__(self, form, field):
         o_id = form.ownership_id.data
         if not valid_ownership_id(o_id):
-            raise ValidationError(f"{self.ownership_id_title} must be numeric and less than 20 characters. Got: {o_id}")
+            raise ValidationError(f"{self.ownership_id_title} must be numeric and less than 20 characters.")

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -374,8 +374,6 @@ def datetime_filter(source, fmt):
 
 
 def valid_ownership_id(o_id):
-    if not isinstance(o_id, str):
-        o_id = str(o_id)
     if not o_id or (isinstance(o_id, str) and o_id.isnumeric() and len(o_id) <= 20):
         return True
     return False

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -373,12 +373,12 @@ def datetime_filter(source, fmt):
     return source.strftime(fmt)
 
 
-def validate_ownership_id(o_id):
-    ownership_id_title = current_app.config.get('OWNERSHIP_ID_TITLE', 'Ownership ID')
+def valid_ownership_id(o_id):
     if o_id == None or len(o_id) == 0:
-        return
+        return True
     if not (o_id.isnumeric() and len(o_id) <= 20):
-        raise ValueError(f"{ownership_id_title} must be numeric and less than 20 characters. Got: {o_id}")
+        return False
+    return True
 
 class Pagination(object):
 

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -374,11 +374,11 @@ def datetime_filter(source, fmt):
 
 
 def valid_ownership_id(o_id):
-    if o_id == None or len(o_id) == 0:
+    if not isinstance(o_id, str):
+        o_id = str(o_id)
+    if not o_id or (isinstance(o_id, str) and o_id.isnumeric() and len(o_id) <= 20):
         return True
-    if not (o_id.isnumeric() and len(o_id) <= 20):
-        return False
-    return True
+    return False
 
 class Pagination(object):
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -108,7 +108,7 @@ import pybossa.app_settings as app_settings
 from copy import deepcopy
 from pybossa.cache import delete_memoized
 from sqlalchemy.orm.attributes import flag_modified
-from pybossa.util import admin_or_project_owner, validate_ownership_id
+from pybossa.util import admin_or_project_owner, valid_ownership_id
 from pybossa.api.project import ProjectAPI
 
 cors_headers = ['Content-Type', 'Authorization']

--- a/test/test_forms.py
+++ b/test/test_forms.py
@@ -168,6 +168,25 @@ class TestValidator(Test):
         u = validator.AmpPvfValidator()
         u.__call__(form, form.amp_pvf)
 
+    @with_context
+    @raises(ValidationError)
+    def test_ownership_id_validator_raises_error(self):
+        """Test OwnershipIdValidator raise exception with invalid Ownership ID value """
+        form_data = dict()
+        form = dynamic_project_form(ProjectForm, form_data, [], {}, {})
+        form.ownership_id.data = 'xxx yyy'
+        u = validator.OwnershipIdValidator()
+        u.__call__(form, form.ownership_id)
+
+    @with_context
+    def test_ownership_id_validator_pass(self):
+        """Test OwnershipIdValidator pass with correct format Ownership ID value """
+        form_data = dict()
+        form = dynamic_project_form(ProjectForm, form_data, [], {}, {})
+        form.ownership_id.data = '123123123'
+        u = validator.OwnershipIdValidator()
+        u.__call__(form, form.ownership_id)
+
 
 class TestRegisterForm(Test):
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1930,19 +1930,19 @@ class TestMapLocations(Test):
         assert mapped_locations['locations'] == expected_locations, (mapped_locations['locations'], expected_locations)
 
     @with_context
-    def test_validate_ownership_id(self):
+    def test_valid_ownership_id(self):
         # valid ownership_id
         ownership_id = "1111"
-        util.validate_ownership_id(ownership_id)
+        assert util.valid_ownership_id(ownership_id) == True
 
         # empty ownership_id
         ownership_id = ""
-        util.validate_ownership_id(ownership_id)
+        assert util.valid_ownership_id(ownership_id) == True
 
         # ownership_id too long (> 20 chars)
         ownership_id = "123412341234123412341234"
-        assert_raises(ValueError, util.validate_ownership_id, ownership_id)
+        assert util.valid_ownership_id(ownership_id) == False
 
         # ownership_id not numeric
         ownership_id = "1234abcd1234"
-        assert_raises(ValueError, util.validate_ownership_id, ownership_id)
+        assert util.valid_ownership_id(ownership_id) == False


### PR DESCRIPTION
*Issue number of the reported bug or feature request: *[RDISCROWD-7728](https://jira.prod.bloomberg.com/browse/RDISCROWD-7728)*

**Describe your changes**
- add ownership id field to project create field
- refactor ownership ID validator

![image](https://github.com/user-attachments/assets/e4cb8276-7ae4-4394-986f-46d79ef805c9)

**Related**
https://github.com/bloomberg/pybossa-default-theme/pull/488