### PR TITLE
Fix task expiration config key mismatch

### DIFF
--- a/pybossa/task_creator_helper.py
+++ b/pybossa/task_creator_helper.py
@@ -58,7 +58,7 @@ def get_task_expiration(expiration, create_time):
     Returns the minimum of requested expiration and max allowed expiration.
     If no expiration is provided, uses the default expiration.
     """
-    default_expiration_days = current_app.config.get('TASK_EXPIRATION', 60)
+    default_expiration_days = current_app.config.get('TASK_DEFAULT_EXPIRATION', 60)
     max_expiration_days = current_app.config.get('TASK_MAX_EXPIRATION', 365)
 
     default_expiration = get_time_plus_delta_ts(create_time, days=default_expiration_days)


### PR DESCRIPTION
## Summary
- Fix config key mismatch in `get_task_expiration()` that caused tasks to expire after 60 days instead of the configured value
- The code read `TASK_EXPIRATION` (which doesn't exist in any settings file) instead of `TASK_DEFAULT_EXPIRATION` (defined in `settings_local.py.tmpl` and production configs)
- This caused silent fallback to the 60-day hardcoded default, ignoring the production setting of 180 days

## Test plan
- [ ] Verify `test_task_creator_helpers.py` passes (unit tests for `get_task_expiration`)
- [ ] Verify `test_task_expiration.py` passes (integration tests)
- [ ] Verify `test_task_api.py` tests that patch `TASK_DEFAULT_EXPIRATION` now correctly exercise the code path
- [ ] Confirm new tasks created without explicit expiration use the configured `TASK_DEFAULT_EXPIRATION` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)