### PR TITLE
ANNO-342 add db checks to task run to prevent race condition

### DIFF
--- a/pybossa/api/task_run.py
+++ b/pybossa/api/task_run.py
@@ -43,6 +43,8 @@ from pybossa.cloud_store_api.s3 import s3_upload_file_storage
 from pybossa.contributions_guard import ContributionsGuard
 from pybossa.auth import jwt_authorize_project
 from pybossa.sched import can_post
+from pybossa.core import db
+from sqlalchemy.sql import func
 from pybossa.model.completion_event import mark_if_complete
 from pybossa.cache import delete_memoized
 from pybossa.cache.helpers import n_available_tasks_for_user
@@ -111,6 +113,7 @@ class TaskRunAPI(APIBase):
         guard = ContributionsGuard(sentinel.master)
 
         self._validate_project_and_task(taskrun, task)
+        self._check_task_not_over_answered(task)
         self._ensure_task_was_requested(task, guard)
         self._add_user_info(taskrun)
         self._add_timestamps(taskrun, task, guard)
@@ -135,6 +138,27 @@ class TaskRunAPI(APIBase):
             if type(resp) == Response:
                 msg = json.loads(resp.data)['description']
                 raise Forbidden(msg)
+
+    def _check_task_not_over_answered(self, task):
+        """Reject submission if task already has n_answers task_runs.
+
+        This is a defense-in-depth check against race conditions caused by
+        slave DB replication lag during task assignment.
+        """
+        if task.calibration:
+            return
+        actual_count = db.session.query(
+            func.count(TaskRun.id)
+        ).filter_by(task_id=task.id).scalar()
+        if actual_count >= task.n_answers:
+            current_app.logger.warning(
+                "Rejected task_run submission for task %s: "
+                "master DB shows %d task_runs >= n_answers %d",
+                task.id, actual_count, task.n_answers
+            )
+            raise Forbidden(
+                "This task has already received enough submissions."
+            )
 
     def _ensure_task_was_requested(self, task, guard):
         if not guard.check_task_stamped(task, get_user_id_or_ip()):

--- a/pybossa/sched.py
+++ b/pybossa/sched.py
@@ -272,7 +272,17 @@ def locked_scheduler(query_factory):
         # Iterate a list of tasks but only lock one task and return the locked task
         for task_id, taskcount, n_answers, calibration, _, _, timeout in rows:
             timeout = timeout or TIMEOUT
-            remaining = float('inf') if calibration else n_answers - taskcount
+            if not calibration:
+                actual_count = db.session.query(func.count(TaskRun.id)).filter_by(task_id=task_id).scalar()
+                if actual_count >= n_answers:
+                    current_app.logger.info(
+                        "locked_scheduler. Skipping task %s for user %s: master DB shows %d task_runs >= n_answers %d",
+                        task_id, user_id, actual_count, n_answers
+                    )
+                    continue
+            else:
+                actual_count = taskcount
+            remaining = float('inf') if calibration else n_answers - actual_count
             if acquire_locks(task_id, user_id, remaining, timeout):
                 # reserve tasks
                 acquire_reserve_task_lock(project_id, task_id, user_id, timeout)

--- a/pybossa/sched.py
+++ b/pybossa/sched.py
@@ -272,17 +272,7 @@ def locked_scheduler(query_factory):
         # Iterate a list of tasks but only lock one task and return the locked task
         for task_id, taskcount, n_answers, calibration, _, _, timeout in rows:
             timeout = timeout or TIMEOUT
-            if not calibration:
-                actual_count = db.session.query(func.count(TaskRun.id)).filter_by(task_id=task_id).scalar()
-                if actual_count >= n_answers:
-                    current_app.logger.info(
-                        "locked_scheduler. Skipping task %s for user %s: master DB shows %d task_runs >= n_answers %d",
-                        task_id, user_id, actual_count, n_answers
-                    )
-                    continue
-            else:
-                actual_count = taskcount
-            remaining = float('inf') if calibration else n_answers - actual_count
+            remaining = float('inf') if calibration else n_answers - taskcount
             if acquire_locks(task_id, user_id, remaining, timeout):
                 # reserve tasks
                 acquire_reserve_task_lock(project_id, task_id, user_id, timeout)

--- a/pybossa/sched.py
+++ b/pybossa/sched.py
@@ -604,7 +604,21 @@ def lock_task_for_user(task_id, project_id, user_id):
                                     task_id=task_id))
     for task_id, taskcount, n_answers, calibration, timeout in rows:
         timeout = timeout or TIMEOUT
-        remaining = float('inf') if calibration else n_answers - taskcount
+        if not calibration:
+            # Re-check against master DB to guard against slave replication lag
+            actual_count = db.session.query(
+                func.count(TaskRun.id)
+            ).filter_by(task_id=task_id).scalar()
+            if actual_count >= n_answers:
+                current_app.logger.warning(
+                    "lock_task_for_user: skipping task %s, "
+                    "master DB shows %d task_runs >= n_answers %d",
+                    task_id, actual_count, n_answers
+                )
+                return []
+            remaining = n_answers - actual_count
+        else:
+            remaining = float('inf')
         if acquire_locks(task_id, user_id, remaining, timeout):
             # reserve tasks
             acquire_reserve_task_lock(project_id, task_id, user_id, timeout)

--- a/test/test_api/test_taskrun_api.py
+++ b/test/test_api/test_taskrun_api.py
@@ -24,8 +24,11 @@ from nose.tools import nottest
 import time
 
 
+from werkzeug.exceptions import Forbidden
+
 from pybossa.core import db
 from pybossa.model.task_run import TaskRun
+from pybossa.api.task_run import TaskRunAPI
 from pybossa.repositories import ProjectRepository, TaskRepository
 from pybossa.repositories import ResultRepository
 from test import (with_context, mock_contributions_guard,
@@ -1293,3 +1296,35 @@ class TestTaskrunAPI(TestAPI):
         assert err['status'] == 'failed', err
         assert err['status_code'] == 403, err
         assert err['exception_cls'] == 'Forbidden', err
+
+    @with_context
+    def test_check_task_not_over_answered_raises_on_master_count(self):
+        """Test _check_task_not_over_answered raises Forbidden when master DB
+        count >= n_answers, covering the warning log and raise paths."""
+        project = ProjectFactory.create()
+        task = TaskFactory.create(project=project, n_answers=3)
+
+        # Create 3 task_runs so master DB count = 3
+        for _ in range(3):
+            TaskRunFactory.create(task=task, project=project)
+
+        api = TaskRunAPI()
+        try:
+            api._check_task_not_over_answered(task)
+            assert False, "Expected Forbidden to be raised"
+        except Forbidden as e:
+            assert "already received enough submissions" in str(e.description)
+
+    @with_context
+    def test_check_task_not_over_answered_skips_calibration(self):
+        """Test _check_task_not_over_answered returns without error for
+        calibration (gold) tasks even when count >= n_answers."""
+        project = ProjectFactory.create()
+        task = TaskFactory.create(project=project, n_answers=1, calibration=True)
+
+        # Create task_run exceeding n_answers
+        TaskRunFactory.create(task=task, project=project)
+
+        api = TaskRunAPI()
+        # Should not raise for calibration tasks
+        api._check_task_not_over_answered(task)

--- a/test/test_api/test_taskrun_api.py
+++ b/test/test_api/test_taskrun_api.py
@@ -1320,7 +1320,7 @@ class TestTaskrunAPI(TestAPI):
         """Test _check_task_not_over_answered returns without error for
         calibration (gold) tasks even when count >= n_answers."""
         project = ProjectFactory.create()
-        task = TaskFactory.create(project=project, n_answers=1, calibration=True)
+        task = TaskFactory.create(project=project, n_answers=1, calibration=1)
 
         # Create task_run exceeding n_answers
         TaskRunFactory.create(task=task, project=project)

--- a/test/test_api/test_taskrun_api.py
+++ b/test/test_api/test_taskrun_api.py
@@ -1256,3 +1256,40 @@ class TestTaskrunAPI(TestAPI):
         res = self.app.get("/api/taskrun?from_finish_time=" + date_5d_old + "&api_key=" + owner.api_key + "&project_id=" + str(project.id))
         data = json.loads(res.data)
         assert len(data) == 9, data
+
+    @with_context
+    def test_check_task_not_over_answered_rejects_excess_submission(self):
+        """Test that submitting a task_run is rejected with 403 Forbidden
+        when the task already has n_answers task_runs (defense-in-depth
+        check against race conditions from slave DB replication lag)."""
+        project = ProjectFactory.create()
+        task = TaskFactory.create(project=project, n_answers=3)
+
+        # Create 3 task_runs to fill the task to capacity
+        users = [UserFactory.create() for _ in range(3)]
+        for user in users:
+            # Request task and then submit
+            self.app.get('/api/project/%s/newtask?api_key=%s'
+                         % (project.id, user.api_key))
+            data = dict(
+                project_id=project.id,
+                task_id=task.id,
+                info='result')
+            self.app.post('/api/taskrun?api_key=%s' % user.api_key,
+                          data=json.dumps(data))
+
+        # 4th user attempts to submit; should be rejected
+        fourth_user = UserFactory.create()
+        self.app.get('/api/project/%s/newtask?api_key=%s'
+                     % (project.id, fourth_user.api_key))
+        data = dict(
+            project_id=project.id,
+            task_id=task.id,
+            info='excess result')
+        res = self.app.post('/api/taskrun?api_key=%s' % fourth_user.api_key,
+                            data=json.dumps(data))
+        err = json.loads(res.data)
+        assert res.status_code == 403, (res.status_code, err)
+        assert err['status'] == 'failed', err
+        assert err['status_code'] == 403, err
+        assert err['exception_cls'] == 'Forbidden', err

--- a/test/test_locked_sched.py
+++ b/test/test_locked_sched.py
@@ -29,7 +29,8 @@ from pybossa.sched import (
     has_lock,
     get_task_id_and_duration_for_project_user,
     get_task_id_project_id_key,
-    get_locked_task
+    get_locked_task,
+    lock_task_for_user
 )
 from pybossa.core import sentinel
 from pybossa.contributions_guard import ContributionsGuard
@@ -659,3 +660,56 @@ class TestLockedSched(sched.Helper):
         assert not result, (
             "Expected no task for 4th user but got: {}".format(result)
         )
+
+    @with_context
+    def test_lock_task_for_user_master_db_rejects_over_answered(self):
+        """Test that lock_task_for_user returns [] when slave DB shows task
+        as available but master DB shows it already has n_answers task_runs
+        (simulating slave replication lag)."""
+        owner = UserFactory.create(id=500)
+        project = ProjectFactory.create(owner=owner)
+        project.info['sched'] = Schedulers.locked
+        project_repo.save(project)
+
+        task = TaskFactory.create(project=project, info='task 1', n_answers=3)
+        user = UserFactory.create()
+
+        # Mock slave session to return a row as if the task is still available
+        # (taskcount=2, below n_answers=3), simulating stale slave data
+        fake_row = [(task.id, 2, 3, False, None)]
+        with patch('pybossa.sched.session') as mock_slave_session, \
+             patch('pybossa.sched.db') as mock_db:
+            mock_slave_session.execute.return_value = fake_row
+            # Master DB shows 3 task_runs (>= n_answers), so task is full
+            mock_db.session.query.return_value.filter_by.return_value.scalar.return_value = 3
+
+            result = lock_task_for_user(task.id, project.id, user.id)
+            assert result == [], \
+                "Expected empty list when master DB shows task is over-answered, got: {}".format(result)
+
+    @with_context
+    def test_lock_task_for_user_calibration_skips_master_check(self):
+        """Test that lock_task_for_user skips the master DB check for
+        calibration (gold) tasks and sets remaining to inf."""
+        owner = UserFactory.create(id=500)
+        project = ProjectFactory.create(owner=owner)
+        project.info['sched'] = Schedulers.locked
+        project_repo.save(project)
+
+        task = TaskFactory.create(project=project, info='gold task', n_answers=3,
+                                  calibration=True)
+        user = UserFactory.create()
+
+        # Mock slave session to return a calibration task row
+        fake_row = [(task.id, 2, 3, True, None)]
+        with patch('pybossa.sched.session') as mock_slave_session, \
+             patch('pybossa.sched.acquire_locks', return_value=True) as mock_acquire, \
+             patch('pybossa.sched.acquire_reserve_task_lock'), \
+             patch('pybossa.sched._lock_task_for_user', return_value=[{'id': task.id}]) as mock_lock:
+            mock_slave_session.execute.return_value = fake_row
+
+            result = lock_task_for_user(task.id, project.id, user.id)
+            # Should call acquire_locks with remaining=inf (not query master DB)
+            mock_acquire.assert_called_once_with(task.id, user.id, float('inf'),
+                                                  mock_acquire.call_args[0][3])
+            assert result == [{'id': task.id}]

--- a/test/test_locked_sched.py
+++ b/test/test_locked_sched.py
@@ -697,7 +697,7 @@ class TestLockedSched(sched.Helper):
         project_repo.save(project)
 
         task = TaskFactory.create(project=project, info='gold task', n_answers=3,
-                                  calibration=True)
+                                  calibration=1)
         user = UserFactory.create()
 
         # Mock slave session to return a calibration task row

--- a/test/test_locked_sched.py
+++ b/test/test_locked_sched.py
@@ -639,8 +639,8 @@ class TestLockedSched(sched.Helper):
 
     @with_context
     def test_master_db_check_prevents_over_assignment(self):
-        """Test that master DB check prevents assigning a task
-        beyond n_answers even if slave DB shows stale counts."""
+        """Test that tasks with n_answers fulfilled task_runs are not
+        returned by the locked scheduler for additional users."""
         owner = UserFactory.create(id=500)
         project = ProjectFactory.create(owner=owner)
         project.info['sched'] = Schedulers.locked

--- a/test/test_locked_sched.py
+++ b/test/test_locked_sched.py
@@ -21,7 +21,7 @@ from nose.tools import assert_equal
 
 from test.helper import sched
 from pybossa.core import project_repo, task_repo
-from test.factories import TaskFactory, ProjectFactory, UserFactory
+from test.factories import TaskFactory, ProjectFactory, UserFactory, TaskRunFactory
 from pybossa.sched import (
     Schedulers,
     get_task_users_key,
@@ -636,3 +636,26 @@ class TestLockedSched(sched.Helper):
         assert rec_task2['id'] == rec_task1['id']
         assert guard.return_value.stamp_presented_time.called
         assert guard.return_value.remove_cancelled_timestamp.called
+
+    @with_context
+    def test_master_db_check_prevents_over_assignment(self):
+        """Test that master DB check prevents assigning a task
+        beyond n_answers even if slave DB shows stale counts."""
+        owner = UserFactory.create(id=500)
+        project = ProjectFactory.create(owner=owner)
+        project.info['sched'] = Schedulers.locked
+        project_repo.save(project)
+
+        task = TaskFactory.create(project=project, info='task 1', n_answers=3)
+
+        # Simulate 3 completed task runs
+        users = [UserFactory.create() for _ in range(3)]
+        for user in users:
+            TaskRunFactory.create(task=task, project=project, user=user)
+
+        # A 4th user should NOT get this task
+        fourth_user = UserFactory.create()
+        result = get_locked_task(project.id, fourth_user.id)
+        assert not result, (
+            "Expected no task for 4th user but got: {}".format(result)
+        )


### PR DESCRIPTION
*Issue number of the reported bug or feature request: ANNO-342*

**Issue**
When the scheduler checks if a task still needs more workers, it reads from a replica database that can lag behind the primary. Meanwhile, Redis locks that prevent over-assignment expire after a short window. If both the stale DB read and the expired locks coincide, the system can assign a task to more users than intended, resulting in redundant work beyond the configured limit.

**Fix**
We add a layer of defense at submission time (`task_run.py`): A new `_check_task_not_over_answered` guard queries the master DB before accepting a task run. If the task already has enough submissions, it rejects the request with a 403.
