### PR TITLE
Port rq changes, python 3.12 pr-review from priv

### DIFF
--- a/pybossa/cache/project_stats.py
+++ b/pybossa/cache/project_stats.py
@@ -84,7 +84,7 @@ def stats_users(project_id, period=None):
                task_run.user_ip IS NULL AND
                task_run.project_id=:project_id;''')
     if period:
-        sql = text('''SELECT count(distinct(task_run.user_id)) AS user_id
+        sql = text(r'''SELECT count(distinct(task_run.user_id)) AS user_id
                    FROM task_run WHERE task_run.user_id IS NOT NULL AND
                    task_run.user_ip IS NULL AND
                    task_run.project_id=:project_id AND
@@ -110,7 +110,7 @@ def stats_users(project_id, period=None):
         .execution_options(stream=True)
 
     if period:
-        sql = text('''SELECT task_run.user_ip AS user_ip,
+        sql = text(r'''SELECT task_run.user_ip AS user_ip,
                    COUNT(task_run.id) as n_tasks FROM task_run
                    WHERE task_run.user_ip IS NOT NULL AND
                    task_run.user_id IS NULL AND
@@ -130,7 +130,7 @@ def stats_users(project_id, period=None):
                task_run.user_id IS NULL AND
                task_run.project_id=:project_id;''')
     if period:
-        sql = text('''SELECT COUNT(DISTINCT(task_run.user_ip)) AS user_ip
+        sql = text(r'''SELECT COUNT(DISTINCT(task_run.user_ip)) AS user_ip
                    FROM task_run WHERE task_run.user_ip IS NOT NULL AND
                    task_run.user_id IS NULL AND
                    task_run.project_id=:project_id AND
@@ -176,7 +176,7 @@ def stats_dates(project_id, period='15 day'):
     params = dict(project_id=project_id, period=period)
 
     # Get all tasks with at least 1 task run and its last finish time
-    sql = text('''
+    sql = text(r'''
                SELECT task_id as id, MAX(task_run.finish_time) AS day
                FROM task_run
                WHERE project_id=:project_id AND
@@ -206,7 +206,7 @@ def stats_dates(project_id, period='15 day'):
         return dates, dates_anon, dates_auth
 
     # Get all answers per date for auth
-    sql = text('''
+    sql = text(r'''
                 WITH myquery AS (
                     SELECT TO_DATE(finish_time, 'YYYY-MM-DD\THH24:MI:SS.US')
                     as d, COUNT(id)
@@ -225,7 +225,7 @@ def stats_dates(project_id, period='15 day'):
     dates_auth = _fill_empty_days(list(dates_auth.keys()), dates_auth)
 
     # Get all answers per date for anon
-    sql = text('''
+    sql = text(r'''
                 WITH myquery AS (
                     SELECT TO_DATE(finish_time, 'YYYY-MM-DD\THH24:MI:SS.US')
                     as d, COUNT(id)
@@ -264,7 +264,7 @@ def stats_hours(project_id, period='2 week'):
 
     params = dict(project_id=project_id, period=period)
     # Get hour stats for all users
-    sql = text('''
+    sql = text(r'''
                WITH myquery AS
                 (SELECT to_char(
                     DATE_TRUNC('hour',
@@ -284,7 +284,7 @@ def stats_hours(project_id, period='2 week'):
         hours[row.h] = row.count
 
     # Get maximum stats for all users
-    sql = text('''
+    sql = text(r'''
                WITH myquery AS
                 (SELECT to_char(
                     DATE_TRUNC('hour',
@@ -310,7 +310,7 @@ def stats_hours(project_id, period='2 week'):
             max_hours_auth
 
     # Get hour stats for Anonymous users
-    sql = text('''
+    sql = text(r'''
                WITH myquery AS
                 (SELECT to_char(
                     DATE_TRUNC('hour',
@@ -331,7 +331,7 @@ def stats_hours(project_id, period='2 week'):
         hours_anon[row.h] = row.count
 
     # Get maximum stats for Anonymous users
-    sql = text('''
+    sql = text(r'''
                WITH myquery AS
                 (SELECT to_char(
                     DATE_TRUNC('hour',
@@ -351,7 +351,7 @@ def stats_hours(project_id, period='2 week'):
         max_hours_anon = row.max
 
     # Get hour stats for Auth users
-    sql = text('''
+    sql = text(r'''
                WITH myquery AS
                 (SELECT to_char(
                     DATE_TRUNC('hour',
@@ -372,7 +372,7 @@ def stats_hours(project_id, period='2 week'):
         hours_auth[row.h] = row.count
 
     # Get maximum stats for Auth users
-    sql = text('''
+    sql = text(r'''
                WITH myquery AS
                 (SELECT to_char(
                     DATE_TRUNC('hour',

--- a/pybossa/cache/task_browse_helpers.py
+++ b/pybossa/cache/task_browse_helpers.py
@@ -237,7 +237,7 @@ def parse_tasks_browse_args(args):
     if args.get('hide_completed'):
         parsed_args['hide_completed'] = args['hide_completed'].lower() == 'true'
 
-    iso_string_format = '^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d+)?$'
+    iso_string_format = r'^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d+)?$'
 
     if args.get('created_from'):
         if re.match(iso_string_format, args['created_from']):

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -160,6 +160,8 @@ def upgrade_rq_config(app):
                 else:
                     app.config['RQ_DASHBOARD_REDIS_URL'] = ('redis+sentinel://{}/{}/{}'.format(
                         sentinels_str, master_name, db),)
+            else:
+                app.config['RQ_DASHBOARD_REDIS_URL'] = ('redis://localhost:{}'.format(port),)
     elif isinstance(app.config.get('RQ_DASHBOARD_REDIS_URL'), str):
         app.config['RQ_DASHBOARD_REDIS_URL'] = (app.config['RQ_DASHBOARD_REDIS_URL'],)
 

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -390,7 +390,7 @@ def setup_babel(app):
             else:
                 lang = request.cookies.get('language')
         except Exception:
-            app.logger.debug("setup_babel: failed to get user locale", exc_info=True)
+            app.logger.info("setup_babel: failed to get user locale", exc_info=True)
             lang = request.cookies.get('language')
         if (lang is None or lang == '' or
             lang.lower() not in locales):
@@ -706,7 +706,7 @@ def setup_hooks(app):
             else:
                 news = None
         except Exception:
-            app.logger.debug("_global_template_context: failed to load news", exc_info=True)
+            app.logger.info("_global_template_context: failed to load news", exc_info=True)
             news = None
 
         # Cookies warning

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -449,7 +449,7 @@ def setup_blueprints(app):
         return []
     if hasattr(rq_web, 'escape_format_instance_list'):
         rq_web.escape_format_instance_list = _masked_escape
-    if not rq_dashboard.blueprint._got_registered_once:
+    if not getattr(rq_dashboard.blueprint, '_got_registered_once', False):
         rq_dashboard.blueprint.before_request(is_admin)
     csrf.exempt(rq_dashboard.blueprint)
     app.register_blueprint(rq_dashboard.blueprint, url_prefix="/admin/rq",

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -139,13 +139,27 @@ def upgrade_rq_config(app):
 
     # Ensure RQ_DASHBOARD_REDIS_URL is always set as a tuple for rq_dashboard
     if not app.config.get('RQ_DASHBOARD_REDIS_URL'):
-        host = app.config.get('REDIS_MASTER_DNS', 'localhost')
+        host = app.config.get('REDIS_MASTER_DNS')
         port = app.config.get('REDIS_PORT', 6379)
         password = app.config.get('REDIS_PWD', '')
-        if password:
-            app.config['RQ_DASHBOARD_REDIS_URL'] = ('redis://:{}@{}:{}'.format(urlquote(password, safe=''), host, port),)
+        if host:
+            if password:
+                app.config['RQ_DASHBOARD_REDIS_URL'] = ('redis://:{}@{}:{}'.format(urlquote(password, safe=''), host, port),)
+            else:
+                app.config['RQ_DASHBOARD_REDIS_URL'] = ('redis://{}:{}'.format(host, port),)
         else:
-            app.config['RQ_DASHBOARD_REDIS_URL'] = ('redis://{}:{}'.format(host, port),)
+            sentinels_str = app.config.get('REDIS_SENTINELS')
+            if not sentinels_str and app.config.get('REDIS_SENTINEL'):
+                sentinels_str = ','.join('{}:{}'.format(h, p) for h, p in app.config['REDIS_SENTINEL'])
+            if sentinels_str:
+                master_name = app.config.get('REDIS_MASTER', 'mymaster')
+                db = app.config.get('REDIS_DB', 0)
+                if password:
+                    app.config['RQ_DASHBOARD_REDIS_URL'] = ('redis+sentinel://:{}@{}/{}/{}'.format(
+                        urlquote(password, safe=''), sentinels_str, master_name, db),)
+                else:
+                    app.config['RQ_DASHBOARD_REDIS_URL'] = ('redis+sentinel://{}/{}/{}'.format(
+                        sentinels_str, master_name, db),)
     elif isinstance(app.config.get('RQ_DASHBOARD_REDIS_URL'), str):
         app.config['RQ_DASHBOARD_REDIS_URL'] = (app.config['RQ_DASHBOARD_REDIS_URL'],)
 
@@ -427,6 +441,12 @@ def setup_blueprints(app):
         app.register_blueprint(bp['handler'], url_prefix=bp['url_prefix'])
 
     import rq_dashboard
+    # Hide Redis connection details from rq-dashboard UI for both direct and sentinel-based configs
+    from rq_dashboard import web as rq_web
+    def _masked_escape(url_list):
+        return []
+    if hasattr(rq_web, 'escape_format_instance_list'):
+        rq_web.escape_format_instance_list = _masked_escape
     if not rq_dashboard.blueprint._got_registered_once:
         rq_dashboard.blueprint.before_request(is_admin)
     csrf.exempt(rq_dashboard.blueprint)

--- a/pybossa/dashboard/jobs.py
+++ b/pybossa/dashboard/jobs.py
@@ -46,7 +46,7 @@ def active_users_week():
     if _exists_materialized_view('dashboard_week_users'):
         return _refresh_materialized_view('dashboard_week_users')
     else:
-        sql = text('''CREATE MATERIALIZED VIEW dashboard_week_users AS
+        sql = text(r'''CREATE MATERIALIZED VIEW dashboard_week_users AS
                    WITH crafters_per_day AS
                         (select to_date(task_run.finish_time,
                                         'YYYY-MM-DD\THH24:MI:SS.US') AS day,
@@ -68,7 +68,7 @@ def active_anon_week():
     if _exists_materialized_view('dashboard_week_anon'):
         return _refresh_materialized_view('dashboard_week_anon')
     else:
-        sql = text('''CREATE MATERIALIZED VIEW dashboard_week_anon AS
+        sql = text(r'''CREATE MATERIALIZED VIEW dashboard_week_anon AS
                    WITH crafters_per_day AS
                         (select to_date(task_run.finish_time,
                                         'YYYY-MM-DD\THH24:MI:SS.US') AS day,
@@ -90,7 +90,7 @@ def draft_projects_week():
     if _exists_materialized_view('dashboard_week_project_draft'):
         return _refresh_materialized_view('dashboard_week_project_draft')
     else:
-        sql = text('''CREATE MATERIALIZED VIEW dashboard_week_project_draft AS
+        sql = text(r'''CREATE MATERIALIZED VIEW dashboard_week_project_draft AS
                    SELECT TO_DATE(project.created, 'YYYY-MM-DD\THH24:MI:SS.US') AS day,
                    project.id, short_name, project.name,
                    owner_id, "user".name AS u_name, "user".email_addr
@@ -112,7 +112,7 @@ def published_projects_week():
     if _exists_materialized_view('dashboard_week_project_published'):
         return _refresh_materialized_view('dashboard_week_project_published')
     else:
-        sql = text('''CREATE MATERIALIZED VIEW dashboard_week_project_published AS
+        sql = text(r'''CREATE MATERIALIZED VIEW dashboard_week_project_published AS
                    SELECT TO_DATE(auditlog.created, 'YYYY-MM-DD\THH24:MI:SS.US') AS day,
                    project.id, project.short_name, project.name,
                    owner_id, "user".name AS u_name, "user".email_addr
@@ -136,7 +136,7 @@ def update_projects_week():
     if _exists_materialized_view('dashboard_week_project_update'):
         return _refresh_materialized_view('dashboard_week_project_update')
     else:
-        sql = text('''CREATE MATERIALIZED VIEW dashboard_week_project_update AS
+        sql = text(r'''CREATE MATERIALIZED VIEW dashboard_week_project_update AS
                    SELECT TO_DATE(project.updated, 'YYYY-MM-DD\THH24:MI:SS.US') AS day,
                    project.id, short_name, project.name,
                    owner_id, "user".name AS u_name, "user".email_addr
@@ -157,7 +157,7 @@ def new_tasks_week():
     if _exists_materialized_view('dashboard_week_new_task'):
         return _refresh_materialized_view('dashboard_week_new_task')
     else:
-        sql = text('''CREATE MATERIALIZED VIEW dashboard_week_new_task AS
+        sql = text(r'''CREATE MATERIALIZED VIEW dashboard_week_new_task AS
                       SELECT TO_DATE(task.created,
                                      'YYYY-MM-DD\THH24:MI:SS.US') AS day,
                       COUNT(task.id) AS day_tasks
@@ -175,7 +175,7 @@ def new_task_runs_week():
     if _exists_materialized_view('dashboard_week_new_task_run'):
         return _refresh_materialized_view('dashboard_week_new_task_run')
     else:
-        sql = text('''CREATE MATERIALIZED VIEW dashboard_week_new_task_run AS
+        sql = text(r'''CREATE MATERIALIZED VIEW dashboard_week_new_task_run AS
                       SELECT TO_DATE(task_run.finish_time,
                                      'YYYY-MM-DD\THH24:MI:SS.US') AS day,
                       COUNT(task_run.id) AS day_task_runs
@@ -193,7 +193,7 @@ def new_users_week():
     if _exists_materialized_view('dashboard_week_new_users'):
         return _refresh_materialized_view('dashboard_week_new_users')
     else:
-        sql = text('''CREATE MATERIALIZED VIEW dashboard_week_new_users AS
+        sql = text(r'''CREATE MATERIALIZED VIEW dashboard_week_new_users AS
                       SELECT TO_DATE("user".created,
                                      'YYYY-MM-DD\THH24:MI:SS.US') AS day,
                       COUNT("user".id) AS day_users
@@ -212,7 +212,7 @@ def returning_users_week():
     if _exists_materialized_view('dashboard_week_returning_users'):
         return _refresh_materialized_view('dashboard_week_returning_users')
     else:
-        sql = text('''CREATE MATERIALIZED VIEW dashboard_week_returning_users AS
+        sql = text(r'''CREATE MATERIALIZED VIEW dashboard_week_returning_users AS
                    WITH data AS (
                     SELECT user_id, TO_DATE(task_run.finish_time,
                     'YYYY-MM-DD\THH24:MI:SS.US') AS day

--- a/pybossa/forms/validator.py
+++ b/pybossa/forms/validator.py
@@ -88,7 +88,7 @@ class NotAllowedChars(object):
 
 class CommaSeparatedIntegers(object):
     """Validator that validates input fields that have comma separated values"""
-    not_valid_chars = '$#&\/| '
+    not_valid_chars = r'$#&\/| '
 
     def __init__(self, message=None):
         if not message:
@@ -99,7 +99,7 @@ class CommaSeparatedIntegers(object):
             self.message = message
 
     def __call__(self, form, field):
-        pattern = re.compile('^[\d,]+$')
+        pattern = re.compile(r'^[\d,]+$')
         if pattern.match(field.data) is None:
             raise ValidationError(self.message)
 

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -524,7 +524,7 @@ def get_non_updated_projects():
     from sqlalchemy.sql import text
     from pybossa.model.project import Project
     from pybossa.core import db
-    sql = text('''SELECT id FROM project WHERE TO_DATE(updated,
+    sql = text(r'''SELECT id FROM project WHERE TO_DATE(updated,
                 'YYYY-MM-DD\THH24:MI:SS.US') <= NOW() - '3 month':: INTERVAL
                AND contacted != True AND published = True
                AND project.id NOT IN

--- a/pybossa/model/project.py
+++ b/pybossa/model/project.py
@@ -158,7 +158,7 @@ class Project(db.Model, DomainObject):
             return fields
 
         search_backward_stop = 0
-        for match in re.finditer('\.info\.([a-zA-Z0-9_]+)', task_presenter):
+        for match in re.finditer(r'\.info\.([a-zA-Z0-9_]+)', task_presenter):
             linebreak_index = task_presenter.rfind(
                 '\n', search_backward_stop, match.start())
             if linebreak_index > -1:

--- a/pybossa/repositories/__init__.py
+++ b/pybossa/repositories/__init__.py
@@ -47,7 +47,7 @@ from sqlalchemy.sql import and_, or_
 from sqlalchemy import cast, Text, func, desc, text
 from sqlalchemy.types import TIMESTAMP
 from sqlalchemy.orm.base import _entity_descriptor
-from datetime import datetime
+from datetime import datetime, timezone
 
 class Repository(object):
 
@@ -250,7 +250,7 @@ class Repository(object):
         if hasattr(model, 'finish_time'):
             if from_finish_time:
                 if not to_finish_time:
-                    to_finish_time = datetime.utcnow().isoformat()
+                    to_finish_time = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
                 query = query.filter(and_(model.finish_time >= from_finish_time,
                                           model.finish_time <= to_finish_time))
 

--- a/pybossa/repositories/task_repository.py
+++ b/pybossa/repositories/task_repository.py
@@ -386,7 +386,7 @@ class TaskRepository(Repository):
             project, n_answers, conditions, params, task_expiration)
 
         self.update_task_exported_status(project.id, n_answers, conditions, params, task_expiration)
-        sql = text('''
+        sql = text(r'''
                    WITH all_tasks_with_orig_filter AS (
                         SELECT task.id as id,
                         coalesce(ct, 0) as n_task_runs, task.n_answers, ft,
@@ -557,7 +557,7 @@ class TaskRepository(Repository):
         Update exported=False for completed tasks that were exported
         and with new redundancy, they'll be marked as ongoing
         """
-        sql = text('''
+        sql = text(r'''
                    WITH all_tasks_with_orig_filter AS (
                         SELECT task.id as id,
                         coalesce(ct, 0) as n_task_runs, task.n_answers, ft,
@@ -598,7 +598,7 @@ class TaskRepository(Repository):
 
 
     def _get_redundancy_update_msg(self, project, n_answers, conditions, params, task_expiration):
-        sql = text('''
+        sql = text(r'''
                    WITH all_tasks_with_orig_filter AS (
                         SELECT task.id as id,
                         coalesce(ct, 0) as n_task_runs, task.n_answers, ft,

--- a/test/test_core_upgrade_rq_config.py
+++ b/test/test_core_upgrade_rq_config.py
@@ -174,3 +174,74 @@ class TestUpgradeRqConfig(unittest.TestCase):
                              [('s1.host.', 26379), ('s2.host.', 26380)])
             self.assertEqual(app.config['REDIS_SENTINELS'],
                              's1.host.:26379,s2.host.:26380')
+
+    # --- Sentinel URL construction (lines 151-162) ---
+
+    def test_sentinel_url_from_redis_sentinels_string_no_password(self):
+        """Line 151,154-162: when REDIS_SENTINELS string is in config, builds sentinel URL."""
+        app = self._make_app({
+            'REDIS_SENTINELS': 'sentinel1:26379,sentinel2:26380',
+            'REDIS_MASTER': 'my-master',
+            'REDIS_DB': 2,
+            'REDIS_PWD': '',
+        })
+
+        upgrade_rq_config(app)
+
+        self.assertEqual(app.config['RQ_DASHBOARD_REDIS_URL'],
+                         ('redis+sentinel://sentinel1:26379,sentinel2:26380/my-master/2',))
+
+    def test_sentinel_url_from_redis_sentinels_string_with_password(self):
+        """Line 157-159: sentinel URL includes password when REDIS_PWD is set."""
+        app = self._make_app({
+            'REDIS_SENTINELS': 'sentinel1:26379',
+            'REDIS_MASTER': 'mymaster',
+            'REDIS_DB': 0,
+            'REDIS_PWD': 'p@ss',
+        })
+
+        upgrade_rq_config(app)
+
+        self.assertEqual(app.config['RQ_DASHBOARD_REDIS_URL'],
+                         ('redis+sentinel://:p%40ss@sentinel1:26379/mymaster/0',))
+
+    def test_sentinel_url_built_from_redis_sentinel_list(self):
+        """Line 152-153: when REDIS_SENTINELS string is absent but REDIS_SENTINEL list
+        exists, sentinels_str is constructed from the list."""
+        app = self._make_app({
+            'REDIS_SENTINEL': [('host1', 26379), ('host2', 26380)],
+            'REDIS_MASTER': 'mymaster',
+            'REDIS_DB': 0,
+            'REDIS_PWD': '',
+        })
+
+        upgrade_rq_config(app)
+
+        self.assertEqual(app.config['RQ_DASHBOARD_REDIS_URL'],
+                         ('redis+sentinel://host1:26379,host2:26380/mymaster/0',))
+
+    def test_sentinel_url_from_list_with_password(self):
+        """Sentinel URL from REDIS_SENTINEL list includes password."""
+        app = self._make_app({
+            'REDIS_SENTINEL': [('sentinel-node', 26379)],
+            'REDIS_MASTER': 'master1',
+            'REDIS_DB': 3,
+            'REDIS_PWD': 'secret',
+        })
+
+        upgrade_rq_config(app)
+
+        self.assertEqual(app.config['RQ_DASHBOARD_REDIS_URL'],
+                         ('redis+sentinel://:secret@sentinel-node:26379/master1/3',))
+
+    def test_sentinel_url_defaults_master_name_and_db(self):
+        """When REDIS_MASTER and REDIS_DB are absent, defaults to 'mymaster' and 0."""
+        app = self._make_app({
+            'REDIS_SENTINELS': 'sentinel1:26379',
+            'REDIS_PWD': '',
+        })
+
+        upgrade_rq_config(app)
+
+        self.assertEqual(app.config['RQ_DASHBOARD_REDIS_URL'],
+                         ('redis+sentinel://sentinel1:26379/mymaster/0',))

--- a/test/test_sentinel.py
+++ b/test/test_sentinel.py
@@ -123,6 +123,29 @@ class TestSentinelInitAppDNS(unittest.TestCase):
             assert c.kwargs.get('ssl') is True
             assert c.kwargs.get('ssl_ca_certs') is None
 
+    @patch('pybossa.sentinel.StrictRedis')
+    def test_direct_dns_skipped_when_slave_missing(self, mock_strict_redis):
+        """If REDIS_SLAVE_DNS is not set, direct DNS path is not taken."""
+        config = {
+            'REDIS_MASTER_DNS': 'redis-master.example.com',
+            'REDIS_PORT': 6379,
+            'REDIS_SENTINEL': [('sentinel1', 26379)],
+            'REDIS_DB': 0,
+            'REDIS_PWD': None,
+            'REDIS_SOCKET_TIMEOUT': 0.1,
+            'REDIS_RETRY_ON_TIMEOUT': True,
+            'REDIS_SSL': False,
+        }
+        app = make_app(config)
+
+        s = Sentinel()
+        s.init_app(app)
+
+        # Should fall through to the sentinel path, not direct DNS
+        for c in mock_strict_redis.call_args_list:
+            if c.kwargs:
+                assert c.kwargs.get('host') != 'redis-master.example.com'
+
 
 class TestSentinelInitAppSentinelConfig(unittest.TestCase):
     """Tests for init_app when REDIS_SENTINEL list is configured (no DNS)."""
@@ -190,6 +213,28 @@ class TestSentinelInitAppSentinelConfig(unittest.TestCase):
     def test_sentinel_mode_master_and_slave_set(self, mock_sentinel_module):
         """init_app calls master_for and slave_for with the configured master name."""
         config = {**self.BASE_CONFIG, 'REDIS_SSL': False}
+        app = make_app(config)
+
+        mock_sentinel_instance = MagicMock()
+        mock_sentinel_module.Sentinel.return_value = mock_sentinel_instance
+
+        s = Sentinel()
+        s.init_app(app)
+
+        mock_sentinel_instance.master_for.assert_called_once_with('mymaster')
+        mock_sentinel_instance.slave_for.assert_called_once_with('mymaster')
+
+    @patch('pybossa.sentinel.sentinel')
+    def test_sentinel_mode_defaults_to_mymaster(self, mock_sentinel_module):
+        """When REDIS_MASTER is not set, defaults to 'mymaster'."""
+        config = {
+            'REDIS_SENTINEL': [('sentinel1.example.com', 26379)],
+            'REDIS_DB': 0,
+            'REDIS_PWD': None,
+            'REDIS_SOCKET_TIMEOUT': 0.1,
+            'REDIS_RETRY_ON_TIMEOUT': True,
+            'REDIS_SSL': False,
+        }
         app = make_app(config)
 
         mock_sentinel_instance = MagicMock()
@@ -298,3 +343,53 @@ class TestSentinelInitAppDNSResolution(unittest.TestCase):
 
         assert app.config['REDIS_SENTINEL'] == [('s1.example.com.', 26379), ('s2.example.com.', 26380)]
         assert app.config['REDIS_SENTINELS'] == 's1.example.com.:26379,s2.example.com.:26380'
+
+    @patch('pybossa.sentinel.sentinel')
+    @patch('pybossa.sentinel.resolver')
+    @patch.dict('os.environ', {'REDIS_SENTINELS_DNS': 'sentinels.example.com'})
+    def test_dns_resolution_defaults_to_mymaster(self, mock_resolver, mock_sentinel_module):
+        """When REDIS_MASTER is not set, DNS resolution path defaults to 'mymaster'."""
+        srv_records = [self._make_srv_record('sentinel1.example.com.', 26379)]
+        mock_resolver.resolve.return_value = srv_records
+
+        config = {
+            'REDIS_DB': 0,
+            'REDIS_PWD': None,
+            'REDIS_SOCKET_TIMEOUT': 0.1,
+            'REDIS_RETRY_ON_TIMEOUT': True,
+            'REDIS_SSL': False,
+        }
+        app = make_app(config)
+
+        mock_sentinel_instance = MagicMock()
+        mock_sentinel_module.Sentinel.return_value = mock_sentinel_instance
+
+        s = Sentinel()
+        s.init_app(app)
+
+        mock_sentinel_instance.master_for.assert_called_once_with('mymaster')
+        mock_sentinel_instance.slave_for.assert_called_once_with('mymaster')
+
+    @patch('pybossa.sentinel.sentinel')
+    @patch('pybossa.sentinel.resolver')
+    @patch.dict('os.environ', {'REDIS_SENTINELS_DNS': 'sentinels.example.com'})
+    def test_dns_resolution_uses_default_conn_kwargs(self, mock_resolver, mock_sentinel_module):
+        """Connection kwargs use defaults when config values are absent."""
+        srv_records = [self._make_srv_record('sentinel1.example.com.', 26379)]
+        mock_resolver.resolve.return_value = srv_records
+        mock_sentinel_module.Sentinel.return_value = MagicMock()
+
+        config = {'REDIS_SSL': False}
+        app = make_app(config)
+
+        s = Sentinel()
+        s.init_app(app)
+
+        mock_sentinel_module.Sentinel.assert_called_once_with(
+            [('sentinel1.example.com.', 26379)],
+            sentinel_kwargs={},
+            db=0,
+            password=None,
+            socket_timeout=0.1,
+            retry_on_timeout=True,
+        )


### PR DESCRIPTION
**rq-dashboard / Redis config (core.py)**
- upgrade_rq_config: Added redis+sentinel:// URL construction when REDIS_MASTER_DNS is not set and sentinels are configured (via REDIS_SENTINELS string or REDIS_SENTINEL list)
- Added localhost fallback when neither direct DNS nor sentinels are configured
- Masked Redis connection details from rq-dashboard UI via escape_format_instance_list patch with hasattr guard
- Replaced rq_dashboard.blueprint._got_registered_once with getattr(..., False) for defensive access to Flask internals

**Logging (core.py)**
- Bumped setup_babel and _global_template_context exception logging from debug to info for production visibility

**Python 3.12 SyntaxWarning fixes**
- Added r (raw string) prefix to SQL text() calls with \T escape sequences in cache/project_stats.py (12), dashboard/jobs.py (9), jobs.py (1), repositories/task_repository.py (3)
- Added r prefix to regex/string literals in cache/task_browse_helpers.py, forms/validator.py, model/project.py

**Deprecated API replacement (repositories/__init__.py)**
- Replaced datetime.utcnow() with datetime.now(timezone.utc).replace(tzinfo=None) to avoid Python 3.12 deprecation warning while preserving naive UTC format

**Test coverage**
- Added 5 tests for sentinel URL construction paths in upgrade_rq_config (test_core_upgrade_rq_config.py)
- Added 4 tests for Sentinel.init_app covering direct DNS skip, DNS resolution defaults, and default connection kwargs (test_sentinel.py)